### PR TITLE
improvement: Emit metrics about transaction read

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -957,7 +957,7 @@ public class SnapshotTransaction extends AbstractTransaction
     private void emitReadMetrics(boolean allPossibleCellsReadAndPresent) {
         Map<String, String> exhaustiveReadTags =
                 ImmutableMap.of("isExhaustive", Boolean.toString(allPossibleCellsReadAndPresent));
-        getCounter("snapshotTransactionGet", exhaustiveReadTags).inc();
+        getCounter("snapshotTransactionGetInternal", exhaustiveReadTags).inc();
     }
 
     @Override

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -2438,11 +2438,9 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         Transaction transaction =
                 getSnapshotTransactionWith(timelockService, () -> transactionTs, res, PreCommitConditions.NO_OP, false);
 
-        Counter exhaustiveReadCounter = metricsManager.registerOrGetTaggedCounter(
-                SnapshotTransaction.class, "snapshotTransactionGetInternal", Map.of("isExhaustive", "true"));
+        Counter exhaustiveReadCounter = getExhaustiveReadCounter(true);
         long exhaustiveReadsBeforeGet = exhaustiveReadCounter.getCount();
-        Counter nonExhaustiveReadCounter = metricsManager.registerOrGetTaggedCounter(
-                SnapshotTransaction.class, "snapshotTransactionGetInternal", Map.of("isExhaustive", "false"));
+        Counter nonExhaustiveReadCounter = getExhaustiveReadCounter(false);
         long nonExhaustiveReadsBeforeGet = nonExhaustiveReadCounter.getCount();
 
         transaction.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL));
@@ -2460,11 +2458,9 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         Transaction transaction =
                 getSnapshotTransactionWith(timelockService, () -> transactionTs, res, PreCommitConditions.NO_OP, false);
 
-        Counter exhaustiveReadCounter = metricsManager.registerOrGetTaggedCounter(
-                SnapshotTransaction.class, "snapshotTransactionGetInternal", Map.of("isExhaustive", "true"));
+        Counter exhaustiveReadCounter = getExhaustiveReadCounter(true);
         long exhaustiveReadsBeforeGet = exhaustiveReadCounter.getCount();
-        Counter nonExhaustiveReadCounter = metricsManager.registerOrGetTaggedCounter(
-                SnapshotTransaction.class, "snapshotTransactionGetInternal", Map.of("isExhaustive", "false"));
+        Counter nonExhaustiveReadCounter = getExhaustiveReadCounter(false);
         long nonExhaustiveReadsBeforeGet = nonExhaustiveReadCounter.getCount();
 
         transaction.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL_2));
@@ -2484,11 +2480,9 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         Transaction transaction =
                 getSnapshotTransactionWith(timelockService, () -> transactionTs, res, PreCommitConditions.NO_OP, false);
 
-        Counter exhaustiveReadCounter = metricsManager.registerOrGetTaggedCounter(
-                SnapshotTransaction.class, "snapshotTransactionGetInternal", Map.of("isExhaustive", "true"));
+        Counter exhaustiveReadCounter = getExhaustiveReadCounter(true);
         long exhaustiveReadsBeforeGet = exhaustiveReadCounter.getCount();
-        Counter nonExhaustiveReadCounter = metricsManager.registerOrGetTaggedCounter(
-                SnapshotTransaction.class, "snapshotTransactionGetInternal", Map.of("isExhaustive", "false"));
+        Counter nonExhaustiveReadCounter = getExhaustiveReadCounter(false);
         long nonExhaustiveReadsBeforeGet = nonExhaustiveReadCounter.getCount();
 
         transaction.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL, TEST_CELL_2));
@@ -2497,6 +2491,13 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         assertThat(exhaustiveReadsCountAfterGet).isEqualTo(exhaustiveReadsBeforeGet);
         long nonExhaustiveReadsCountAfterGet = nonExhaustiveReadCounter.getCount();
         assertThat(nonExhaustiveReadsCountAfterGet).isEqualTo(nonExhaustiveReadsBeforeGet + 1);
+    }
+
+    private Counter getExhaustiveReadCounter(boolean isExhaustive) {
+        return metricsManager.registerOrGetTaggedCounter(
+                SnapshotTransaction.class,
+                "snapshotTransactionGetInternal",
+                Map.of("isExhaustive", Boolean.toString(isExhaustive)));
     }
 
     private void verifyPrefetchValidations(

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -2438,16 +2438,14 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         Transaction transaction =
                 getSnapshotTransactionWith(timelockService, () -> transactionTs, res, PreCommitConditions.NO_OP, false);
 
-        Counter exhaustiveReadCounter = getExhaustiveReadCounter(true);
-        long exhaustiveReadsBeforeGet = exhaustiveReadCounter.getCount();
-        Counter nonExhaustiveReadCounter = getExhaustiveReadCounter(false);
-        long nonExhaustiveReadsBeforeGet = nonExhaustiveReadCounter.getCount();
+        long exhaustiveReadsBeforeGet = getReadCounter(true).getCount();
+        long nonExhaustiveReadsBeforeGet = getReadCounter(false).getCount();
 
         transaction.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL));
 
-        long exhaustiveReadsCountAfterGet = exhaustiveReadCounter.getCount();
+        long exhaustiveReadsCountAfterGet = getReadCounter(true).getCount();
         assertThat(exhaustiveReadsCountAfterGet).isEqualTo(exhaustiveReadsBeforeGet + 1);
-        long nonExhaustiveReadsCountAfterGet = nonExhaustiveReadCounter.getCount();
+        long nonExhaustiveReadsCountAfterGet = getReadCounter(false).getCount();
         assertThat(nonExhaustiveReadsCountAfterGet).isEqualTo(nonExhaustiveReadsBeforeGet);
     }
 
@@ -2458,16 +2456,14 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         Transaction transaction =
                 getSnapshotTransactionWith(timelockService, () -> transactionTs, res, PreCommitConditions.NO_OP, false);
 
-        Counter exhaustiveReadCounter = getExhaustiveReadCounter(true);
-        long exhaustiveReadsBeforeGet = exhaustiveReadCounter.getCount();
-        Counter nonExhaustiveReadCounter = getExhaustiveReadCounter(false);
-        long nonExhaustiveReadsBeforeGet = nonExhaustiveReadCounter.getCount();
+        long exhaustiveReadsBeforeGet = getReadCounter(true).getCount();
+        long nonExhaustiveReadsBeforeGet = getReadCounter(false).getCount();
 
         transaction.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL_2));
 
-        long exhaustiveReadsCountAfterGet = exhaustiveReadCounter.getCount();
+        long exhaustiveReadsCountAfterGet = getReadCounter(true).getCount();
         assertThat(exhaustiveReadsCountAfterGet).isEqualTo(exhaustiveReadsBeforeGet);
-        long nonExhaustiveReadsCountAfterGet = nonExhaustiveReadCounter.getCount();
+        long nonExhaustiveReadsCountAfterGet = getReadCounter(false).getCount();
         assertThat(nonExhaustiveReadsCountAfterGet).isEqualTo(nonExhaustiveReadsBeforeGet + 1);
     }
 
@@ -2480,20 +2476,18 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
         Transaction transaction =
                 getSnapshotTransactionWith(timelockService, () -> transactionTs, res, PreCommitConditions.NO_OP, false);
 
-        Counter exhaustiveReadCounter = getExhaustiveReadCounter(true);
-        long exhaustiveReadsBeforeGet = exhaustiveReadCounter.getCount();
-        Counter nonExhaustiveReadCounter = getExhaustiveReadCounter(false);
-        long nonExhaustiveReadsBeforeGet = nonExhaustiveReadCounter.getCount();
+        long exhaustiveReadsBeforeGet = getReadCounter(true).getCount();
+        long nonExhaustiveReadsBeforeGet = getReadCounter(false).getCount();
 
         transaction.get(TABLE_SWEPT_THOROUGH, ImmutableSet.of(TEST_CELL, TEST_CELL_2));
 
-        long exhaustiveReadsCountAfterGet = exhaustiveReadCounter.getCount();
+        long exhaustiveReadsCountAfterGet = getReadCounter(true).getCount();
         assertThat(exhaustiveReadsCountAfterGet).isEqualTo(exhaustiveReadsBeforeGet);
-        long nonExhaustiveReadsCountAfterGet = nonExhaustiveReadCounter.getCount();
+        long nonExhaustiveReadsCountAfterGet = getReadCounter(false).getCount();
         assertThat(nonExhaustiveReadsCountAfterGet).isEqualTo(nonExhaustiveReadsBeforeGet + 1);
     }
 
-    private Counter getExhaustiveReadCounter(boolean isExhaustive) {
+    private Counter getReadCounter(boolean isExhaustive) {
         return metricsManager.registerOrGetTaggedCounter(
                 SnapshotTransaction.class,
                 "snapshotTransactionGetInternal",

--- a/changelog/@unreleased/pr-6639.v2.yml
+++ b/changelog/@unreleased/pr-6639.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: We now emit metrics with how often we're going exhaustive and non-exhaustive
+    KVS gets.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6639


### PR DESCRIPTION
## General
**Before this PR**:
We didn't have much insight into how many times we'd read values and they'd actually exist in the underlying KVS or not. That is important to be able to judge actual efficacy of changes like https://github.com/palantir/atlasdb/pull/6624. 

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
We now emit metrics with how often we're going exhaustive and non-exhaustive KVS gets.
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
