### PR TITLE
Transaction impls use Eclipse primitive collections for in-memory transaction tracking

### DIFF
--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -50,6 +50,8 @@ dependencies {
   implementation 'jakarta.ws.rs:jakarta.ws.rs-api'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'org.checkerframework:checker-qual'
+  implementation 'org.eclipse.collections:eclipse-collections'
+  implementation 'org.eclipse.collections:eclipse-collections-api'
   implementation 'org.slf4j:slf4j-api'
 
   implementation project(':atlasdb-api')

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/ClientLockDiagnosticCollector.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/ClientLockDiagnosticCollector.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.LongStream;
+import org.eclipse.collections.api.map.primitive.ImmutableLongLongMap;
 import org.immutables.value.Value;
 
 /**
@@ -105,6 +106,6 @@ public interface ClientLockDiagnosticCollector extends ConflictTracer {
         Map<Cell, Long> latestTimestamps();
 
         @Value.Parameter
-        Map<Long, Long> commitTimestamps();
+        ImmutableLongLongMap commitTimestamps();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/ClientLockDiagnosticCollectorImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/ClientLockDiagnosticCollectorImpl.java
@@ -29,6 +29,7 @@ import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 import java.util.stream.LongStream;
 import javax.annotation.Nullable;
+import org.eclipse.collections.api.map.primitive.LongLongMap;
 
 /**
  * TODO(fdesouza): Remove this once PDS-95791 is resolved.
@@ -63,8 +64,9 @@ public class ClientLockDiagnosticCollectorImpl implements ClientLockDiagnosticCo
             long startTimestamp,
             Map<Cell, Long> keysToLoad,
             Map<Cell, Long> latestTimestamps,
-            Map<Long, Long> commitTimestamps) {
-        ConflictTrace conflictTrace = ImmutableConflictTrace.of(keysToLoad, latestTimestamps, commitTimestamps);
+            LongLongMap commitTimestamps) {
+        ConflictTrace conflictTrace =
+                ImmutableConflictTrace.of(keysToLoad, latestTimestamps, commitTimestamps.toImmutable());
         cache.asMap().compute(startTimestamp, mutateDigest(digest -> digest.withNewConflictDigest(conflictTrace)));
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/ConflictTracer.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/debug/ConflictTracer.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.debug;
 
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import java.util.Map;
+import org.eclipse.collections.api.map.primitive.LongLongMap;
 
 /**
  * TODO(fdesouza): Remove this once PDS-95791 is resolved.
@@ -31,5 +32,5 @@ public interface ConflictTracer {
             long startTimestamp,
             Map<Cell, Long> keysToLoad,
             Map<Cell, Long> latestTimestamps,
-            Map<Long, Long> commitTimestamps);
+            LongLongMap commitTimestamps);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -109,6 +109,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.factory.primitive.LongLongMaps;
+import org.eclipse.collections.api.factory.primitive.LongSets;
+import org.eclipse.collections.api.map.primitive.LongLongMap;
+import org.eclipse.collections.api.map.primitive.MutableLongLongMap;
+import org.eclipse.collections.api.set.primitive.LongSet;
+import org.eclipse.collections.api.set.primitive.MutableLongSet;
 import org.immutables.value.Value;
 
 /**
@@ -881,21 +888,21 @@ public class SerializableTransaction extends SnapshotTransaction {
             }
 
             @Override
-            protected ListenableFuture<Map<Long, Long>> getCommitTimestamps(
+            protected ListenableFuture<LongLongMap> getCommitTimestamps(
                     TableReference tableRef,
-                    Iterable<Long> startTimestamps,
+                    LongIterable startTimestamps,
                     boolean shouldWaitForCommitterToComplete,
                     AsyncTransactionService asyncTransactionService) {
                 long myStart = SerializableTransaction.this.getTimestamp();
                 PartitionedTimestamps partitionedTimestamps = splitTransactionBeforeAndAfter(myStart, startTimestamps);
 
-                ListenableFuture<Map<Long, Long>> postStartCommitTimestamps =
+                ListenableFuture<LongLongMap> postStartCommitTimestamps =
                         getCommitTimestampsForTransactionsStartedAfterMe(
                                 tableRef, asyncTransactionService, partitionedTimestamps.afterStart());
 
                 // We are ok to block here because if there is a cycle of transactions that could result in a deadlock,
                 // then at least one of them will be in the ab
-                ListenableFuture<Map<Long, Long>> preStartCommitTimestamps = super.getCommitTimestamps(
+                ListenableFuture<LongLongMap> preStartCommitTimestamps = super.getCommitTimestamps(
                         tableRef,
                         partitionedTimestamps.beforeStart(),
                         shouldWaitForCommitterToComplete,
@@ -903,20 +910,20 @@ public class SerializableTransaction extends SnapshotTransaction {
 
                 return Futures.whenAllComplete(postStartCommitTimestamps, preStartCommitTimestamps)
                         .call(
-                                () -> ImmutableMap.<Long, Long>builder()
-                                        .putAll(AtlasFutures.getDone(preStartCommitTimestamps))
-                                        .putAll(AtlasFutures.getDone(postStartCommitTimestamps))
-                                        .putAll(partitionedTimestamps.myCommittedTransaction())
-                                        .buildOrThrow(),
+                                () -> {
+                                    MutableLongLongMap map = LongLongMaps.mutable.withAll(
+                                            AtlasFutures.getDone(preStartCommitTimestamps));
+                                    map.putAll(AtlasFutures.getDone(postStartCommitTimestamps));
+                                    map.putAll(partitionedTimestamps.myCommittedTransaction());
+                                    return map.toImmutable();
+                                },
                                 MoreExecutors.directExecutor());
             }
 
-            private ListenableFuture<Map<Long, Long>> getCommitTimestampsForTransactionsStartedAfterMe(
-                    TableReference tableRef,
-                    AsyncTransactionService asyncTransactionService,
-                    Set<Long> startTimestamps) {
+            private ListenableFuture<LongLongMap> getCommitTimestampsForTransactionsStartedAfterMe(
+                    TableReference tableRef, AsyncTransactionService asyncTransactionService, LongSet startTimestamps) {
                 if (startTimestamps.isEmpty()) {
-                    return Futures.immediateFuture(ImmutableMap.of());
+                    return Futures.immediateFuture(LongLongMaps.immutable.empty());
                 }
 
                 return Futures.transform(
@@ -950,19 +957,22 @@ public class SerializableTransaction extends SnapshotTransaction {
              * @param startTimestamps of transactions we are interested in
              * @return a {@link PartitionedTimestamps} object containing split timestamps
              */
-            private PartitionedTimestamps splitTransactionBeforeAndAfter(long myStart, Iterable<Long> startTimestamps) {
+            private PartitionedTimestamps splitTransactionBeforeAndAfter(long myStart, LongIterable startTimestamps) {
                 ImmutablePartitionedTimestamps.Builder builder =
                         ImmutablePartitionedTimestamps.builder().myCommitTimestamp(commitTs);
+                MutableLongSet beforeStart = LongSets.mutable.empty();
+                MutableLongSet afterStart = LongSets.mutable.empty();
                 startTimestamps.forEach(startTimestamp -> {
                     if (startTimestamp == myStart) {
                         builder.splittingStartTimestamp(myStart);
                     } else if (startTimestamp < myStart) {
-                        builder.addBeforeStart(startTimestamp);
+                        beforeStart.add(startTimestamp);
                     } else {
-                        builder.addAfterStart(startTimestamp);
+                        afterStart.add(startTimestamp);
                     }
                 });
-
+                builder.beforeStart(beforeStart.asUnmodifiable());
+                builder.afterStart(afterStart.asUnmodifiable());
                 return builder.build();
             }
         };
@@ -1039,17 +1049,17 @@ public class SerializableTransaction extends SnapshotTransaction {
     interface PartitionedTimestamps {
         long myCommitTimestamp();
 
-        Set<Long> afterStart();
+        LongSet afterStart();
 
-        Set<Long> beforeStart();
+        LongSet beforeStart();
 
         OptionalLong splittingStartTimestamp();
 
         @Value.Derived
-        default Map<Long, Long> myCommittedTransaction() {
+        default LongLongMap myCommittedTransaction() {
             return splittingStartTimestamp().isPresent()
-                    ? ImmutableMap.of(splittingStartTimestamp().getAsLong(), myCommitTimestamp())
-                    : ImmutableMap.of();
+                    ? LongLongMaps.immutable.of(splittingStartTimestamp().getAsLong(), myCommitTimestamp())
+                    : LongLongMaps.immutable.empty();
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -192,7 +192,6 @@ import org.eclipse.collections.api.factory.primitive.LongSets;
 import org.eclipse.collections.api.map.primitive.LongLongMap;
 import org.eclipse.collections.api.set.primitive.ImmutableLongSet;
 import org.eclipse.collections.api.set.primitive.LongSet;
-import org.eclipse.collections.api.set.primitive.MutableLongSet;
 
 /**
  * This implements snapshot isolation for transactions.
@@ -2567,11 +2566,7 @@ public class SnapshotTransaction extends AbstractTransaction
     ///////////////////////////////////////////////////////////////////////////
 
     private LongSet getStartTimestampsForValues(Iterable<Value> values) {
-        MutableLongSet results = LongSets.mutable.empty();
-        for (Value v : values) {
-            results.add(v.getTimestamp());
-        }
-        return results.toImmutable();
+        return LongSets.immutable.withAll(Streams.stream(values).mapToLong(Value::getTimestamp));
     }
 
     private LongLongMap getCommitTimestampsSync(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2402,11 +2402,10 @@ public class SnapshotTransaction extends AbstractTransaction
                             SafeArg.of("startTs", startTs),
                             SafeArg.of("commitTs", commitTs));
                 }
-            } else {
-                log.warn("Rolling back transaction: {}", SafeArg.of("startTs", startTs));
-                return rollbackOtherTransaction(startTs, transactionService);
+                return true;
             }
-            return true;
+            log.warn("Rolling back transaction: {}", SafeArg.of("startTs", startTs));
+            return rollbackOtherTransaction(startTs, transactionService);
         });
 
         if (allRolledBack) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -186,6 +186,13 @@ import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.factory.primitive.LongLists;
+import org.eclipse.collections.api.factory.primitive.LongSets;
+import org.eclipse.collections.api.map.primitive.LongLongMap;
+import org.eclipse.collections.api.set.primitive.ImmutableLongSet;
+import org.eclipse.collections.api.set.primitive.LongSet;
+import org.eclipse.collections.api.set.primitive.MutableLongSet;
 
 /**
  * This implements snapshot isolation for transactions.
@@ -1646,7 +1653,7 @@ public class SnapshotTransaction extends AbstractTransaction
             AsyncKeyValueService asyncKeyValueService,
             AsyncTransactionService asyncTransactionService) {
         Set<Cell> orphanedSentinels = findOrphanedSweepSentinels(tableRef, rawResults);
-        Set<Long> valuesStartTimestamps = getStartTimestampsForValues(rawResults.values());
+        LongSet valuesStartTimestamps = getStartTimestampsForValues(rawResults.values());
 
         return Futures.transformAsync(
                 getCommitTimestamps(tableRef, valuesStartTimestamps, true, asyncTransactionService),
@@ -1668,7 +1675,7 @@ public class SnapshotTransaction extends AbstractTransaction
             Function<Value, T> transformer,
             AsyncKeyValueService asyncKeyValueService,
             Set<Cell> orphanedSentinels,
-            Map<Long, Long> commitTimestamps) {
+            LongLongMap commitTimestamps) {
         Map<Cell, Long> keysToReload = Maps.newHashMapWithExpectedSize(0);
         Map<Cell, Long> keysToDelete = Maps.newHashMapWithExpectedSize(0);
         ImmutableSet.Builder<Cell> keysAddedBuilder = ImmutableSet.builder();
@@ -1699,8 +1706,9 @@ public class SnapshotTransaction extends AbstractTransaction
                         throw new IllegalStateException("Invalid read sentinel behavior " + getReadSentinelBehavior());
                 }
             } else {
-                Long theirCommitTimestamp = commitTimestamps.get(value.getTimestamp());
-                if (theirCommitTimestamp == null || theirCommitTimestamp == TransactionConstants.FAILED_COMMIT_TS) {
+                long theirCommitTimestamp =
+                        commitTimestamps.getIfAbsent(value.getTimestamp(), TransactionConstants.FAILED_COMMIT_TS);
+                if (theirCommitTimestamp == TransactionConstants.FAILED_COMMIT_TS) {
                     keysToReload.put(key, value.getTimestamp());
                     if (shouldDeleteAndRollback()) {
                         // This is from a failed transaction so we can roll it back and then reload it.
@@ -2327,33 +2335,37 @@ public class SnapshotTransaction extends AbstractTransaction
             @Output Set<CellConflict> spanningWrites,
             @Output Set<CellConflict> dominatingWrites,
             TransactionService transactionService) {
+        long startTs = getStartTimestamp();
         Map<Cell, Long> rawResults = keyValueService.getLatestTimestamps(tableRef, keysToLoad);
-        Map<Long, Long> commitTimestamps = getCommitTimestampsSync(tableRef, rawResults.values(), false);
+        LongLongMap commitTimestamps =
+                getCommitTimestampsSync(tableRef, LongLists.immutable.ofAll(rawResults.values()), false);
 
         // TODO(fdesouza): Remove this once PDS-95791 is resolved.
-        conflictTracer.collect(getStartTimestamp(), keysToLoad, rawResults, commitTimestamps);
+        conflictTracer.collect(startTs, keysToLoad, rawResults, commitTimestamps);
 
         Map<Cell, Long> keysToDelete = Maps.newHashMapWithExpectedSize(0);
 
         for (Map.Entry<Cell, Long> e : rawResults.entrySet()) {
             Cell key = e.getKey();
             long theirStartTimestamp = e.getValue();
-            AssertUtils.assertAndLog(
-                    log, theirStartTimestamp != getStartTimestamp(), "Timestamp reuse is bad:" + getStartTimestamp());
+            if (theirStartTimestamp == startTs) {
+                AssertUtils.assertAndLog(log, false, "Timestamp reuse is bad:" + startTs);
+            }
 
-            Long theirCommitTimestamp = commitTimestamps.get(theirStartTimestamp);
-            if (theirCommitTimestamp == null || theirCommitTimestamp == TransactionConstants.FAILED_COMMIT_TS) {
+            long theirCommitTimestamp =
+                    commitTimestamps.getIfAbsent(theirStartTimestamp, TransactionConstants.FAILED_COMMIT_TS);
+            if (theirCommitTimestamp == TransactionConstants.FAILED_COMMIT_TS) {
                 // The value has no commit timestamp or was explicitly rolled back.
                 // This means the value is garbage from a transaction which didn't commit.
                 keysToDelete.put(key, theirStartTimestamp);
                 continue;
+            } else if (theirCommitTimestamp == startTs) {
+                AssertUtils.assertAndLog(log, false, "Timestamp reuse is bad:" + startTs);
             }
 
-            AssertUtils.assertAndLog(
-                    log, theirCommitTimestamp != getStartTimestamp(), "Timestamp reuse is bad:" + getStartTimestamp());
-            if (theirStartTimestamp > getStartTimestamp()) {
+            if (theirStartTimestamp > startTs) {
                 dominatingWrites.add(Cells.createConflict(key, theirStartTimestamp, theirCommitTimestamp));
-            } else if (theirCommitTimestamp > getStartTimestamp()) {
+            } else if (theirCommitTimestamp > startTs) {
                 spanningWrites.add(Cells.createConflict(key, theirStartTimestamp, theirCommitTimestamp));
             }
         }
@@ -2378,30 +2390,38 @@ public class SnapshotTransaction extends AbstractTransaction
     private boolean rollbackFailedTransactions(
             TableReference tableRef,
             Map<Cell, Long> keysToDelete,
-            Map<Long, Long> commitTimestamps,
+            LongLongMap commitTimestamps,
             TransactionService transactionService) {
-        for (long startTs : new HashSet<>(keysToDelete.values())) {
-            if (commitTimestamps.get(startTs) == null) {
-                log.warn("Rolling back transaction: {}", SafeArg.of("startTs", startTs));
-                if (!rollbackOtherTransaction(startTs, transactionService)) {
-                    return false;
+        ImmutableLongSet timestamps = LongSets.immutable.ofAll(keysToDelete.values());
+        boolean allRolledBack = timestamps.allSatisfy(startTs -> {
+            if (commitTimestamps.containsKey(startTs)) {
+                long commitTs = commitTimestamps.get(startTs);
+                if (commitTs != TransactionConstants.FAILED_COMMIT_TS) {
+                    throw new SafeIllegalArgumentException(
+                            "Cannot rollback already committed transaction",
+                            SafeArg.of("startTs", startTs),
+                            SafeArg.of("commitTs", commitTs));
                 }
             } else {
-                Preconditions.checkArgument(commitTimestamps.get(startTs) == TransactionConstants.FAILED_COMMIT_TS);
+                log.warn("Rolling back transaction: {}", SafeArg.of("startTs", startTs));
+                return rollbackOtherTransaction(startTs, transactionService);
+            }
+            return true;
+        });
+
+        if (allRolledBack) {
+            try {
+                runTaskOnDeleteExecutor(kvs -> deleteCells(kvs, tableRef, keysToDelete));
+            } catch (RejectedExecutionException rejected) {
+                deleteExecutorRateLimitedLogger.log(logger -> logger.info(
+                        "Could not delete keys {} for table {}, because the delete executor's queue was full."
+                                + " Sweep should eventually clean these values.",
+                        SafeArg.of("numKeysToDelete", keysToDelete.size()),
+                        LoggingArgs.tableRef(tableRef),
+                        rejected));
             }
         }
-
-        try {
-            runTaskOnDeleteExecutor(kvs -> deleteCells(kvs, tableRef, keysToDelete));
-        } catch (RejectedExecutionException rejected) {
-            deleteExecutorRateLimitedLogger.log(logger -> logger.info(
-                    "Could not delete keys {} for table {}, because the delete executor's queue was full."
-                            + " Sweep should eventually clean these values.",
-                    SafeArg.of("numKeysToDelete", keysToDelete.size()),
-                    LoggingArgs.tableRef(tableRef),
-                    rejected));
-        }
-        return true;
+        return allRolledBack;
     }
 
     private static void deleteCells(
@@ -2487,9 +2507,9 @@ public class SnapshotTransaction extends AbstractTransaction
         return lockResponse.getToken();
     }
 
-    protected ListenableFuture<Map<Long, Long>> getCommitTimestamps(
+    protected ListenableFuture<LongLongMap> getCommitTimestamps(
             TableReference tableRef,
-            Iterable<Long> startTimestamps,
+            LongIterable startTimestamps,
             boolean shouldWaitForCommitterToComplete,
             AsyncTransactionService asyncTransactionService) {
         return commitTimestampLoader.getCommitTimestamps(
@@ -2547,16 +2567,16 @@ public class SnapshotTransaction extends AbstractTransaction
     /// Commit timestamp management
     ///////////////////////////////////////////////////////////////////////////
 
-    private Set<Long> getStartTimestampsForValues(Iterable<Value> values) {
-        Set<Long> results = new HashSet<>();
+    private LongSet getStartTimestampsForValues(Iterable<Value> values) {
+        MutableLongSet results = LongSets.mutable.empty();
         for (Value v : values) {
             results.add(v.getTimestamp());
         }
-        return results;
+        return results.toImmutable();
     }
 
-    private Map<Long, Long> getCommitTimestampsSync(
-            @Nullable TableReference tableRef, Iterable<Long> startTimestamps, boolean waitForCommitterToComplete) {
+    private LongLongMap getCommitTimestampsSync(
+            @Nullable TableReference tableRef, LongIterable startTimestamps, boolean waitForCommitterToComplete) {
         return AtlasFutures.getUnchecked(getCommitTimestamps(
                 tableRef, startTimestamps, waitForCommitterToComplete, immediateTransactionService));
     }
@@ -2625,11 +2645,14 @@ public class SnapshotTransaction extends AbstractTransaction
     }
 
     private boolean wasCommitSuccessful(long commitTs) {
-        Map<Long, Long> commitTimestamps =
-                getCommitTimestampsSync(null, Collections.singleton(getStartTimestamp()), false);
-        long storedCommit = commitTimestamps.get(getStartTimestamp());
+        long startTs = getStartTimestamp();
+        LongLongMap commitTimestamps = getCommitTimestampsSync(null, LongSets.immutable.of(startTs), false);
+        long storedCommit = commitTimestamps.get(startTs);
         if (storedCommit != commitTs && storedCommit != TransactionConstants.FAILED_COMMIT_TS) {
-            Validate.isTrue(false, "Commit value is wrong. startTs %s  commitTs: %s", getStartTimestamp(), commitTs);
+            throw new SafeIllegalArgumentException(
+                    "Commit value is wrong.",
+                    SafeArg.of("startTimestamp", startTs),
+                    SafeArg.of("commitTimestamp", commitTs));
         }
         return storedCommit == commitTs;
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CommitTimestampLoaderTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CommitTimestampLoaderTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -40,9 +39,10 @@ import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import org.eclipse.collections.api.factory.primitive.LongLists;
+import org.eclipse.collections.api.map.primitive.LongLongMap;
 import org.junit.Test;
 
 public class CommitTimestampLoaderTest {
@@ -96,7 +96,7 @@ public class CommitTimestampLoaderTest {
 
         assertThatExceptionOfType(ExecutionException.class)
                 .isThrownBy(() -> commitTimestampLoader
-                        .getCommitTimestamps(TABLE_REF, ImmutableList.of(startTs), false, transactionService)
+                        .getCommitTimestamps(TABLE_REF, LongLists.immutable.of(startTs), false, transactionService)
                         .get())
                 .withRootCauseInstanceOf(SafeIllegalStateException.class)
                 .withMessageContaining("Sweep has swept some entries with a commit TS after us");
@@ -182,10 +182,10 @@ public class CommitTimestampLoaderTest {
 
     private void assertCanGetCommitTs(long startTs, long commitTs, CommitTimestampLoader commitTimestampLoader)
             throws InterruptedException, ExecutionException {
-        Map<Long, Long> loadedCommitTs = commitTimestampLoader
-                .getCommitTimestamps(TABLE_REF, ImmutableList.of(startTs), false, transactionService)
+        LongLongMap loadedCommitTs = commitTimestampLoader
+                .getCommitTimestamps(TABLE_REF, LongLists.immutable.of(startTs), false, transactionService)
                 .get();
-        assertThat(loadedCommitTs).hasSize(1);
+        assertThat(loadedCommitTs.size()).isEqualTo(1);
         assertThat(loadedCommitTs.get(startTs)).isEqualTo(commitTs);
     }
 

--- a/changelog/@unreleased/pr-6640.v2.yml
+++ b/changelog/@unreleased/pr-6640.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Transaction impls use Eclipse primitive collections for in-memory transaction
+    tracking
+  links:
+  - https://github.com/palantir/atlasdb/pull/6640


### PR DESCRIPTION
## General
**Before this PR**:

Was looking through some JFR for a service heavily using AtlasDB queues and noticed a lot of `Long.valueOf` boxing in `com.palantir.atlasdb.transaction.impl.SnapshotTransaction.collectCellsToPostFilter(TableReference, Map, Collection, Function, AsyncKeyValueService, Set, Map):1641` to get commit timestamp for each result value:

https://github.com/palantir/atlasdb/blob/33865f731778e813c41aa03b24eae93de88fdc59/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java#L1641

![image](https://github.com/palantir/atlasdb/assets/54594/681ac258-b65e-419f-b7e3-5da560ccdc9b)


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Transaction impls use Eclipse primitive collections for in-memory transaction tracking
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
Needs benchmark & performance testing. Eclipse collections isn't heavily used in AtlasDB yet, there may be other places we'd want to consider using Eclipse primitive collections for more memory efficient collections & data structures.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
