### PR TITLE
[LWMeta] Create LockRequestMetadata and ChangeMetadata

### DIFF
--- a/changelog/@unreleased/pr-6644.v2.yml
+++ b/changelog/@unreleased/pr-6644.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Add LockMetadata interface with CRUD-like Metadata events
+  description: Create LockRequestMetadata and ChangeMetadata
   links:
   - https://github.com/palantir/atlasdb/pull/6644

--- a/changelog/@unreleased/pr-6644.v2.yml
+++ b/changelog/@unreleased/pr-6644.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add LockMetadata interface with CRUD-like Metadata events
+  links:
+  - https://github.com/palantir/atlasdb/pull/6644

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/ChangeMetadata.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/ChangeMetadata.java
@@ -1,0 +1,136 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.watch;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.lock.watch.ChangeMetadata.Created;
+import com.palantir.lock.watch.ChangeMetadata.Deleted;
+import com.palantir.lock.watch.ChangeMetadata.Unchanged;
+import com.palantir.lock.watch.ChangeMetadata.Updated;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+/**
+ * The subtypes of this class can be used to document CRUD-like operations that were applied to a value.
+ * Every instance should be associated with a {@link com.palantir.lock.LockDescriptor}.
+ * It is up to the users of metadata to know the type of value it refers to
+ * and how to interpret the different subtypes.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Unchanged.class, name = Unchanged.TYPE),
+    @JsonSubTypes.Type(value = Updated.class, name = Updated.TYPE),
+    @JsonSubTypes.Type(value = Deleted.class, name = Deleted.TYPE),
+    @JsonSubTypes.Type(value = Created.class, name = Created.TYPE),
+})
+public interface ChangeMetadata {
+    <T> T accept(Visitor<T> visitor);
+
+    static Unchanged unchanged() {
+        return ImmutableUnchanged.builder().build();
+    }
+
+    static Updated updated(byte[] before, byte[] after) {
+        return ImmutableUpdated.of(before, after);
+    }
+
+    static Deleted deleted(byte[] before) {
+        return ImmutableDeleted.of(before);
+    }
+
+    static Created created(byte[] after) {
+        return ImmutableCreated.of(after);
+    }
+
+    interface Visitor<T> {
+        T visit(Unchanged unchanged);
+
+        T visit(Updated updated);
+
+        T visit(Deleted deleted);
+
+        T visit(Created created);
+    }
+
+    @Immutable
+    @JsonSerialize(as = ImmutableUnchanged.class)
+    @JsonDeserialize(as = ImmutableUnchanged.class)
+    @JsonTypeName(Unchanged.TYPE)
+    interface Unchanged extends ChangeMetadata {
+        String TYPE = "unchanged";
+
+        @Override
+        default <T> T accept(Visitor<T> visitor) {
+            return visitor.visit(this);
+        }
+    }
+
+    @Immutable
+    @JsonSerialize(as = ImmutableUpdated.class)
+    @JsonDeserialize(as = ImmutableUpdated.class)
+    @JsonTypeName(Updated.TYPE)
+    interface Updated extends ChangeMetadata {
+        String TYPE = "updated";
+
+        @Value.Parameter
+        byte[] oldValue();
+
+        @Value.Parameter
+        byte[] newValue();
+
+        @Override
+        default <T> T accept(Visitor<T> visitor) {
+            return visitor.visit(this);
+        }
+    }
+
+    @Immutable
+    @JsonSerialize(as = ImmutableDeleted.class)
+    @JsonDeserialize(as = ImmutableDeleted.class)
+    @JsonTypeName(Deleted.TYPE)
+    interface Deleted extends ChangeMetadata {
+        String TYPE = "deleted";
+
+        @Value.Parameter
+        byte[] oldValue();
+
+        @Override
+        default <T> T accept(Visitor<T> visitor) {
+            return visitor.visit(this);
+        }
+    }
+
+    @Immutable
+    @JsonSerialize(as = ImmutableCreated.class)
+    @JsonDeserialize(as = ImmutableCreated.class)
+    @JsonTypeName(Created.TYPE)
+    interface Created extends ChangeMetadata {
+        String TYPE = "created";
+
+        @Value.Parameter
+        byte[] newValue();
+
+        @Override
+        default <T> T accept(Visitor<T> visitor) {
+            return visitor.visit(this);
+        }
+    }
+}

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/ChangeMetadata.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/ChangeMetadata.java
@@ -39,8 +39,8 @@ import org.immutables.value.Value.Immutable;
 @JsonSubTypes({
     @JsonSubTypes.Type(value = Unchanged.class, name = Unchanged.TYPE),
     @JsonSubTypes.Type(value = Updated.class, name = Updated.TYPE),
-        @JsonSubTypes.Type(value = Deleted.class, name = Deleted.TYPE),
-        @JsonSubTypes.Type(value = Created.class, name = Created.TYPE),
+    @JsonSubTypes.Type(value = Deleted.class, name = Deleted.TYPE),
+    @JsonSubTypes.Type(value = Created.class, name = Created.TYPE),
 })
 public interface ChangeMetadata {
     <T> T accept(Visitor<T> visitor);

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/ChangeMetadata.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/ChangeMetadata.java
@@ -30,6 +30,7 @@ import org.immutables.value.Value.Immutable;
 
 /**
  * The subtypes of this class can be used to document CRUD-like operations that were applied to a value.
+ * However, the READ case is not accounted for as no locks are taken out for reads.
  * Every instance should be associated with a {@link com.palantir.lock.LockDescriptor}.
  * It is up to the users of metadata to know the type of value it refers to
  * and how to interpret the different subtypes.
@@ -38,8 +39,8 @@ import org.immutables.value.Value.Immutable;
 @JsonSubTypes({
     @JsonSubTypes.Type(value = Unchanged.class, name = Unchanged.TYPE),
     @JsonSubTypes.Type(value = Updated.class, name = Updated.TYPE),
-    @JsonSubTypes.Type(value = Deleted.class, name = Deleted.TYPE),
-    @JsonSubTypes.Type(value = Created.class, name = Created.TYPE),
+        @JsonSubTypes.Type(value = Deleted.class, name = Deleted.TYPE),
+        @JsonSubTypes.Type(value = Created.class, name = Created.TYPE),
 })
 public interface ChangeMetadata {
     <T> T accept(Visitor<T> visitor);
@@ -48,16 +49,16 @@ public interface ChangeMetadata {
         return ImmutableUnchanged.builder().build();
     }
 
-    static Updated updated(byte[] before, byte[] after) {
-        return ImmutableUpdated.of(before, after);
+    static Updated updated(byte[] oldValue, byte[] newValue) {
+        return ImmutableUpdated.of(oldValue, newValue);
     }
 
-    static Deleted deleted(byte[] before) {
-        return ImmutableDeleted.of(before);
+    static Deleted deleted(byte[] oldValue) {
+        return ImmutableDeleted.of(oldValue);
     }
 
-    static Created created(byte[] after) {
-        return ImmutableCreated.of(after);
+    static Created created(byte[] newValue) {
+        return ImmutableCreated.of(newValue);
     }
 
     interface Visitor<T> {

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.watch;
+
+import com.palantir.lock.LockDescriptor;
+import com.palantir.logsafe.Unsafe;
+import java.util.Map;
+import org.immutables.value.Value;
+
+/**
+ * Metadata that is attached to lock requests and to any {@link LockEvent} created as a result of that request.
+ */
+@Unsafe
+@Value.Immutable
+public interface LockRequestMetadata {
+    Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata();
+}

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
@@ -22,7 +22,8 @@ import java.util.Map;
 import org.immutables.value.Value;
 
 /**
- * Metadata that is attached to lock requests and to any {@link LockEvent} created as a result of that request.
+ * Metadata attached to a lock request and to any {@link LockEvent} created as a result of that request.
+ * Instances of this class should not be serialized as-is.
  */
 @Unsafe
 @Value.Immutable

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
@@ -23,7 +23,8 @@ import org.immutables.value.Value;
 
 /**
  * Metadata attached to a lock request and to any {@link LockEvent} created as a result of that request.
- * Instances of this class should not be serialized as-is.
+ * Ideally, this class is not serialized as-is to JSON due to the repetition of {@link LockDescriptor} values
+ * in {@link LockRequestMetadata#lockDescriptorToChangeMetadata()} and the parent object.
  */
 @Unsafe
 @Value.Immutable


### PR DESCRIPTION
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[LWMeta] Create LockRequestMetadata and ChangeMetadata
==COMMIT_MSG==

**Priority**:
P1

**Concerns / possible downsides (what feedback would you like?)**:
How are we feeling about naming here? 
Do we want to use a wrapper to encapsulate lock metadata in the future?

**Is documentation needed?**:

## Compatibility
This PR only adds value classes that are currently unused

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
The added metadata types are informed by the theoretical work behind SKAPC. If we later on find that these types are not sufficient, we must adjust them.
## Execution
This PR only adds value classes that are currently unused
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Scale will only come into play once we attach metadata to lock requests / events.

## Development Process
**Where should we start reviewing?**:
LockRequestMetadata

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
