### PR TITLE
only allow range scan batch size increases to be a factor of 8

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIterator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIterator.java
@@ -75,7 +75,7 @@ public class BatchSizeIncreasingIterator<T> implements Closeable {
             batchSize = Math.min(
                     (long) Math.ceil(originalBatchSize * (numReturned / (double) numNotDeleted)), maxNewBatchSize);
         }
-        return (int) Math.min(batchSize, Math.min(maxBatchSize, AtlasDbPerformanceConstants.MAX_BATCH_SIZE));
+        return (int) Math.min(batchSize, maxBatchSize);
     }
 
     private void updateResultsIfNeeded() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIterator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIterator.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.transaction.impl;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
+import com.google.common.math.IntMath;
 import com.palantir.atlasdb.AtlasDbPerformanceConstants;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.base.ClosableIterators;
@@ -60,7 +61,8 @@ public class BatchSizeIncreasingIterator<T> implements Closeable {
         if (currentResults != null) {
             this.lastBatchSize = originalBatchSize;
         }
-        this.maxBatchSize = Math.min(originalBatchSize * MAX_FACTOR, AtlasDbPerformanceConstants.MAX_BATCH_SIZE);
+        this.maxBatchSize = Math.min(
+                IntMath.saturatedMultiply(originalBatchSize, MAX_FACTOR), AtlasDbPerformanceConstants.MAX_BATCH_SIZE);
     }
 
     public void markNumResultsNotDeleted(int resultsInBatch) {
@@ -124,6 +126,11 @@ public class BatchSizeIncreasingIterator<T> implements Closeable {
             lastToken = batchProvider.getLastToken(list);
         }
         return ImmutableBatchResult.of(list, isLastBatch);
+    }
+
+    @VisibleForTesting
+    int getMaxBatchSize() {
+        return maxBatchSize;
     }
 
     @Value.Immutable

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIterator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIterator.java
@@ -53,7 +53,7 @@ public class BatchSizeIncreasingIterator<T> implements Closeable {
         if (currentResults != null) {
             this.lastBatchSize = originalBatchSize;
         }
-        this.maxBatchSize = originalBatchSize * 8;
+        this.maxBatchSize = Math.min(originalBatchSize * 8, AtlasDbPerformanceConstants.MAX_BATCH_SIZE);
     }
 
     public void markNumResultsNotDeleted(int resultsInBatch) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIterator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIterator.java
@@ -35,6 +35,8 @@ public class BatchSizeIncreasingIterator<T> implements Closeable {
     private final int originalBatchSize;
     private final BatchProvider<T> batchProvider;
 
+    private final int maxBatchSize;
+
     private ClosableIterator<T> currentResults;
     private byte[] lastToken;
 
@@ -51,6 +53,7 @@ public class BatchSizeIncreasingIterator<T> implements Closeable {
         if (currentResults != null) {
             this.lastBatchSize = originalBatchSize;
         }
+        this.maxBatchSize = originalBatchSize * 8;
     }
 
     public void markNumResultsNotDeleted(int resultsInBatch) {
@@ -72,7 +75,7 @@ public class BatchSizeIncreasingIterator<T> implements Closeable {
             batchSize = Math.min(
                     (long) Math.ceil(originalBatchSize * (numReturned / (double) numNotDeleted)), maxNewBatchSize);
         }
-        return (int) Math.min(batchSize, AtlasDbPerformanceConstants.MAX_BATCH_SIZE);
+        return (int) Math.min(batchSize, Math.min(maxBatchSize, AtlasDbPerformanceConstants.MAX_BATCH_SIZE));
     }
 
     private void updateResultsIfNeeded() {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIteratorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIteratorTest.java
@@ -45,7 +45,7 @@ public class BatchSizeIncreasingIteratorTest {
                 new TestBatchProvider(1000),
                 originalBatchSize,
                 ClosableIterators.wrap(List.of(0).iterator()));
-        // This will make the batch size increasing iterator that it is only getting deleted values, which will
+        // This will make the batch size increasing iterator think that it is only getting deleted values, which will
         // result in an increase by BatchSizeIncreasingIterator.INCREASE_FACTOR.
         iterator.markNumResultsNotDeleted(0);
         IntStream.range(0, BatchSizeIncreasingIterator.MAX_FACTOR / BatchSizeIncreasingIterator.INCREASE_FACTOR + 1)

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIteratorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/BatchSizeIncreasingIteratorTest.java
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.common.base.ClosableIterator;
+import com.palantir.common.base.ClosableIterators;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Test;
+
+public class BatchSizeIncreasingIteratorTest {
+
+    @Test
+    public void getBestBatchSizeEqualToOriginalOnFirstIteration() {
+        assertThat(new BatchSizeIncreasingIterator<>(
+                                new TestBatchProvider(0), 1, ClosableIterators.emptyImmutableClosableIterator())
+                        .getBestBatchSize())
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void getBestBatchSizeNeverLargerThanMax() {
+        int originalBatchSize = 1;
+        BatchSizeIncreasingIterator<Integer> iterator = new BatchSizeIncreasingIterator<>(
+                new TestBatchProvider(1000),
+                originalBatchSize,
+                ClosableIterators.wrap(List.of(0).iterator()));
+        // This will make the batch size increasing iterator that it is only getting deleted values, which will
+        // result in an increase by BatchSizeIncreasingIterator.INCREASE_FACTOR.
+        iterator.markNumResultsNotDeleted(0);
+        IntStream.range(0, BatchSizeIncreasingIterator.MAX_FACTOR / BatchSizeIncreasingIterator.INCREASE_FACTOR + 1)
+                .forEach(_ignore -> iterator.getBatch());
+        assertThat(iterator.getBestBatchSize()).isEqualTo(originalBatchSize * BatchSizeIncreasingIterator.MAX_FACTOR);
+    }
+
+    private static class TestBatchProvider implements BatchProvider<Integer> {
+
+        private final NavigableSet<Integer> values;
+
+        public TestBatchProvider(Integer count) {
+            this(IntStream.range(0, count)
+                    .boxed()
+                    .collect(Collectors.<Integer, TreeSet<Integer>>toCollection(TreeSet::new)));
+        }
+
+        public TestBatchProvider(NavigableSet<Integer> values) {
+            this.values = values;
+        }
+
+        @Override
+        public ClosableIterator<Integer> getBatch(int batchSize, byte[] lastToken) {
+            int value = ByteBuffer.wrap(lastToken).getInt();
+            return ClosableIterators.wrapWithEmptyClose(
+                    values.tailSet(value, true).iterator());
+        }
+
+        @Override
+        public boolean hasNext(byte[] lastToken) {
+            int value = ByteBuffer.wrap(lastToken).getInt();
+            return values.ceiling(value) != null;
+        }
+
+        @Override
+        public byte[] getLastToken(List<Integer> batch) {
+            return ByteBuffer.allocate(4).putInt(batch.get(batch.size() - 1)).array();
+        }
+    }
+}

--- a/changelog/@unreleased/pr-6645.v2.yml
+++ b/changelog/@unreleased/pr-6645.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Only allow range scan max batch size to be a factor of 8 of the batch
+    hint.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6645


### PR DESCRIPTION
## General
**Before this PR**:
Currently, users of Atlas who leverage range scans are at a risk of an outage due to some internal mechanics on how we adjust the user-provided batch limit in certain cases.

For example, if a user's range request has a batch hint limit of `1`, if the first row we read is "empty" (no committed data), we will increase it by a factor of 4. If subsequent reads are empty, we will then increase it by a factor of 4 once again... this can continue until the limit is `10_000`, which is not ideal. Especially consider the fact that the mindful user who is aware they have wide rows in Cassandra (or another KVS), and specifically sets the limit to `1` to avoid an outage -- sadly for them they may still incur it, despite best behavior, and they have no course for remediation outside releasing a new version of Atlas. 

**After this PR**:
Change the "max batch size" to be a factor of the user-specified limit. In this case, we will be _at most_ 8 times larger than the user specified limit, which should not introduce too many performance regressions; users who only wish to read `1-10` rows will get more predictable performance, and users who do perform larger scans `100-1000` will still be able to progress in a reasonable amount of time.
==COMMIT_MSG==
Ensure user-specified batch hints for range scans do not auto-increase beyond a factor of 8.
==COMMIT_MSG==

**Priority**:
P0

**Concerns / possible downsides (what feedback would you like?)**:
This may introduce random performance regressions if users were relying on the behavior of having `10_000` rows request when they only supplied `1`. 

**Is documentation needed?**:
N/A

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No schematic API breaks but could introduce a performance regression. 

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That 

**What was existing testing like? What have you done to improve it?**:
Does not exist

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
No

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**
No:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Logs, by looking at the batch limit being printed at various stages.

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
If there is a functional issue, logs will indicate issues; for performance regressions, we will have to rely on a per-product basis that they're seeing massive performance regressions. 

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Yes, can just roll back, but we should instead push users to instead increase their batch limit size. 

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
This will only help our largest stack :) 

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
This question would have been very applicable to the original PR. 

## Development Process
**Where should we start reviewing?**:
Immediately! 

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
