### PR TITLE
[LWMeta] Add metadata to LockEvent

### DIFF
--- a/changelog/@unreleased/pr-6646.v2.yml
+++ b/changelog/@unreleased/pr-6646.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[LWMeta] Add metadata to LockEvent'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6646

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockEvent.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockEvent.java
@@ -16,12 +16,14 @@
 
 package com.palantir.lock.watch;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.logsafe.Unsafe;
+import java.util.Optional;
 import java.util.Set;
 import org.immutables.value.Value;
 
@@ -37,6 +39,9 @@ public abstract class LockEvent implements LockWatchEvent {
 
     public abstract LockToken lockToken();
 
+    @JsonIgnore
+    public abstract Optional<LockRequestMetadata> metadata();
+
     @Override
     public int size() {
         return lockDescriptors().size();
@@ -48,8 +53,15 @@ public abstract class LockEvent implements LockWatchEvent {
     }
 
     public static LockWatchEvent.Builder builder(Set<LockDescriptor> lockDescriptors, LockToken lockToken) {
-        ImmutableLockEvent.Builder builder =
-                ImmutableLockEvent.builder().lockDescriptors(lockDescriptors).lockToken(lockToken);
+        return builder(lockDescriptors, lockToken, Optional.empty());
+    }
+
+    public static LockWatchEvent.Builder builder(
+            Set<LockDescriptor> lockDescriptors, LockToken lockToken, Optional<LockRequestMetadata> metadata) {
+        ImmutableLockEvent.Builder builder = ImmutableLockEvent.builder()
+                .lockDescriptors(lockDescriptors)
+                .lockToken(lockToken)
+                .metadata(metadata);
         return seq -> builder.sequence(seq).build();
     }
 }


### PR DESCRIPTION
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[LWMeta] Add metadata to LockEvent
==COMMIT_MSG==

Even though this change is small, I isolated since it is part of the TimeLock API. 

**Priority**:
P1

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
If we enabled the property for JSON serialization: `LockEvent` is part of the TimeLock API since it is returned inside `LockWatchStateUpdate` which is a part of `ConjureStartTransactionsResponse`. However,  LockEvents are only ever transferred from TimeLock to clients, which are guaranteed to be forward-compatible (https://github.com/palantir/conjure/blob/master/docs/spec/wire.md#41-forward-compatible-clients)
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
N/A
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No

## Testing
If we enabled the property for JSON serialization:  We will have to refactor the existing integration tests for lock watches. They byte-compare raw JSON. 

## Execution
We are currently not populating the metadata and it is ignored during serialization, so it has no impact on production
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Once this is deployed, TimeLock will send an empty metadata field  with  each lock event. The impact of this is negligible compared to the other components of a lock event.

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
We will discuss this once we actually populate the metadata.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
