### PR TITLE
[LWMeta] Add LockMetadata to IdentifiedLockRequest

### DIFF
--- a/changelog/@unreleased/pr-6647.v2.yml
+++ b/changelog/@unreleased/pr-6647.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[LWMeta] Add LockMetadata to IdentifiedLockRequest'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6647

--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.guava:guava'
     implementation project(':commons-annotations')
+    testImplementation project(path: ':lock-api')
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
@@ -30,4 +30,10 @@ import org.immutables.value.Value;
 @Value.Immutable
 public interface LockRequestMetadata {
     Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata();
+
+    static LockRequestMetadata of(Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata) {
+        return ImmutableLockRequestMetadata.builder()
+                .lockDescriptorToChangeMetadata(lockDescriptorToChangeMetadata)
+                .build();
+    }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/IdentifiedLockRequest.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/IdentifiedLockRequest.java
@@ -15,10 +15,12 @@
  */
 package com.palantir.lock.client;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.watch.LockRequestMetadata;
 import com.palantir.logsafe.Unsafe;
 import java.util.Optional;
 import java.util.Set;
@@ -43,15 +45,32 @@ public interface IdentifiedLockRequest {
     @Value.Parameter
     Optional<String> getClientDescription();
 
+    @Value.Parameter
+    @JsonIgnore
+    Optional<LockRequestMetadata> getMetadata();
+
     static IdentifiedLockRequest of(Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs) {
         return ImmutableIdentifiedLockRequest.of(
-                UUID.randomUUID(), lockDescriptors, acquireTimeoutMs, Optional.empty());
+                UUID.randomUUID(), lockDescriptors, acquireTimeoutMs, Optional.empty(), Optional.empty());
     }
 
     static IdentifiedLockRequest of(
             Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs, String clientDescription) {
         return ImmutableIdentifiedLockRequest.of(
-                UUID.randomUUID(), lockDescriptors, acquireTimeoutMs, Optional.of(clientDescription));
+                UUID.randomUUID(), lockDescriptors, acquireTimeoutMs, Optional.of(clientDescription), Optional.empty());
+    }
+
+    static IdentifiedLockRequest of(
+            Set<LockDescriptor> lockDescriptors,
+            long acquireTimeoutMs,
+            String clientDescription,
+            LockRequestMetadata metadata) {
+        return ImmutableIdentifiedLockRequest.of(
+                UUID.randomUUID(),
+                lockDescriptors,
+                acquireTimeoutMs,
+                Optional.of(clientDescription),
+                Optional.of(metadata));
     }
 
     static IdentifiedLockRequest from(LockRequest lockRequest) {

--- a/lock-api/src/test/java/com/palantir/lock/client/IdentifiedLockRequestTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/IdentifiedLockRequestTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 
 public class IdentifiedLockRequestTest {
     private static final String BASE = "src/test/resources/identified-lock-request-wire-format/";
-    private static final Mode MODE = Mode.CI;
+    private static final boolean REWRITE_JSON_BLOBS = false;
     private static final IdentifiedLockRequest BASELINE_REQUEST = ImmutableIdentifiedLockRequest.builder()
             .requestId(new UUID(1337, 42))
             .lockDescriptors(ImmutableSet.of(StringLockDescriptor.of("lock1"), StringLockDescriptor.of("lock2")))
@@ -49,15 +49,6 @@ public class IdentifiedLockRequestTest {
             .enable(SerializationFeature.INDENT_OUTPUT)
             .registerModule(new Jdk8Module())
             .registerModule(new GuavaModule());
-
-    private enum Mode {
-        DEV,
-        CI;
-
-        boolean isDev() {
-            return this.equals(Mode.DEV);
-        }
-    }
 
     @Test
     public void baselineRequestIsFullCompat() {
@@ -75,7 +66,7 @@ public class IdentifiedLockRequestTest {
     private void assertSerializedEquals(IdentifiedLockRequest request, String jsonFileName) {
         try {
             Path path = getJsonPath(jsonFileName);
-            if (MODE.isDev()) {
+            if (REWRITE_JSON_BLOBS) {
                 mapper.writeValue(path.toFile(), request);
             }
             String serialized = serialize(request);

--- a/lock-api/src/test/java/com/palantir/lock/client/IdentifiedLockRequestTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/IdentifiedLockRequestTest.java
@@ -45,7 +45,7 @@ public class IdentifiedLockRequestTest {
             .build();
     private static final LockRequestMetadata LOCK_REQUEST_METADATA = LockRequestMetadata.of(ImmutableMap.of(
             StringLockDescriptor.of("lock1"), ChangeMetadata.created("something".getBytes(StandardCharsets.UTF_8))));
-    private static final ObjectMapper mapper = new ObjectMapper()
+    private static final ObjectMapper MAPPER = new ObjectMapper()
             .enable(SerializationFeature.INDENT_OUTPUT)
             .registerModule(new Jdk8Module())
             .registerModule(new GuavaModule());
@@ -63,42 +63,42 @@ public class IdentifiedLockRequestTest {
                 "baseline");
     }
 
-    private void assertSerializedEquals(IdentifiedLockRequest request, String jsonFileName) {
+    private static void assertSerializedEquals(IdentifiedLockRequest request, String jsonFileName) {
         try {
             Path path = getJsonPath(jsonFileName);
             if (REWRITE_JSON_BLOBS) {
-                mapper.writeValue(path.toFile(), request);
+                MAPPER.writeValue(path.toFile(), request);
             }
             String serialized = serialize(request);
-            assertThat(mapper.readTree(serialized))
+            assertThat(MAPPER.readTree(serialized))
                     .as("Serialization yields identical JSON representation")
-                    .isEqualTo(mapper.readTree(Files.readString(path)));
+                    .isEqualTo(MAPPER.readTree(Files.readString(path)));
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }
     }
 
-    private void assertDeserializedEquals(String jsonFileName, IdentifiedLockRequest request) {
+    private static void assertDeserializedEquals(String jsonFileName, IdentifiedLockRequest request) {
         assertThat(deserialize(jsonFileName)).isEqualTo(request);
     }
 
-    private String serialize(IdentifiedLockRequest request) {
+    private static String serialize(IdentifiedLockRequest request) {
         try {
-            return mapper.writeValueAsString(request);
+            return MAPPER.writeValueAsString(request);
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }
     }
 
-    private IdentifiedLockRequest deserialize(String jsonFileName) {
+    private static IdentifiedLockRequest deserialize(String jsonFileName) {
         try {
-            return mapper.readValue(Files.readString(getJsonPath(jsonFileName)), IdentifiedLockRequest.class);
+            return MAPPER.readValue(Files.readString(getJsonPath(jsonFileName)), IdentifiedLockRequest.class);
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }
     }
 
-    private Path getJsonPath(String jsonFileName) {
+    private static Path getJsonPath(String jsonFileName) {
         return Paths.get(BASE + jsonFileName + ".json");
     }
 }

--- a/lock-api/src/test/java/com/palantir/lock/client/IdentifiedLockRequestTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/IdentifiedLockRequestTest.java
@@ -19,24 +19,97 @@ package com.palantir.lock.client;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.lock.watch.ChangeMetadata;
+import com.palantir.lock.watch.LockRequestMetadata;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
 import org.junit.Test;
 
 public class IdentifiedLockRequestTest {
+    private static final String BASE = "src/test/resources/identified-lock-request-wire-format/";
+    private static final Mode MODE = Mode.CI;
+    private static final IdentifiedLockRequest BASELINE_REQUEST = ImmutableIdentifiedLockRequest.builder()
+            .requestId(new UUID(1337, 42))
+            .lockDescriptors(ImmutableSet.of(StringLockDescriptor.of("lock1"), StringLockDescriptor.of("lock2")))
+            .acquireTimeoutMs(100)
+            .clientDescription("client: test, thread: test")
+            .build();
+    private static final LockRequestMetadata LOCK_REQUEST_METADATA = LockRequestMetadata.of(ImmutableMap.of(
+            StringLockDescriptor.of("lock1"), ChangeMetadata.created("something".getBytes(StandardCharsets.UTF_8))));
     private static final String SERIALIZED_LOCK_REQUEST = "{"
             + "\"requestId\":\"885afd9c-de62-44ff-a517-5db14b71bfaa\","
             + "\"lockDescriptors\":[{\"bytes\":\"Zm9v\"}],"
             + "\"acquireTimeoutMs\":123,"
             + "\"clientDescription\":\"Thread: main\"}";
+    private static final ObjectMapper mapper = new ObjectMapper()
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .registerModule(new Jdk8Module())
+            .registerModule(new GuavaModule());
 
-    private static final ObjectMapper mapper =
-            new ObjectMapper().registerModule(new Jdk8Module()).registerModule(new GuavaModule());
+    private enum Mode {
+        DEV,
+        CI;
+
+        boolean isDev() {
+            return this.equals(Mode.DEV);
+        }
+    }
 
     @Test
     public void ensureSerdeBackcompat() throws Exception {
         IdentifiedLockRequest request = mapper.readValue(SERIALIZED_LOCK_REQUEST, IdentifiedLockRequest.class);
         String deserialized = mapper.writeValueAsString(request);
         assertThat(mapper.readTree(deserialized)).isEqualTo(mapper.readTree(SERIALIZED_LOCK_REQUEST));
+    }
+
+    @Test
+    public void baselineRequestIsFullCompat() {
+        assertSerializedEquals(BASELINE_REQUEST, "baseline");
+        assertDeserializedEquals("baseline", BASELINE_REQUEST);
+    }
+
+    @Test
+    public void baselineRequestWithMetadataIsBackCompat() {
+        assertSerializedEquals(
+                ImmutableIdentifiedLockRequest.copyOf(BASELINE_REQUEST).withMetadata(LOCK_REQUEST_METADATA),
+                "baseline");
+    }
+
+    private void assertSerializedEquals(IdentifiedLockRequest request, String jsonFileName) {
+        try {
+            Path path = getJsonPath(jsonFileName);
+            if (MODE.isDev()) {
+                mapper.writeValue(path.toFile(), request);
+            }
+            String deserialized = mapper.writeValueAsString(request);
+            assertThat(mapper.readTree(deserialized))
+                    .as("Serialization yields identical JSON representation")
+                    .isEqualTo(mapper.readTree(Files.readString(path)));
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    private void assertDeserializedEquals(String jsonFileName, IdentifiedLockRequest request) {
+        try {
+            assertThat(mapper.readValue(Files.readString(getJsonPath(jsonFileName)), IdentifiedLockRequest.class))
+                    .as("Deserialization yields equal Java representation")
+                    .isEqualTo(request);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    private Path getJsonPath(String jsonFileName) {
+        return Paths.get(BASE + jsonFileName + ".json");
     }
 }

--- a/lock-api/src/test/resources/identified-lock-request-wire-format/baseline.json
+++ b/lock-api/src/test/resources/identified-lock-request-wire-format/baseline.json
@@ -1,0 +1,10 @@
+{
+  "requestId" : "00000000-0000-0539-0000-00000000002a",
+  "lockDescriptors" : [ {
+    "bytes" : "bG9jazE="
+  }, {
+    "bytes" : "bG9jazI="
+  } ],
+  "acquireTimeoutMs" : 100,
+  "clientDescription" : "client: test, thread: test"
+}


### PR DESCRIPTION
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[LWMeta] Add LockMetadata to IdentifiedLockRequest
==COMMIT_MSG==

**Priority**:
P1
**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
The JSON property is ignored, so no API breaks here. We have to look into Jersey serialization/deserialization before enabling it. If jersey is not an issue, we can enable it.

## Testing
I significantly expanded the existing testing for back wards compatibility of `IdentifiedLockRequest` and removed some duplicate tests. This overengineering was performed in preparation of the upcoming wire format changes, which will be partially tested in this class.

## Execution
JSON property is disabled and the field is set to default by a builder -> no impact on production.

## Scale
if we enabled the field: We always attach at least an additional empty map to every object. Since Jersey is deprecated, we won't think of an efficient wire format for `IdentifiedLockRequest`

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
