### PR TITLE
[LWMeta] Pass optional metadata through TimeLock

### DIFF
--- a/changelog/@unreleased/pr-6651.v2.yml
+++ b/changelog/@unreleased/pr-6651.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[LWMeta] Pass optional metadata through TimeLock'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6651

--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
@@ -29,11 +29,11 @@ import org.immutables.value.Value;
 @Unsafe
 @Value.Immutable
 public interface LockRequestMetadata {
+
+    @Value.Parameter
     Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata();
 
     static LockRequestMetadata of(Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata) {
-        return ImmutableLockRequestMetadata.builder()
-                .lockDescriptorToChangeMetadata(lockDescriptorToChangeMetadata)
-                .build();
+        return ImmutableLockRequestMetadata.of(lockDescriptorToChangeMetadata);
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -48,6 +48,7 @@ import com.palantir.lock.v2.StartTransactionResponseV4;
 import com.palantir.lock.v2.TimestampAndPartition;
 import com.palantir.lock.v2.WaitForLocksRequest;
 import com.palantir.lock.v2.WaitForLocksResponse;
+import com.palantir.lock.watch.LockRequestMetadata;
 import com.palantir.lock.watch.LockWatchStateUpdate;
 import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.timestamp.ManagedTimestampService;
@@ -101,7 +102,10 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     @Override
     public ListenableFuture<LockResponseV2> lock(IdentifiedLockRequest request) {
         AsyncResult<Leased<LockToken>> result = lockService.lock(
-                request.getRequestId(), request.getLockDescriptors(), TimeLimit.of(request.getAcquireTimeoutMs()));
+                request.getRequestId(),
+                request.getLockDescriptors(),
+                TimeLimit.of(request.getAcquireTimeoutMs()),
+                request.getMetadata());
         lockLog.registerRequest(request, result);
         SettableFuture<LockResponseV2> response = SettableFuture.create();
         result.onComplete(() -> {
@@ -274,8 +278,9 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     }
 
     @Override
-    public void registerLock(Set<LockDescriptor> locksTakenOut, LockToken token) {
-        lockService.getLockWatchingService().registerLock(locksTakenOut, token);
+    public void registerLock(
+            Set<LockDescriptor> locksTakenOut, LockToken token, Optional<LockRequestMetadata> metadata) {
+        lockService.getLockWatchingService().registerLock(locksTakenOut, token, metadata);
     }
 
     @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockAcquirer.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockAcquirer.java
@@ -17,9 +17,11 @@ package com.palantir.atlasdb.timelock.lock;
 
 import com.google.common.base.Throwables;
 import com.palantir.atlasdb.timelock.lock.watch.LockWatchingService;
+import com.palantir.lock.watch.LockRequestMetadata;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -46,9 +48,14 @@ public class LockAcquirer implements AutoCloseable {
     }
 
     public AsyncResult<HeldLocks> acquireLocks(UUID requestId, OrderedLocks locks, TimeLimit timeout) {
+        return acquireLocks(requestId, locks, timeout, Optional.empty());
+    }
+
+    public AsyncResult<HeldLocks> acquireLocks(
+            UUID requestId, OrderedLocks locks, TimeLimit timeout, Optional<LockRequestMetadata> metadata) {
         return new Acquisition(requestId, locks, timeout, lock -> lock.lock(requestId))
                 .execute()
-                .map(ignored -> HeldLocks.create(lockLog, locks.get(), requestId, leaderClock, lockWatcher));
+                .map(ignored -> HeldLocks.create(lockLog, locks.get(), requestId, leaderClock, lockWatcher, metadata));
     }
 
     public AsyncResult<Void> waitForLocks(UUID requestId, OrderedLocks locks, TimeLimit timeout) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLog.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLog.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.timelock.lock.watch;
 
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.watch.LockRequestMetadata;
 import com.palantir.lock.watch.LockWatchStateUpdate;
 import com.palantir.lock.watch.LockWatchVersion;
 import java.util.Optional;
@@ -29,7 +30,11 @@ public interface LockEventLog {
 
     <T> ValueAndLockWatchStateUpdate<T> runTask(Optional<LockWatchVersion> lastKnownVersion, Supplier<T> task);
 
-    void logLock(Set<LockDescriptor> locksTakenOut, LockToken lockToken);
+    default void logLock(Set<LockDescriptor> locksTakenOut, LockToken lockToken) {
+        logLock(locksTakenOut, lockToken, Optional.empty());
+    }
+
+    void logLock(Set<LockDescriptor> locksTakenOut, LockToken lockToken, Optional<LockRequestMetadata> metadata);
 
     void logUnlock(Set<LockDescriptor> locksUnlocked);
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
@@ -22,6 +22,7 @@ import com.palantir.atlasdb.timelock.lock.HeldLocksCollection;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.watch.LockEvent;
+import com.palantir.lock.watch.LockRequestMetadata;
 import com.palantir.lock.watch.LockWatchCreatedEvent;
 import com.palantir.lock.watch.LockWatchReferences.LockWatchReference;
 import com.palantir.lock.watch.LockWatchStateUpdate;
@@ -61,8 +62,9 @@ public class LockEventLogImpl implements LockEventLog {
     }
 
     @Override
-    public synchronized void logLock(Set<LockDescriptor> locksTakenOut, LockToken lockToken) {
-        slidingWindow.add(LockEvent.builder(locksTakenOut, lockToken));
+    public synchronized void logLock(
+            Set<LockDescriptor> locksTakenOut, LockToken lockToken, Optional<LockRequestMetadata> metadata) {
+        slidingWindow.add(LockEvent.builder(locksTakenOut, lockToken, metadata));
     }
 
     @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingService.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.timelock.lock.watch;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.client.LockWatchStarter;
 import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.watch.LockRequestMetadata;
 import com.palantir.lock.watch.LockWatchStateUpdate;
 import com.palantir.lock.watch.LockWatchVersion;
 import java.util.Optional;
@@ -30,7 +31,11 @@ public interface LockWatchingService extends LockWatchStarter {
 
     <T> ValueAndLockWatchStateUpdate<T> runTask(Optional<LockWatchVersion> lastKnownVersion, Supplier<T> task);
 
-    void registerLock(Set<LockDescriptor> locksTakenOut, LockToken token);
+    default void registerLock(Set<LockDescriptor> locksTakenOut, LockToken token) {
+        registerLock(locksTakenOut, token, Optional.empty());
+    }
+
+    void registerLock(Set<LockDescriptor> locksTakenOut, LockToken token, Optional<LockRequestMetadata> metadata);
 
     void registerUnlock(Set<LockDescriptor> locksUnlocked);
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
@@ -169,7 +169,6 @@ public class LockWatchingServiceImpl implements LockWatchingService {
             RangeSet<LockDescriptor> ranges = watches.get().ranges();
             Set<LockDescriptor> filteredLocks =
                     unfilteredLocks.stream().filter(ranges::contains).collect(Collectors.toSet());
-            // We would expect metadata to be absent in ~1/2 of the cases, so this ternary will save us some overhead
             Optional<LockRequestMetadata> filteredMetadata = unfilteredMetadata
                     .map(LockRequestMetadata::lockDescriptorToChangeMetadata)
                     .map(unfilteredLockMetadata -> {
@@ -180,7 +179,6 @@ public class LockWatchingServiceImpl implements LockWatchingService {
                         return LockRequestMetadata.of(filteredLockMetadata);
                     });
             // Even if our metadata is non-empty after filtering, but our locks are, we do not proceed.
-            // This is done to maintain the existing lock watch semantics
             if (!filteredLocks.isEmpty()) {
                 biConsumer.accept(filteredLocks, filteredMetadata);
             }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
@@ -179,8 +179,9 @@ public class LockWatchingServiceImpl implements LockWatchingService {
         }
     }
 
-    // For an efficient encoding, we enforce that metadata is never attached to a lock descriptor that is not contained
-    // in the original request, so filtering metadata based on the already filtered locks is sufficient.
+    // For an efficient encoding, we expect that metadata is never attached to a lock descriptor that is not contained
+    // in the original request, so filtering metadata based on the already filtered locks is sufficient and enforces
+    // this invariant.
     // It is also cheaper than calling RangeSet::contains.
     private static Optional<LockRequestMetadata> filterMetadataBasedOnFilteredLocks(
             Set<LockDescriptor> filteredLocks, Optional<LockRequestMetadata> unfilteredMetadata) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
@@ -27,7 +27,6 @@ import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.v2.LeadershipId;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.watch.ChangeMetadata;
-import com.palantir.lock.watch.ImmutableLockRequestMetadata;
 import com.palantir.lock.watch.LockRequestMetadata;
 import com.palantir.lock.watch.LockWatchReferences;
 import com.palantir.lock.watch.LockWatchReferences.LockWatchReference;
@@ -178,10 +177,10 @@ public class LockWatchingServiceImpl implements LockWatchingService {
                                         unfilteredLockMetadata.entrySet().stream())
                                 .filterKeys(ranges::contains)
                                 .collectToMap();
-                        return ImmutableLockRequestMetadata.builder()
-                                .lockDescriptorToChangeMetadata(filteredLockMetadata)
-                                .build();
+                        return LockRequestMetadata.of(filteredLockMetadata);
                     });
+            // Even if our metadata is non-empty after filtering, but our locks are, we do not proceed.
+            // This is done to maintain the existing lock watch semantics
             if (!filteredLocks.isEmpty()) {
                 biConsumer.accept(filteredLocks, filteredMetadata);
             }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
@@ -178,7 +178,11 @@ public class LockWatchingServiceImpl implements LockWatchingService {
                     .map(unfilteredLockMetadata -> {
                         Map<LockDescriptor, ChangeMetadata> filteredLockMetadata = KeyedStream.ofEntries(
                                         unfilteredLockMetadata.entrySet().stream())
-                                .filterKeys(ranges::contains)
+                                // For an efficient encoding, we enforce that metadata is never attached to a lock
+                                // descriptor that is not contained in the original request, so this lookup is
+                                // sufficient.
+                                // It is also cheaper than calling RangeSet::contains.
+                                .filterKeys(filteredLocks::contains)
                                 .collectToMap();
                         return LockRequestMetadata.of(filteredLockMetadata);
                     });

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
@@ -179,6 +179,9 @@ public class LockWatchingServiceImpl implements LockWatchingService {
         }
     }
 
+    // For an efficient encoding, we enforce that metadata is never attached to a lock descriptor that is not contained
+    // in the original request, so filtering metadata based on the already filtered locks is sufficient.
+    // It is also cheaper than calling RangeSet::contains.
     private static Optional<LockRequestMetadata> filterMetadataBasedOnFilteredLocks(
             Set<LockDescriptor> filteredLocks, Optional<LockRequestMetadata> unfilteredMetadata) {
         return unfilteredMetadata
@@ -186,9 +189,6 @@ public class LockWatchingServiceImpl implements LockWatchingService {
                 .map(unfilteredLockMetadata -> {
                     Map<LockDescriptor, ChangeMetadata> filteredLockMetadata = KeyedStream.ofEntries(
                                     unfilteredLockMetadata.entrySet().stream())
-                            // For an efficient encoding, we enforce that metadata is never attached to a lock
-                            // descriptor that is not contained in the original request, so this lookup is sufficient.
-                            // It is also cheaper than calling RangeSet::contains.
                             .filterKeys(filteredLocks::contains)
                             .collectToMap();
                     return LockRequestMetadata.of(filteredLockMetadata);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImplTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImplTest.java
@@ -108,7 +108,7 @@ public class LockWatchingServiceImplTest {
         Set<LockDescriptor> locks = ImmutableSet.of(CELL_DESCRIPTOR);
 
         Future<?> registerLock = executor.submit(() -> {
-            lockWatcher.registerLock(locks, TOKEN, Optional.empty());
+            lockWatcher.registerLock(locks, TOKEN);
             otherTaskCompleted.countDown();
             return null;
         });
@@ -152,11 +152,11 @@ public class LockWatchingServiceImplTest {
         lockWatcher.startWatching(request);
 
         Set<LockDescriptor> cellDescriptor = ImmutableSet.of(CELL_DESCRIPTOR);
-        lockWatcher.registerLock(cellDescriptor, TOKEN, attachMetadataToLocks(cellDescriptor));
+        lockWatcher.registerLock(cellDescriptor, TOKEN, createMetadataForLocks(cellDescriptor));
 
         assertLoggedEvents(ImmutableList.of(
                 createdEvent(request.getReferences(), ImmutableSet.of(ROW_DESCRIPTOR)),
-                lockEvent(cellDescriptor, attachMetadataToLocks(cellDescriptor))));
+                lockEvent(cellDescriptor, createMetadataForLocks(cellDescriptor))));
     }
 
     @Test
@@ -237,12 +237,12 @@ public class LockWatchingServiceImplTest {
         lockWatcher.startWatching(request);
 
         ImmutableSet<LockDescriptor> locks = ImmutableSet.of(CELL_DESCRIPTOR, cellSuffixDescriptor);
-        lockWatcher.registerLock(locks, TOKEN, attachMetadataToLocks(locks));
+        lockWatcher.registerLock(locks, TOKEN, createMetadataForLocks(locks));
 
         ImmutableSet<LockDescriptor> expectedFilteredLocks = ImmutableSet.of(CELL_DESCRIPTOR);
         List<LockWatchEvent> expectedEvents = ImmutableList.of(
                 createdEvent(request.getReferences(), ImmutableSet.of()),
-                lockEvent(expectedFilteredLocks, attachMetadataToLocks(expectedFilteredLocks)));
+                lockEvent(expectedFilteredLocks, createMetadataForLocks(expectedFilteredLocks)));
         assertLoggedEvents(expectedEvents);
     }
 
@@ -253,12 +253,12 @@ public class LockWatchingServiceImplTest {
         lockWatcher.startWatching(rowRequest);
 
         ImmutableSet<LockDescriptor> locks = ImmutableSet.of(CELL_DESCRIPTOR, ROW_DESCRIPTOR);
-        lockWatcher.registerLock(locks, TOKEN, attachMetadataToLocks(locks));
+        lockWatcher.registerLock(locks, TOKEN, createMetadataForLocks(locks));
 
         ImmutableSet<LockDescriptor> expectedFilteredLocks = ImmutableSet.of(ROW_DESCRIPTOR, CELL_DESCRIPTOR);
         List<LockWatchEvent> expectedEvents = ImmutableList.of(
                 createdEvent(rowRequest.getReferences(), ImmutableSet.of(ROW_DESCRIPTOR)),
-                lockEvent(expectedFilteredLocks, attachMetadataToLocks(expectedFilteredLocks)));
+                lockEvent(expectedFilteredLocks, createMetadataForLocks(expectedFilteredLocks)));
         assertLoggedEvents(expectedEvents);
     }
 
@@ -271,12 +271,12 @@ public class LockWatchingServiceImplTest {
         lockWatcher.startWatching(prefixRequest);
 
         ImmutableSet<LockDescriptor> locks = ImmutableSet.of(CELL_DESCRIPTOR, ROW_DESCRIPTOR, notPrefixDescriptor);
-        lockWatcher.registerLock(locks, TOKEN, attachMetadataToLocks(locks));
+        lockWatcher.registerLock(locks, TOKEN, createMetadataForLocks(locks));
 
         ImmutableSet<LockDescriptor> expectedFilteredLocks = ImmutableSet.of(CELL_DESCRIPTOR, ROW_DESCRIPTOR);
         List<LockWatchEvent> expectedEvents = ImmutableList.of(
                 createdEvent(prefixRequest.getReferences(), ImmutableSet.of(ROW_DESCRIPTOR)),
-                lockEvent(expectedFilteredLocks, attachMetadataToLocks(expectedFilteredLocks)));
+                lockEvent(expectedFilteredLocks, createMetadataForLocks(expectedFilteredLocks)));
         assertLoggedEvents(expectedEvents);
     }
 
@@ -299,12 +299,12 @@ public class LockWatchingServiceImplTest {
         ImmutableSet<LockDescriptor> locks =
                 ImmutableSet.of(cellInRange, cellOutOfRange, rowInRange, rowInRange2, rowOutOfRange);
 
-        lockWatcher.registerLock(locks, TOKEN, attachMetadataToLocks(locks));
+        lockWatcher.registerLock(locks, TOKEN, createMetadataForLocks(locks));
 
         ImmutableSet<LockDescriptor> expectedFilteredLocks = ImmutableSet.of(cellInRange, rowInRange, rowInRange2);
         List<LockWatchEvent> expectedEvents = ImmutableList.of(
                 createdEvent(rangeRequest.getReferences(), ImmutableSet.of()),
-                lockEvent(expectedFilteredLocks, attachMetadataToLocks(expectedFilteredLocks)));
+                lockEvent(expectedFilteredLocks, createMetadataForLocks(expectedFilteredLocks)));
         assertLoggedEvents(expectedEvents);
     }
 
@@ -319,13 +319,13 @@ public class LockWatchingServiceImplTest {
 
         ImmutableSet<LockDescriptor> locks =
                 ImmutableSet.of(CELL_DESCRIPTOR, cellOutOfRange, rowInRange, rowOutOfRange);
-        lockWatcher.registerLock(locks, TOKEN, attachMetadataToLocks(locks));
+        lockWatcher.registerLock(locks, TOKEN, createMetadataForLocks(locks));
 
         ImmutableSet<LockDescriptor> expectedFilteredLocks =
                 ImmutableSet.of(ROW_DESCRIPTOR, CELL_DESCRIPTOR, rowInRange);
         List<LockWatchEvent> expectedEvents = ImmutableList.of(
                 createdEvent(tableRequest.getReferences(), ImmutableSet.of(ROW_DESCRIPTOR)),
-                lockEvent(expectedFilteredLocks, attachMetadataToLocks(expectedFilteredLocks)));
+                lockEvent(expectedFilteredLocks, createMetadataForLocks(expectedFilteredLocks)));
         assertLoggedEvents(expectedEvents);
     }
 
@@ -370,9 +370,9 @@ public class LockWatchingServiceImplTest {
         return AtlasRowLockDescriptor.of(TABLE_2.getQualifiedName(), ROW);
     }
 
-    private static Optional<LockRequestMetadata> attachMetadataToLocks(Set<LockDescriptor> lockDescriptors) {
+    private static Optional<LockRequestMetadata> createMetadataForLocks(Set<LockDescriptor> lockDescriptors) {
         return Optional.of(LockRequestMetadata.of(
-                KeyedStream.of(lockDescriptors).map(unused -> DUMMY_METADATA).collectToMap()));
+                KeyedStream.of(lockDescriptors).map(_unused -> DUMMY_METADATA).collectToMap()));
     }
 
     private void assertLoggedEvents(List<LockWatchEvent> expectedEvents) {

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimeLockServiceMetadataIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimeLockServiceMetadataIntegrationTest.java
@@ -123,7 +123,6 @@ public class AsyncTimeLockServiceMetadataIntegrationTest {
 
     @Test
     public void lockEventDoesNotContainMetadataThatIsNotWatched() {
-
         IdentifiedLockRequest mixedRequest =
                 standardRequestWithMetadata(ImmutableMap.<LockDescriptor, ChangeMetadata>builder()
                         .putAll(ALL_WATCHED_LOCKS_WITH_METADATA)
@@ -146,6 +145,7 @@ public class AsyncTimeLockServiceMetadataIntegrationTest {
                 ChangeMetadata.updated(
                         "bla".getBytes(StandardCharsets.UTF_8), "blabla".getBytes(StandardCharsets.UTF_8))));
         waitForFuture(timeLockService.lock(mixedRequest));
+
         assertThat(getAllLockEventsMetadata()).isEmpty();
     }
 

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimeLockServiceMetadataIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimeLockServiceMetadataIntegrationTest.java
@@ -1,0 +1,270 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.timelock.api.ConjureIdentifiedVersion;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
+import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
+import com.palantir.atlasdb.timelock.api.LockWatchRequest;
+import com.palantir.atlasdb.timelock.lock.AsyncLockService;
+import com.palantir.atlasdb.timelock.lock.LockLog;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.lock.AtlasRowLockDescriptor;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.client.IdentifiedLockRequest;
+import com.palantir.lock.client.ImmutableIdentifiedLockRequest;
+import com.palantir.lock.v2.LockResponseV2;
+import com.palantir.lock.v2.LockResponseV2.Successful;
+import com.palantir.lock.v2.LockResponseV2.Unsuccessful;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.watch.ChangeMetadata;
+import com.palantir.lock.watch.LockEvent;
+import com.palantir.lock.watch.LockRequestMetadata;
+import com.palantir.lock.watch.LockWatchCreatedEvent;
+import com.palantir.lock.watch.LockWatchEvent;
+import com.palantir.lock.watch.LockWatchReferences;
+import com.palantir.lock.watch.LockWatchStateUpdate.Snapshot;
+import com.palantir.lock.watch.LockWatchStateUpdate.Success;
+import com.palantir.lock.watch.LockWatchStateUpdate.Visitor;
+import com.palantir.lock.watch.UnlockEvent;
+import com.palantir.timestamp.InMemoryTimestampService;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AsyncTimeLockServiceMetadataIntegrationTest {
+    private static final String WATCHED_TABLE_NAME = "watched-table";
+    private static final LockDescriptor WATCHED_LOCK_1 =
+            AtlasRowLockDescriptor.of(WATCHED_TABLE_NAME, "lock1".getBytes(StandardCharsets.UTF_8));
+    private static final LockDescriptor WATCHED_LOCK_2 =
+            AtlasRowLockDescriptor.of(WATCHED_TABLE_NAME, "lock2".getBytes(StandardCharsets.UTF_8));
+    private static final LockDescriptor WATCHED_LOCK_3 =
+            AtlasRowLockDescriptor.of(WATCHED_TABLE_NAME, "lock3".getBytes(StandardCharsets.UTF_8));
+    private static final LockDescriptor WATCHED_LOCK_4 =
+            AtlasRowLockDescriptor.of(WATCHED_TABLE_NAME, "lock4".getBytes(StandardCharsets.UTF_8));
+    private static final Map<LockDescriptor, ChangeMetadata> ALL_WATCHED_LOCKS_WITH_METADATA = ImmutableMap.of(
+            WATCHED_LOCK_1,
+            ChangeMetadata.unchanged(),
+            WATCHED_LOCK_2,
+            ChangeMetadata.updated("old".getBytes(StandardCharsets.UTF_8), "new".getBytes(StandardCharsets.UTF_8)),
+            WATCHED_LOCK_3,
+            ChangeMetadata.deleted("deleted".getBytes(StandardCharsets.UTF_8)),
+            WATCHED_LOCK_4,
+            ChangeMetadata.created("created".getBytes(StandardCharsets.UTF_8)));
+    private static final String UNWATCHED_TABLE_NAME = "a-random-unwatched-table";
+    private static final LockDescriptor UNWATCHED_LOCK_1 =
+            AtlasRowLockDescriptor.of(UNWATCHED_TABLE_NAME, "lock1".getBytes(StandardCharsets.UTF_8));
+    private static final IdentifiedLockRequest WATCHED_LOCK_REQUEST_WITH_METADATA =
+            standardRequestWithMetadata(ALL_WATCHED_LOCKS_WITH_METADATA);
+
+    private final LockLog lockLog = new LockLog(new MetricRegistry(), () -> 10000L);
+    private final ScheduledExecutorService scheduledExecutorService = PTExecutors.newSingleThreadScheduledExecutor();
+    private final AsyncLockService asyncLockService =
+            AsyncLockService.createDefault(lockLog, scheduledExecutorService, scheduledExecutorService);
+    private final AsyncTimelockServiceImpl timeLockService =
+            new AsyncTimelockServiceImpl(asyncLockService, new InMemoryTimestampService(), lockLog);
+    private final ConjureStartTransactionsRequest startTransactionsRequestWithInitialVersion =
+            ConjureStartTransactionsRequest.builder()
+                    .requestId(UUID.randomUUID())
+                    .lastKnownVersion(ConjureIdentifiedVersion.of(
+                            asyncLockService.leaderTime().id().id(), 0))
+                    .numTransactions(1)
+                    .requestorId(UUID.randomUUID())
+                    .build();
+
+    @Before
+    public void setupLockServiceWithWatches() {
+        timeLockService.startWatching(
+                LockWatchRequest.of(ImmutableSet.of(LockWatchReferences.entireTable(WATCHED_TABLE_NAME))));
+    }
+
+    @Test
+    public void lockEventContainsMetadataFromRequestIfWatched() {
+        waitForFuture(timeLockService.lock(WATCHED_LOCK_REQUEST_WITH_METADATA));
+
+        assertThat(getAllLockEventsMetadata())
+                .containsExactly(Optional.of(LockRequestMetadata.of(ALL_WATCHED_LOCKS_WITH_METADATA)));
+    }
+
+    @Test
+    public void lockEventDoesNotContainMetadataThatIsNotWatched() {
+
+        IdentifiedLockRequest mixedRequest =
+                standardRequestWithMetadata(ImmutableMap.<LockDescriptor, ChangeMetadata>builder()
+                        .putAll(ALL_WATCHED_LOCKS_WITH_METADATA)
+                        .put(
+                                UNWATCHED_LOCK_1,
+                                ChangeMetadata.updated(
+                                        "bla".getBytes(StandardCharsets.UTF_8),
+                                        "blabla".getBytes(StandardCharsets.UTF_8)))
+                        .buildKeepingLast());
+        waitForFuture(timeLockService.lock(mixedRequest));
+
+        assertThat(getAllLockEventsMetadata())
+                .containsExactly(Optional.of(LockRequestMetadata.of(ALL_WATCHED_LOCKS_WITH_METADATA)));
+    }
+
+    @Test
+    public void noLockEventIsPublishedIfNothingIsWatched() {
+        IdentifiedLockRequest mixedRequest = standardRequestWithMetadata(ImmutableMap.of(
+                UNWATCHED_LOCK_1,
+                ChangeMetadata.updated(
+                        "bla".getBytes(StandardCharsets.UTF_8), "blabla".getBytes(StandardCharsets.UTF_8))));
+        waitForFuture(timeLockService.lock(mixedRequest));
+        assertThat(getAllLockEventsMetadata()).isEmpty();
+    }
+
+    @Test
+    public void canRetrieveMultipleEventsWithMetadata() {
+        List<Optional<LockRequestMetadata>> metadataList = new ArrayList<>();
+        ALL_WATCHED_LOCKS_WITH_METADATA.forEach((lock, metadata) -> {
+            Map<LockDescriptor, ChangeMetadata> map = ImmutableMap.of(lock, metadata);
+            IdentifiedLockRequest request = standardRequestWithMetadata(map);
+            waitForFuture(timeLockService.lock(request));
+            metadataList.add(Optional.of(LockRequestMetadata.of(map)));
+        });
+
+        assertThat(getAllLockEventsMetadata()).containsExactlyElementsOf(metadataList);
+    }
+
+    @Test
+    public void toleratesAndPassesDownAbsentMetadata() {
+        // this will create a lock request for 4 lock descriptors, but with absent metadata
+        IdentifiedLockRequest requestWithoutMetadata = ImmutableIdentifiedLockRequest.copyOf(
+                        standardRequestWithMetadata(ALL_WATCHED_LOCKS_WITH_METADATA))
+                .withMetadata(Optional.empty());
+        waitForFuture(timeLockService.lock(requestWithoutMetadata));
+
+        assertThat(getAllLockEventsMetadata()).containsExactly(Optional.empty());
+    }
+
+    @Test
+    public void canMixWithOtherLockWatchEventsAndAbsentMetadata() {
+        List<Optional<LockRequestMetadata>> metadataList = new ArrayList<>();
+        ALL_WATCHED_LOCKS_WITH_METADATA.forEach((lock, metadata) -> {
+            // -> LockWatchCreatedEvent
+            timeLockService.startWatching(LockWatchRequest.of(
+                    ImmutableSet.of(LockWatchReferences.entireTable("randomTable" + metadataList.size()))));
+
+            // -> LockEvent with metadata
+            Map<LockDescriptor, ChangeMetadata> map = ImmutableMap.of(lock, metadata);
+            IdentifiedLockRequest requestWithMetadata = standardRequestWithMetadata(map);
+            LockResponseV2 response = waitForFuture(timeLockService.lock(requestWithMetadata));
+            metadataList.add(Optional.of(LockRequestMetadata.of(map)));
+
+            // -> UnlockEvent
+            waitForFuture(timeLockService.unlock(ImmutableSet.of(getToken(response))));
+
+            // -> LockEvent with absent metadata
+            IdentifiedLockRequest requestWithoutMetadata = ImmutableIdentifiedLockRequest.copyOf(
+                            standardRequestWithMetadata(map))
+                    .withMetadata(Optional.empty());
+            response = waitForFuture(timeLockService.lock(requestWithoutMetadata));
+            metadataList.add(Optional.empty());
+
+            // -> UnlockEvent
+            waitForFuture(timeLockService.unlock(ImmutableSet.of(getToken(response))));
+        });
+
+        assertThat(getAllLockWatchEvents()).hasSize(5 * ALL_WATCHED_LOCKS_WITH_METADATA.size());
+        assertThat(getAllLockEventsMetadata()).containsExactlyElementsOf(metadataList);
+    }
+
+    private List<Optional<LockRequestMetadata>> getAllLockEventsMetadata() {
+        return getAllLockWatchEvents().stream()
+                .map(event -> event.accept(new LockWatchEvent.Visitor<Optional<LockEvent>>() {
+                    @Override
+                    public Optional<LockEvent> visit(LockEvent lockEvent) {
+                        return Optional.of(lockEvent);
+                    }
+
+                    @Override
+                    public Optional<LockEvent> visit(UnlockEvent unlockEvent) {
+                        return Optional.empty();
+                    }
+
+                    @Override
+                    public Optional<LockEvent> visit(LockWatchCreatedEvent lockWatchCreatedEvent) {
+                        return Optional.empty();
+                    }
+                }))
+                .flatMap(Optional::stream)
+                .map(LockEvent::metadata)
+                .collect(Collectors.toList());
+    }
+
+    private List<LockWatchEvent> getAllLockWatchEvents() {
+        ConjureStartTransactionsResponse response =
+                waitForFuture(timeLockService.startTransactionsWithWatches(startTransactionsRequestWithInitialVersion));
+
+        return response.getLockWatchUpdate().accept(new Visitor<>() {
+            @Override
+            public List<LockWatchEvent> visit(Success success) {
+                return success.events();
+            }
+
+            @Override
+            public List<LockWatchEvent> visit(Snapshot snapshot) {
+                return ImmutableList.of();
+            }
+        });
+    }
+
+    private static <T> T waitForFuture(Future<T> future) {
+        Awaitility.await().atMost(Duration.ofMillis(200)).until(future::isDone);
+        try {
+            return future.get();
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    private static LockToken getToken(LockResponseV2 response) {
+        return response.accept(new LockResponseV2.Visitor<Optional<LockToken>>() {
+                    @Override
+                    public Optional<LockToken> visit(Successful successful) {
+                        return Optional.of(successful.getToken());
+                    }
+
+                    @Override
+                    public Optional<LockToken> visit(Unsuccessful failure) {
+                        return Optional.empty();
+                    }
+                })
+                .orElseThrow();
+    }
+
+    private static IdentifiedLockRequest standardRequestWithMetadata(Map<LockDescriptor, ChangeMetadata> metadata) {
+        return IdentifiedLockRequest.of(metadata.keySet(), 1000, "testClient", LockRequestMetadata.of(metadata));
+    }
+}

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimeLockServiceMetadataTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/AsyncTimeLockServiceMetadataTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.timelock.api.ConjureIdentifiedVersion;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
@@ -134,11 +135,7 @@ public class AsyncTimeLockServiceMetadataTest {
         ListenableFuture<ConjureStartTransactionsResponse> responseFuture =
                 timeLockService.startTransactionsWithWatches(startTransactionsRequestWithInitialVersion);
         assertThat(responseFuture).isDone();
-        try {
-            return responseFuture.get().getLockWatchUpdate().accept(LOCK_WATCH_STATE_UPDATE_VISITOR);
-        } catch (Throwable t) {
-            throw new RuntimeException(t);
-        }
+        return AtlasFutures.getUnchecked(responseFuture).getLockWatchUpdate().accept(LOCK_WATCH_STATE_UPDATE_VISITOR);
     }
 
     private static IdentifiedLockRequest standardRequestWithMetadata(Map<LockDescriptor, ChangeMetadata> metadata) {

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
@@ -73,6 +73,7 @@ public class AsyncLockServiceTest {
     @Before
     public void before() {
         when(acquirer.acquireLocks(any(), any(), any())).thenReturn(new AsyncResult<>());
+        when(acquirer.acquireLocks(any(), any(), any(), any())).thenReturn(new AsyncResult<>());
         when(acquirer.waitForLocks(any(), any(), any())).thenReturn(new AsyncResult<>());
         when(locks.getAll(any())).thenReturn(OrderedLocks.fromSingleLock(newLock()));
         when(immutableTimestampTracker.getImmutableTimestamp()).thenReturn(Optional.empty());
@@ -87,7 +88,7 @@ public class AsyncLockServiceTest {
 
         lockService.lock(REQUEST_ID, descriptors, DEADLINE);
 
-        verify(acquirer).acquireLocks(REQUEST_ID, expected, DEADLINE);
+        verify(acquirer).acquireLocks(REQUEST_ID, expected, DEADLINE, Optional.empty());
     }
 
     @Test
@@ -107,7 +108,7 @@ public class AsyncLockServiceTest {
         lockService.lock(REQUEST_ID, descriptors, DEADLINE);
         lockService.lock(REQUEST_ID, descriptors, DEADLINE);
 
-        verify(acquirer, times(1)).acquireLocks(any(), any(), any());
+        verify(acquirer, times(1)).acquireLocks(any(), any(), any(), any());
         verifyNoMoreInteractions(acquirer);
     }
 
@@ -155,7 +156,7 @@ public class AsyncLockServiceTest {
     public void propagatesTimeoutExceptionIfRequestTimesOut() {
         AsyncResult<HeldLocks> timedOutResult = new AsyncResult<>();
         timedOutResult.timeout();
-        when(acquirer.acquireLocks(any(), any(), any())).thenReturn(timedOutResult);
+        when(acquirer.acquireLocks(any(), any(), any(), any())).thenReturn(timedOutResult);
 
         AsyncResult<?> result = lockService.lock(REQUEST_ID, descriptors(LOCK_A), DEADLINE);
 

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/HeldLocksCollectionTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/HeldLocksCollectionTest.java
@@ -32,6 +32,7 @@ import com.palantir.lock.v2.LeadershipId;
 import com.palantir.lock.v2.Lease;
 import com.palantir.lock.v2.LockToken;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -188,7 +189,7 @@ public class HeldLocksCollectionTest {
         AsyncResult<Leased<LockToken>> asyncResult = heldLocksCollection.getExistingOrAcquire(REQUEST_ID, () -> result);
         result.complete(heldLocksForId(REQUEST_ID));
         verify(lockWatcher)
-                .registerLock(ImmutableSet.of(LOCK_DESCRIPTOR), result.get().getToken());
+                .registerLock(ImmutableSet.of(LOCK_DESCRIPTOR), result.get().getToken(), Optional.empty());
 
         Lease lease = asyncResult.get().lease();
 
@@ -206,7 +207,7 @@ public class HeldLocksCollectionTest {
         heldLocksCollection.getExistingOrAcquire(REQUEST_ID, () -> result);
         result.complete(heldLocksForId(REQUEST_ID));
         verify(lockWatcher)
-                .registerLock(ImmutableSet.of(LOCK_DESCRIPTOR), result.get().getToken());
+                .registerLock(ImmutableSet.of(LOCK_DESCRIPTOR), result.get().getToken(), Optional.empty());
 
         heldLocksCollection.unlock(ImmutableSet.of(LockToken.of(REQUEST_ID)));
         verify(lockWatcher).registerUnlock(ImmutableSet.of(LOCK_DESCRIPTOR));


### PR DESCRIPTION
## General
**After this PR**:
If an `IdentifedLockRequest` received by TimeLock has metadata attached to it, TimeLock will pass that metadata all the way down the call stack. If a `LockEvent` is created as a result of that request, the metadata is attached. Along the way, metadata is filtered according to the currently registered lock watches. 

All modified methods retain their original interface.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[LWMeta] Pass optional metadata through TimeLock
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
Using `Optional<LockRequestMetadata>` as the method parameter feels a bit wonky at times. Although I think that it makes sense semantically since we really are just passing it down (with some minor filtering at one step).

The new integration server-side integration tests might partially duplicate existing tests.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No Java API breaks since all existing interface methods are retained as default implementations.

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
We assume that it is correct to filter `LockDescriptor`-attached metadata in the same fashion as `LockDescriptors` according to the currently registered lock watches.
Also, we assume that it is correct (or at least not incorrect) to ignore any metadata if the associated set of lock descriptors is empty after filtering. The existing lock watch semantics dictate that no event should be published in this case.

**What was existing testing like? What have you done to improve it?**:

- I have extended the existing tests for filtering lock descriptors to also verify that the metadata is filtered accordingly.
- I have created a new integration test to verify that the metadata passed to the lock events is indeed identical to the metadata specified on the request, apart from potential filtering.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution

**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Due to the hotness of the path ( I assume) we do not have logs/metrics for the happy path of lock watches. However, we will add metrics to oversee the metadata infrastructure in a future PR.

For now, this PR will have no impact in production anyways, since users cannot send requests with metadata yet.

**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Yes, rollback is sufficient
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Passing the metadata down the stack will pose minimal overhead (one additional pointer as method argument). 
Filtering the lockDescriptor-attached metadata based on watches can be expensive if we have have large amounts of metadata (amounts that drastically exceed the number of lock descriptors).
In a future PR, before users can actually send metadata, we will add restrictions to amount of metadata we can send/receive. Also, we will ensure that metadata is only constrained to lock descriptors that are present in the parent object.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
If we move to a different mechanism for lock descriptor filtering  due to performance reasons (not calling `rangeSet.contains`), we have to think about how we handle metadata as well.

## Development Process
**Where should we start reviewing?**:
`AsyncTimeLockServiceImpl`

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
