### PR TITLE
[LWMeta] Add Conjure metadata types and conversion methods

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/util/IndexEncodingUtils.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/IndexEncodingUtils.java
@@ -17,7 +17,6 @@
 package com.palantir.util;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.palantir.logsafe.Preconditions;
@@ -115,8 +114,7 @@ public final class IndexEncodingUtils {
         return keyToValue;
     }
 
-    @VisibleForTesting
-    static <K extends DeterministicHashable> KeyListChecksum computeChecksum(
+    public static <K extends DeterministicHashable> KeyListChecksum computeChecksum(
             ChecksumType checksumType, List<K> keyList) {
         switch (checksumType) {
             case CRC32_OF_DETERMINISTIC_HASHCODE: {

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     testImplementation 'com.palantir.common:streams'
     testImplementation 'io.dropwizard.metrics:metrics-core'
     testImplementation 'org.slf4j:slf4j-api'
+    testImplementation project(':atlasdb-api')
     testImplementation project(':lock-api-objects')
     testImplementation project(':lock-conjure-api:lock-conjure-api-objects')
     testImplementation project(':timelock-api:timelock-api-objects')

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation 'com.google.guava:guava'
     testImplementation 'com.palantir.common:streams'
+    testImplementation 'com.palantir.safe-logging:preconditions-assertj'
     testImplementation 'io.dropwizard.metrics:metrics-core'
     testImplementation 'org.slf4j:slf4j-api'
     testImplementation project(':atlasdb-api')

--- a/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
@@ -62,7 +62,7 @@ public final class ConjureLockRequestMetadataUtils {
     public static LockRequestMetadata fromConjureIndexEncoded(
             List<LockDescriptor> keyList, ConjureLockRequestMetadata conjureMetadata) {
         ChangeMetadataFromConjureVisitor fromConjureVisitor = new ChangeMetadataFromConjureVisitor();
-        ChecksumType checksumType = ChecksumType.valueOf(conjureMetadata.getChecksumType());
+        ChecksumType checksumType = ChecksumType.valueOf(conjureMetadata.getChecksumTypeId());
         KeyListChecksum checksum = KeyListChecksum.of(
                 checksumType, conjureMetadata.getChecksumValue().asNewByteArray());
         IndexEncodingResult<LockDescriptor, ConjureChangeMetadata> encoded =

--- a/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
@@ -80,7 +80,6 @@ public final class ConjureLockRequestMetadataUtils {
         Map<LockDescriptor, Optional<ChangeMetadata>> optChangeMetadata = IndexEncodingUtils.decode(
                 encoded,
                 conjureChangeMetadata -> conjureChangeMetadata.accept(ChangeMetadataFromConjureVisitor.INSTANCE));
-        // visitUnknown() will return an empty optional
         Map<LockDescriptor, ChangeMetadata> changeMetadata = KeyedStream.ofEntries(
                         optChangeMetadata.entrySet().stream())
                 .flatMap(Optional::stream)

--- a/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
@@ -1,0 +1,132 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.watch;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.atlasdb.timelock.api.ConjureChangeMetadata;
+import com.palantir.atlasdb.timelock.api.ConjureCreatedChangeMetadata;
+import com.palantir.atlasdb.timelock.api.ConjureDeletedChangeMetadata;
+import com.palantir.atlasdb.timelock.api.ConjureLockRequestMetadata;
+import com.palantir.atlasdb.timelock.api.ConjureUnchangedChangeMetadata;
+import com.palantir.atlasdb.timelock.api.ConjureUpdatedChangeMetadata;
+import com.palantir.conjure.java.lib.Bytes;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.watch.ChangeMetadata.Created;
+import com.palantir.lock.watch.ChangeMetadata.Deleted;
+import com.palantir.lock.watch.ChangeMetadata.Unchanged;
+import com.palantir.lock.watch.ChangeMetadata.Updated;
+import com.palantir.util.IndexEncodingUtils;
+import com.palantir.util.IndexEncodingUtils.ChecksumType;
+import com.palantir.util.IndexEncodingUtils.IndexEncodingResult;
+import com.palantir.util.IndexEncodingUtils.KeyListChecksum;
+import com.palantir.util.Pair;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class ConjureLockRequestMetadataUtils {
+    private ConjureLockRequestMetadataUtils() {}
+
+    @VisibleForTesting
+    static final ChecksumType DEFAULT_CHECKSUM_TYPE = ChecksumType.CRC32_OF_DETERMINISTIC_HASHCODE;
+
+    public static Pair<List<LockDescriptor>, ConjureLockRequestMetadata> toConjureIndexEncoded(
+            Set<LockDescriptor> lockDescriptors, LockRequestMetadata metadata) {
+        ChangeMetadataToConjureVisitor toConjureVisitor = new ChangeMetadataToConjureVisitor();
+        IndexEncodingResult<LockDescriptor, ConjureChangeMetadata> encoded = IndexEncodingUtils.encode(
+                lockDescriptors,
+                metadata.lockDescriptorToChangeMetadata(),
+                changeMetadata -> changeMetadata.accept(toConjureVisitor),
+                DEFAULT_CHECKSUM_TYPE);
+        KeyListChecksum checksum = encoded.keyListChecksum();
+        ConjureLockRequestMetadata conjureLockRequestMetadata = ConjureLockRequestMetadata.of(
+                encoded.indexToValue(), checksum.type().getId(), Bytes.from(checksum.value()));
+        return Pair.create(encoded.keyList(), conjureLockRequestMetadata);
+    }
+
+    public static LockRequestMetadata fromConjureIndexEncoded(
+            List<LockDescriptor> keyList, ConjureLockRequestMetadata conjureMetadata) {
+        ChangeMetadataFromConjureVisitor fromConjureVisitor = new ChangeMetadataFromConjureVisitor();
+        ChecksumType checksumType = ChecksumType.valueOf(conjureMetadata.getChecksumType());
+        KeyListChecksum checksum = KeyListChecksum.of(
+                checksumType, conjureMetadata.getChecksumValue().asNewByteArray());
+        IndexEncodingResult<LockDescriptor, ConjureChangeMetadata> encoded =
+                IndexEncodingResult.of(keyList, conjureMetadata.getIndexToChangeMetadata(), checksum);
+        Map<LockDescriptor, ChangeMetadata> changeMetadata = IndexEncodingUtils.decode(
+                encoded, conjureChangeMetadata -> conjureChangeMetadata.accept(fromConjureVisitor));
+        // visitUnknown() will return null
+        changeMetadata.values().removeIf(Objects::isNull);
+        return LockRequestMetadata.of(changeMetadata);
+    }
+
+    private static final class ChangeMetadataToConjureVisitor implements ChangeMetadata.Visitor<ConjureChangeMetadata> {
+
+        @Override
+        public ConjureChangeMetadata visit(Unchanged unchanged) {
+            return ConjureChangeMetadata.unchanged(ConjureUnchangedChangeMetadata.of());
+        }
+
+        @Override
+        public ConjureChangeMetadata visit(Updated updated) {
+            return ConjureChangeMetadata.updated(
+                    ConjureUpdatedChangeMetadata.of(Bytes.from(updated.oldValue()), Bytes.from(updated.newValue())));
+        }
+
+        @Override
+        public ConjureChangeMetadata visit(Deleted deleted) {
+            return ConjureChangeMetadata.deleted(ConjureDeletedChangeMetadata.of(Bytes.from(deleted.oldValue())));
+        }
+
+        @Override
+        public ConjureChangeMetadata visit(Created created) {
+            return ConjureChangeMetadata.created(ConjureCreatedChangeMetadata.of(Bytes.from(created.newValue())));
+        }
+    }
+
+    private static final class ChangeMetadataFromConjureVisitor
+            implements ConjureChangeMetadata.Visitor<ChangeMetadata> {
+
+        @Override
+        public ChangeMetadata visitUnchanged(ConjureUnchangedChangeMetadata unchanged) {
+            return ChangeMetadata.unchanged();
+        }
+
+        @Override
+        public ChangeMetadata visitUpdated(ConjureUpdatedChangeMetadata updated) {
+            return ChangeMetadata.updated(
+                    updated.getOldValue().asNewByteArray(),
+                    updated.getNewValue().asNewByteArray());
+        }
+
+        @Override
+        public ChangeMetadata visitDeleted(ConjureDeletedChangeMetadata deleted) {
+            return ChangeMetadata.deleted(deleted.getOldValue().asNewByteArray());
+        }
+
+        @Override
+        public ChangeMetadata visitCreated(ConjureCreatedChangeMetadata created) {
+            return ChangeMetadata.created(created.getNewValue().asNewByteArray());
+        }
+
+        @Override
+        public ChangeMetadata visitUnknown(String unknownType) {
+            // caller should handle this case
+            return null;
+        }
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
@@ -64,13 +64,13 @@ public final class ConjureLockRequestMetadataUtils {
                 .build();
         return ImmutableConjureMetadataConversionResult.builder()
                 .lockList(encoded.keyList())
-                .conjureLockRequestMetadata(conjureLockRequestMetadata)
+                .conjureMetadata(conjureLockRequestMetadata)
                 .build();
     }
 
     public static LockRequestMetadata fromConjureIndexEncoded(ConjureMetadataConversionResult conversionResult) {
         List<LockDescriptor> keyList = conversionResult.lockList();
-        ConjureLockRequestMetadata conjureMetadata = conversionResult.conjureLockRequestMetadata();
+        ConjureLockRequestMetadata conjureMetadata = conversionResult.conjureMetadata();
         ChecksumType checksumType = ChecksumType.valueOf(conjureMetadata.getChecksumTypeId());
         KeyListChecksum checksum = KeyListChecksum.of(
                 checksumType, conjureMetadata.getChecksumValue().asNewByteArray());
@@ -92,7 +92,7 @@ public final class ConjureLockRequestMetadataUtils {
     public interface ConjureMetadataConversionResult {
         List<LockDescriptor> lockList();
 
-        ConjureLockRequestMetadata conjureLockRequestMetadata();
+        ConjureLockRequestMetadata conjureMetadata();
 
         static ImmutableConjureMetadataConversionResult.Builder builder() {
             return ImmutableConjureMetadataConversionResult.builder();

--- a/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
@@ -54,8 +54,11 @@ public final class ConjureLockRequestMetadataUtils {
                 changeMetadata -> changeMetadata.accept(toConjureVisitor),
                 DEFAULT_CHECKSUM_TYPE);
         KeyListChecksum checksum = encoded.keyListChecksum();
-        ConjureLockRequestMetadata conjureLockRequestMetadata = ConjureLockRequestMetadata.of(
-                encoded.indexToValue(), checksum.type().getId(), Bytes.from(checksum.value()));
+        ConjureLockRequestMetadata conjureLockRequestMetadata = ConjureLockRequestMetadata.builder()
+                .indexToChangeMetadata(encoded.indexToValue())
+                .checksumTypeId(checksum.type().getId())
+                .checksumValue(Bytes.from(checksum.value()))
+                .build();
         return Pair.create(encoded.keyList(), conjureLockRequestMetadata);
     }
 
@@ -66,7 +69,11 @@ public final class ConjureLockRequestMetadataUtils {
         KeyListChecksum checksum = KeyListChecksum.of(
                 checksumType, conjureMetadata.getChecksumValue().asNewByteArray());
         IndexEncodingResult<LockDescriptor, ConjureChangeMetadata> encoded =
-                IndexEncodingResult.of(keyList, conjureMetadata.getIndexToChangeMetadata(), checksum);
+                IndexEncodingResult.<LockDescriptor, ConjureChangeMetadata>builder()
+                        .keyList(keyList)
+                        .indexToValue(conjureMetadata.getIndexToChangeMetadata())
+                        .keyListChecksum(checksum)
+                        .build();
         Map<LockDescriptor, ChangeMetadata> changeMetadata = IndexEncodingUtils.decode(
                 encoded, conjureChangeMetadata -> conjureChangeMetadata.accept(fromConjureVisitor));
         // visitUnknown() will return null

--- a/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
@@ -31,7 +31,10 @@ import com.palantir.lock.watch.ChangeMetadata.Created;
 import com.palantir.lock.watch.ChangeMetadata.Deleted;
 import com.palantir.lock.watch.ChangeMetadata.Unchanged;
 import com.palantir.lock.watch.ChangeMetadata.Updated;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.Unsafe;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.util.IndexEncodingUtils;
 import com.palantir.util.IndexEncodingUtils.ChecksumType;
 import com.palantir.util.IndexEncodingUtils.IndexEncodingResult;
@@ -47,6 +50,8 @@ public final class ConjureLockRequestMetadataUtils {
 
     @VisibleForTesting
     static final ChecksumType DEFAULT_CHECKSUM_TYPE = ChecksumType.CRC32_OF_DETERMINISTIC_HASHCODE;
+
+    private static final SafeLogger log = SafeLoggerFactory.get(ConjureLockRequestMetadataUtils.class);
 
     public static ConjureMetadataConversionResult toConjureIndexEncoded(
             Set<LockDescriptor> lockDescriptors, LockRequestMetadata metadata) {
@@ -161,6 +166,7 @@ public final class ConjureLockRequestMetadataUtils {
 
         @Override
         public Optional<ChangeMetadata> visitUnknown(String unknownType) {
+            log.trace("Unknown ConjureChangeMetadata type", SafeArg.of("unknownType", unknownType));
             return Optional.empty();
         }
     }

--- a/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtils.java
@@ -166,7 +166,10 @@ public final class ConjureLockRequestMetadataUtils {
 
         @Override
         public Optional<ChangeMetadata> visitUnknown(String unknownType) {
-            log.trace("Unknown ConjureChangeMetadata type", SafeArg.of("unknownType", unknownType));
+            log.trace(
+                    "Encountered an unknown ConjureChangeMetadata type. This is likely a new type that was added in a"
+                            + " future version. This ChangeMetadata will be discarded",
+                    SafeArg.of("unknownType", unknownType));
             return Optional.empty();
         }
     }

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runners.Parameterized.Parameters;
 
 public class ConjureLockRequestMetadataUtilsTest {
     private static final LockDescriptor LOCK_1 = StringLockDescriptor.of("lock1");
@@ -106,6 +107,7 @@ public class ConjureLockRequestMetadataUtilsTest {
         assertThat(ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(conjureMetadataConversionResult))
                 .isEqualTo(LOCK_REQUEST_METADATA);
     }
+
 
     @Test
     public void convertingToAndFromConjureIsIdentityForRandomData() {

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -63,7 +63,7 @@ public class ConjureLockRequestMetadataUtilsTest {
             ChangeMetadata.created(BYTES_CREATED));
     // Although this is quite verbose, we explicitly want to test all possible types of change metadata and ensure
     // that we do the conversion right for each of them.
-    private static final Map<LockDescriptor, ChangeMetadata> LOCKS_WITH_METADATA = ImmutableMap.of(
+    private static final LockRequestMetadata LOCK_REQUEST_METADATA = LockRequestMetadata.of(ImmutableMap.of(
             LOCK_1,
             CHANGE_METADATA_LIST.get(0),
             LOCK_2,
@@ -71,8 +71,7 @@ public class ConjureLockRequestMetadataUtilsTest {
             LOCK_3,
             CHANGE_METADATA_LIST.get(2),
             LOCK_4,
-            CHANGE_METADATA_LIST.get(3));
-    private static final LockRequestMetadata LOCK_REQUEST_METADATA = LockRequestMetadata.of(LOCKS_WITH_METADATA);
+            CHANGE_METADATA_LIST.get(3)));
     private static final Map<Integer, ConjureChangeMetadata> CONJURE_LOCKS_WITH_METADATA = ImmutableMap.of(
             0,
             ConjureChangeMetadata.unchanged(ConjureUnchangedChangeMetadata.of()),

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -16,11 +16,13 @@
 
 package com.palantir.lock.watch;
 
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.timelock.api.ConjureChangeMetadata;
 import com.palantir.atlasdb.timelock.api.ConjureCreatedChangeMetadata;
@@ -37,7 +39,9 @@ import com.palantir.lock.watch.ConjureLockRequestMetadataUtils.ConjureMetadataCo
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.util.IndexEncodingUtils;
 import com.palantir.util.IndexEncodingUtils.KeyListChecksum;
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -53,34 +57,43 @@ public class ConjureLockRequestMetadataUtilsTest {
     private static final LockDescriptor LOCK_2 = StringLockDescriptor.of("lock2");
     private static final LockDescriptor LOCK_3 = StringLockDescriptor.of("lock3");
     private static final LockDescriptor LOCK_4 = StringLockDescriptor.of("lock4");
+    private static final byte[] BYTES_OLD = PtBytes.toBytes("old");
+    private static final byte[] BYTES_NEW = PtBytes.toBytes("new");
+    private static final byte[] BYTES_DELETED = PtBytes.toBytes("deleted");
+    private static final byte[] BYTES_CREATED = PtBytes.toBytes("created");
     private static final List<LockDescriptor> LOCK_LIST = ImmutableList.of(LOCK_1, LOCK_2, LOCK_3, LOCK_4);
-    // LinkedHashSet remembers insertion order, which is important for the tests below.
-    private static final Set<LockDescriptor> LOCK_SET = new LinkedHashSet<>(LOCK_LIST);
+    private static final List<ChangeMetadata> CHANGE_METADATA_LIST = ImmutableList.of(
+            ChangeMetadata.unchanged(),
+            ChangeMetadata.updated(BYTES_OLD, BYTES_NEW),
+            ChangeMetadata.deleted(BYTES_DELETED),
+            ChangeMetadata.created(BYTES_CREATED));
     // Although this is quite verbose, we explicitly want to test all possible types of change metadata and ensure
     // that we do the conversion right for each of them.
     private static final Map<LockDescriptor, ChangeMetadata> LOCKS_WITH_METADATA = ImmutableMap.of(
             LOCK_1,
-            ChangeMetadata.unchanged(),
+            CHANGE_METADATA_LIST.get(0),
             LOCK_2,
-            ChangeMetadata.updated(PtBytes.toBytes("old"), PtBytes.toBytes("new")),
+            CHANGE_METADATA_LIST.get(1),
             LOCK_3,
-            ChangeMetadata.deleted(PtBytes.toBytes("deleted")),
+            CHANGE_METADATA_LIST.get(2),
             LOCK_4,
-            ChangeMetadata.created(PtBytes.toBytes("created")));
+            CHANGE_METADATA_LIST.get(3));
     private static final LockRequestMetadata LOCK_REQUEST_METADATA = LockRequestMetadata.of(LOCKS_WITH_METADATA);
     private static final Map<Integer, ConjureChangeMetadata> CONJURE_LOCKS_WITH_METADATA = ImmutableMap.of(
             0,
             ConjureChangeMetadata.unchanged(ConjureUnchangedChangeMetadata.of()),
             1,
-            ConjureChangeMetadata.updated(ConjureUpdatedChangeMetadata.of(
-                    Bytes.from(PtBytes.toBytes("old")), Bytes.from(PtBytes.toBytes("new")))),
+            ConjureChangeMetadata.updated(
+                    ConjureUpdatedChangeMetadata.of(Bytes.from(BYTES_OLD), Bytes.from(BYTES_NEW))),
             2,
-            ConjureChangeMetadata.deleted(ConjureDeletedChangeMetadata.of(Bytes.from(PtBytes.toBytes("deleted")))),
+            ConjureChangeMetadata.deleted(ConjureDeletedChangeMetadata.of(Bytes.from(BYTES_DELETED))),
             3,
-            ConjureChangeMetadata.created(ConjureCreatedChangeMetadata.of(Bytes.from(PtBytes.toBytes("created")))));
-    private static final Random RAND = new Random();
+            ConjureChangeMetadata.created(ConjureCreatedChangeMetadata.of(Bytes.from(BYTES_CREATED))));
+    private static final Random RANDOM = new Random();
     private static ConjureMetadataConversionResult conjureMetadataConversionResult;
 
+    // This is a good candidate for a static construction method, but we would rather avoid testing internals of
+    // IndexEncodingUtils (checksum computation) within the tests for Conjure conversion.
     @BeforeClass
     public static void setup() {
         KeyListChecksum checksum =
@@ -98,7 +111,9 @@ public class ConjureLockRequestMetadataUtilsTest {
 
     @Test
     public void convertsToConjureCorrectly() {
-        assertThat(ConjureLockRequestMetadataUtils.toConjureIndexEncoded(LOCK_SET, LOCK_REQUEST_METADATA))
+        // ImmutableSet remembers insertion order, which is critical here
+        assertThat(ConjureLockRequestMetadataUtils.toConjureIndexEncoded(
+                        ImmutableSet.copyOf(LOCK_LIST), LOCK_REQUEST_METADATA))
                 .isEqualTo(conjureMetadataConversionResult);
     }
 
@@ -115,12 +130,7 @@ public class ConjureLockRequestMetadataUtilsTest {
                 .map(StringLockDescriptor::of)
                 .limit(1000)
                 .collect(Collectors.toSet());
-        Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata = KeyedStream.of(lockDescriptors.stream())
-                .filter(_unused -> RAND.nextBoolean())
-                .map(_unused -> createRandomChangeMetadata())
-                .collectToMap();
-        LockRequestMetadata metadata = LockRequestMetadata.of(lockDescriptorToChangeMetadata);
-
+        LockRequestMetadata metadata = createRandomLockRequestMetadataFor(lockDescriptors);
         assertThat(ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(
                         ConjureLockRequestMetadataUtils.toConjureIndexEncoded(lockDescriptors, metadata)))
                 .isEqualTo(metadata);
@@ -131,25 +141,28 @@ public class ConjureLockRequestMetadataUtilsTest {
         ConjureMetadataConversionResult conversionResult = ImmutableConjureMetadataConversionResult.copyOf(
                         conjureMetadataConversionResult)
                 .withLockList(LOCK_2, LOCK_1, LOCK_3, LOCK_4);
-        assertThatThrownBy(() -> ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(conversionResult))
+        assertThatLoggableExceptionThrownBy(
+                        () -> ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(conversionResult))
                 .isInstanceOf(SafeIllegalArgumentException.class)
                 .hasMessageStartingWith("Key list integrity check failed");
     }
 
-    private static ChangeMetadata createRandomChangeMetadata() {
-        switch (RAND.nextInt(4)) {
-            case 0:
-                return ChangeMetadata.unchanged();
-            case 1:
-                return ChangeMetadata.updated(
-                        PtBytes.toBytes(UUID.randomUUID().toString()),
-                        PtBytes.toBytes(UUID.randomUUID().toString()));
-            case 2:
-                return ChangeMetadata.created(PtBytes.toBytes(UUID.randomUUID().toString()));
-            case 3:
-                return ChangeMetadata.deleted(PtBytes.toBytes(UUID.randomUUID().toString()));
-            default:
-                throw new IllegalStateException();
-        }
+    @Test
+    public void handlesEmptyMetadata() {
+        assertThat(ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(
+                        ConjureLockRequestMetadataUtils.toConjureIndexEncoded(
+                                ImmutableSet.of(), LockRequestMetadata.of(ImmutableMap.of()))))
+                .isEqualTo(LockRequestMetadata.of(ImmutableMap.of()));
+    }
+
+    private static LockRequestMetadata createRandomLockRequestMetadataFor(Set<LockDescriptor> lockDescriptors) {
+        List<ChangeMetadata> shuffled = new ArrayList<>(CHANGE_METADATA_LIST);
+        Collections.shuffle(shuffled, RANDOM);
+        Iterator<ChangeMetadata> iterator = Iterables.cycle(shuffled).iterator();
+        Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata = KeyedStream.of(lockDescriptors.stream())
+                .filter(_unused -> RANDOM.nextBoolean())
+                .map(_unused -> iterator.next())
+                .collectToMap();
+        return LockRequestMetadata.of(lockDescriptorToChangeMetadata);
     }
 }

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -56,22 +56,17 @@ public class ConjureLockRequestMetadataUtilsTest {
     private static final byte[] BYTES_DELETED = PtBytes.toBytes("deleted");
     private static final byte[] BYTES_CREATED = PtBytes.toBytes("created");
     private static final List<LockDescriptor> LOCK_LIST = ImmutableList.of(LOCK_1, LOCK_2, LOCK_3, LOCK_4);
-    private static final List<ChangeMetadata> CHANGE_METADATA_LIST = ImmutableList.of(
-            ChangeMetadata.unchanged(),
-            ChangeMetadata.updated(BYTES_OLD, BYTES_NEW),
-            ChangeMetadata.deleted(BYTES_DELETED),
-            ChangeMetadata.created(BYTES_CREATED));
     // Although this is quite verbose, we explicitly want to test all possible types of change metadata and ensure
     // that we do the conversion right for each of them.
     private static final LockRequestMetadata LOCK_REQUEST_METADATA = LockRequestMetadata.of(ImmutableMap.of(
             LOCK_1,
-            CHANGE_METADATA_LIST.get(0),
+            ChangeMetadata.unchanged(),
             LOCK_2,
-            CHANGE_METADATA_LIST.get(1),
+            ChangeMetadata.updated(BYTES_OLD, BYTES_NEW),
             LOCK_3,
-            CHANGE_METADATA_LIST.get(2),
+            ChangeMetadata.deleted(BYTES_DELETED),
             LOCK_4,
-            CHANGE_METADATA_LIST.get(3)));
+            ChangeMetadata.created(BYTES_CREATED)));
     private static final Map<Integer, ConjureChangeMetadata> CONJURE_LOCKS_WITH_METADATA = ImmutableMap.of(
             0,
             ConjureChangeMetadata.unchanged(ConjureUnchangedChangeMetadata.of()),
@@ -124,10 +119,11 @@ public class ConjureLockRequestMetadataUtilsTest {
                 .collect(Collectors.toList());
         // Unique metadata on some locks, but not all
         Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata = ImmutableMap.of(
-                lockDescriptors.get(0), ChangeMetadata.created(PtBytes.toBytes(0)),
-                lockDescriptors.get(4), ChangeMetadata.created(PtBytes.toBytes(4)),
-                lockDescriptors.get(9), ChangeMetadata.created(PtBytes.toBytes(9)),
-                lockDescriptors.get(5), ChangeMetadata.created(PtBytes.toBytes(5)));
+                lockDescriptors.get(0), ChangeMetadata.created(BYTES_CREATED),
+                lockDescriptors.get(4), ChangeMetadata.deleted(BYTES_DELETED),
+                lockDescriptors.get(9), ChangeMetadata.unchanged(),
+                lockDescriptors.get(5), ChangeMetadata.updated(BYTES_OLD, BYTES_NEW),
+                lockDescriptors.get(7), ChangeMetadata.unchanged());
         LockRequestMetadata metadata = LockRequestMetadata.of(lockDescriptorToChangeMetadata);
 
         assertThat(ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.timelock.api.ConjureChangeMetadata;
 import com.palantir.atlasdb.timelock.api.ConjureCreatedChangeMetadata;
@@ -33,6 +32,7 @@ import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.util.IndexEncodingUtils;
 import com.palantir.util.IndexEncodingUtils.KeyListChecksum;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,8 +44,10 @@ public class ConjureLockRequestMetadataUtilsTest {
     private static final LockDescriptor LOCK_2 = StringLockDescriptor.of("lock2");
     private static final LockDescriptor LOCK_3 = StringLockDescriptor.of("lock3");
     private static final LockDescriptor LOCK_4 = StringLockDescriptor.of("lock4");
-    private static final Set<LockDescriptor> LOCK_SET = ImmutableSet.of(LOCK_1, LOCK_2, LOCK_3, LOCK_4);
+
     private static final List<LockDescriptor> LOCK_LIST = ImmutableList.of(LOCK_1, LOCK_2, LOCK_3, LOCK_4);
+    // LinkedHashSet remembers insertion order, which is important for the tests below.
+    private static final Set<LockDescriptor> LOCK_SET = new LinkedHashSet<>(LOCK_LIST);
 
     // Although this is quite verbose, we explicitly want to test all possible types of change metadata and ensure
     // that we do the conversion right for each of them.

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -52,11 +52,9 @@ public class ConjureLockRequestMetadataUtilsTest {
     private static final LockDescriptor LOCK_2 = StringLockDescriptor.of("lock2");
     private static final LockDescriptor LOCK_3 = StringLockDescriptor.of("lock3");
     private static final LockDescriptor LOCK_4 = StringLockDescriptor.of("lock4");
-
     private static final List<LockDescriptor> LOCK_LIST = ImmutableList.of(LOCK_1, LOCK_2, LOCK_3, LOCK_4);
     // LinkedHashSet remembers insertion order, which is important for the tests below.
     private static final Set<LockDescriptor> LOCK_SET = new LinkedHashSet<>(LOCK_LIST);
-
     // Although this is quite verbose, we explicitly want to test all possible types of change metadata and ensure
     // that we do the conversion right for each of them.
     private static final Map<LockDescriptor, ChangeMetadata> LOCKS_WITH_METADATA = ImmutableMap.of(
@@ -69,7 +67,6 @@ public class ConjureLockRequestMetadataUtilsTest {
             LOCK_4,
             ChangeMetadata.created(PtBytes.toBytes("created")));
     private static final LockRequestMetadata LOCK_REQUEST_METADATA = LockRequestMetadata.of(LOCKS_WITH_METADATA);
-
     private static final Map<Integer, ConjureChangeMetadata> CONJURE_LOCKS_WITH_METADATA = ImmutableMap.of(
             0,
             ConjureChangeMetadata.unchanged(ConjureUnchangedChangeMetadata.of()),
@@ -111,14 +108,14 @@ public class ConjureLockRequestMetadataUtilsTest {
     }
 
     @Test
-    public void convertingToAndFromConjureIsIdentity() {
+    public void convertingToAndFromConjureIsIdentityForRandomData() {
         Set<LockDescriptor> lockDescriptors = Stream.generate(UUID::randomUUID)
                 .map(UUID::toString)
                 .map(StringLockDescriptor::of)
                 .limit(1000)
                 .collect(Collectors.toSet());
         Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata = KeyedStream.of(lockDescriptors.stream())
-                .filter(lockDescriptor -> RAND.nextBoolean())
+                .filter(_unused -> RAND.nextBoolean())
                 .map(_unused -> createRandomChangeMetadata())
                 .collectToMap();
         LockRequestMetadata metadata = LockRequestMetadata.of(lockDescriptorToChangeMetadata);

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -142,7 +142,7 @@ public class ConjureLockRequestMetadataUtilsTest {
         LockRequestMetadata metadata = LockRequestMetadata.of(lockDescriptorToChangeMetadata);
 
         assertThat(ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(
-                ConjureLockRequestMetadataUtils.toConjureIndexEncoded(lockDescriptors, metadata)))
+                        ConjureLockRequestMetadataUtils.toConjureIndexEncoded(lockDescriptors, metadata)))
                 .as("Converting to Conjure and back yields the original data. Random seed: " + randSeed)
                 .isEqualTo(metadata);
     }
@@ -155,7 +155,7 @@ public class ConjureLockRequestMetadataUtilsTest {
                         conjureMetadataConversionResult)
                 .withLockList(modifiedLockList);
         assertThatLoggableExceptionThrownBy(
-                () -> ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(conversionResult))
+                        () -> ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(conversionResult))
                 .isInstanceOf(SafeIllegalArgumentException.class)
                 .hasMessageStartingWith("Key list integrity check failed");
     }
@@ -163,8 +163,8 @@ public class ConjureLockRequestMetadataUtilsTest {
     @Test
     public void handlesEmptyData() {
         assertThat(ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(
-                ConjureLockRequestMetadataUtils.toConjureIndexEncoded(
-                        ImmutableSet.of(), LockRequestMetadata.of(ImmutableMap.of()))))
+                        ConjureLockRequestMetadataUtils.toConjureIndexEncoded(
+                                ImmutableSet.of(), LockRequestMetadata.of(ImmutableMap.of()))))
                 .isEqualTo(LockRequestMetadata.of(ImmutableMap.of()));
     }
 }

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -78,8 +78,11 @@ public class ConjureLockRequestMetadataUtilsTest {
     public static void setup() {
         KeyListChecksum checksum =
                 IndexEncodingUtils.computeChecksum(ConjureLockRequestMetadataUtils.DEFAULT_CHECKSUM_TYPE, LOCK_LIST);
-        conjureLockRequestMetadata = ConjureLockRequestMetadata.of(
-                CONJURE_LOCKS_WITH_METADATA, checksum.type().getId(), Bytes.from(checksum.value()));
+        conjureLockRequestMetadata = ConjureLockRequestMetadata.builder()
+                .indexToChangeMetadata(CONJURE_LOCKS_WITH_METADATA)
+                .checksumTypeId(checksum.type().getId())
+                .checksumValue(Bytes.from(checksum.value()))
+                .build();
     }
 
     @Test

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -25,6 +25,7 @@ import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.timelock.api.ConjureChangeMetadata;
 import com.palantir.atlasdb.timelock.api.ConjureCreatedChangeMetadata;
 import com.palantir.atlasdb.timelock.api.ConjureDeletedChangeMetadata;
+import com.palantir.atlasdb.timelock.api.ConjureLockDescriptorListChecksum;
 import com.palantir.atlasdb.timelock.api.ConjureLockRequestMetadata;
 import com.palantir.atlasdb.timelock.api.ConjureUnchangedChangeMetadata;
 import com.palantir.atlasdb.timelock.api.ConjureUpdatedChangeMetadata;
@@ -46,7 +47,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runners.Parameterized.Parameters;
 
 public class ConjureLockRequestMetadataUtilsTest {
     private static final LockDescriptor LOCK_1 = StringLockDescriptor.of("lock1");
@@ -87,8 +87,8 @@ public class ConjureLockRequestMetadataUtilsTest {
                 IndexEncodingUtils.computeChecksum(ConjureLockRequestMetadataUtils.DEFAULT_CHECKSUM_TYPE, LOCK_LIST);
         ConjureLockRequestMetadata conjureMetadata = ConjureLockRequestMetadata.builder()
                 .indexToChangeMetadata(CONJURE_LOCKS_WITH_METADATA)
-                .checksumTypeId(checksum.type().getId())
-                .checksumValue(Bytes.from(checksum.value()))
+                .lockListChecksum(
+                        ConjureLockDescriptorListChecksum.of(checksum.type().getId(), Bytes.from(checksum.value())))
                 .build();
         conjureMetadataConversionResult = ConjureMetadataConversionResult.builder()
                 .lockList(LOCK_LIST)
@@ -107,7 +107,6 @@ public class ConjureLockRequestMetadataUtilsTest {
         assertThat(ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(conjureMetadataConversionResult))
                 .isEqualTo(LOCK_REQUEST_METADATA);
     }
-
 
     @Test
     public void convertingToAndFromConjureIsIdentityForRandomData() {

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -17,6 +17,7 @@
 package com.palantir.lock.watch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -31,6 +32,7 @@ import com.palantir.common.streams.KeyedStream;
 import com.palantir.conjure.java.lib.Bytes;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.StringLockDescriptor;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.util.IndexEncodingUtils;
 import com.palantir.util.IndexEncodingUtils.KeyListChecksum;
 import com.palantir.util.Pair;
@@ -123,6 +125,15 @@ public class ConjureLockRequestMetadataUtilsTest {
                 lockListAndMetadata.lhSide, lockListAndMetadata.rhSide);
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void changedLockOrderIsDetected() {
+        assertThatThrownBy(() -> ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(
+                        // Lock 1 and 2 are swapped
+                        ImmutableList.of(LOCK_2, LOCK_1, LOCK_3, LOCK_4), conjureLockRequestMetadata))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessageStartingWith("Key list integrity check failed");
     }
 
     private static ChangeMetadata createRandomChangeMetadata() {

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -94,7 +94,7 @@ public class ConjureLockRequestMetadataUtilsTest {
                 .build();
         conjureMetadataConversionResult = ConjureMetadataConversionResult.builder()
                 .lockList(LOCK_LIST)
-                .conjureLockRequestMetadata(conjureMetadata)
+                .conjureMetadata(conjureMetadata)
                 .build();
     }
 

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.watch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.timelock.api.ConjureChangeMetadata;
+import com.palantir.atlasdb.timelock.api.ConjureCreatedChangeMetadata;
+import com.palantir.atlasdb.timelock.api.ConjureDeletedChangeMetadata;
+import com.palantir.atlasdb.timelock.api.ConjureLockRequestMetadata;
+import com.palantir.atlasdb.timelock.api.ConjureUnchangedChangeMetadata;
+import com.palantir.atlasdb.timelock.api.ConjureUpdatedChangeMetadata;
+import com.palantir.conjure.java.lib.Bytes;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.StringLockDescriptor;
+import com.palantir.util.IndexEncodingUtils;
+import com.palantir.util.IndexEncodingUtils.KeyListChecksum;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ConjureLockRequestMetadataUtilsTest {
+    private static final LockDescriptor LOCK_1 = StringLockDescriptor.of("lock1");
+    private static final LockDescriptor LOCK_2 = StringLockDescriptor.of("lock2");
+    private static final LockDescriptor LOCK_3 = StringLockDescriptor.of("lock3");
+    private static final LockDescriptor LOCK_4 = StringLockDescriptor.of("lock4");
+    private static final Set<LockDescriptor> LOCK_SET = ImmutableSet.of(LOCK_1, LOCK_2, LOCK_3, LOCK_4);
+    private static final List<LockDescriptor> LOCK_LIST = ImmutableList.of(LOCK_1, LOCK_2, LOCK_3, LOCK_4);
+
+    // Although this is quite verbose, we explicitly want to test all possible types of change metadata and ensure
+    // that we do the conversion right for each of them.
+    private static final Map<LockDescriptor, ChangeMetadata> LOCKS_WITH_METADATA = ImmutableMap.of(
+            LOCK_1,
+            ChangeMetadata.unchanged(),
+            LOCK_2,
+            ChangeMetadata.updated(PtBytes.toBytes("old"), PtBytes.toBytes("new")),
+            LOCK_3,
+            ChangeMetadata.deleted(PtBytes.toBytes("deleted")),
+            LOCK_4,
+            ChangeMetadata.created(PtBytes.toBytes("created")));
+    private static final LockRequestMetadata LOCK_REQUEST_METADATA = LockRequestMetadata.of(LOCKS_WITH_METADATA);
+
+    private static final Map<Integer, ConjureChangeMetadata> CONJURE_LOCKS_WITH_METADATA = ImmutableMap.of(
+            0,
+            ConjureChangeMetadata.unchanged(ConjureUnchangedChangeMetadata.of()),
+            1,
+            ConjureChangeMetadata.updated(ConjureUpdatedChangeMetadata.of(
+                    Bytes.from(PtBytes.toBytes("old")), Bytes.from(PtBytes.toBytes("new")))),
+            2,
+            ConjureChangeMetadata.deleted(ConjureDeletedChangeMetadata.of(Bytes.from(PtBytes.toBytes("deleted")))),
+            3,
+            ConjureChangeMetadata.created(ConjureCreatedChangeMetadata.of(Bytes.from(PtBytes.toBytes("created")))));
+    private static ConjureLockRequestMetadata conjureLockRequestMetadata;
+
+    @BeforeClass
+    public static void setup() {
+        KeyListChecksum checksum =
+                IndexEncodingUtils.computeChecksum(ConjureLockRequestMetadataUtils.DEFAULT_CHECKSUM_TYPE, LOCK_LIST);
+        conjureLockRequestMetadata = ConjureLockRequestMetadata.of(
+                CONJURE_LOCKS_WITH_METADATA, checksum.type().getId(), Bytes.from(checksum.value()));
+    }
+
+    @Test
+    public void convertsToConjureCorrectly() {
+        assertThat(ConjureLockRequestMetadataUtils.toConjureIndexEncoded(LOCK_SET, LOCK_REQUEST_METADATA).rhSide)
+                .isEqualTo(conjureLockRequestMetadata);
+    }
+
+    @Test
+    public void convertsFromConjureCorrectly() {
+        assertThat(ConjureLockRequestMetadataUtils.fromConjureIndexEncoded(LOCK_LIST, conjureLockRequestMetadata))
+                .isEqualTo(LOCK_REQUEST_METADATA);
+    }
+}

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -93,6 +93,41 @@ types:
           inclusiveUpper: Long
       ConjureGetFreshTimestampsResponseV2:
         alias: ConjureTimestampRange
+      ConjureUnchangedChangeMetadata:
+        fields: {}
+      ConjureUpdatedChangeMetadata:
+        fields:
+          oldValue:
+            type: binary
+            safety: unsafe
+          newValue:
+            type: binary
+            safety: unsafe
+      ConjureDeletedChangeMetadata:
+        fields:
+          oldValue:
+            type: binary
+            safety: unsafe
+      ConjureCreatedChangeMetadata:
+        fields:
+          newValue:
+            type: binary
+            safety: unsafe
+      ConjureChangeMetadata:
+          union:
+            unchanged: ConjureUnchangedChangeMetadata
+            updated: ConjureUpdatedChangeMetadata
+            deleted: ConjureDeletedChangeMetadata
+            created: ConjureCreatedChangeMetadata
+      ConjureLockRequestMetadata:
+        fields:
+          indexToChangeMetadata: map<integer, ConjureChangeMetadata>
+          checksumType:
+            type: integer
+            safety: safe
+          checksumValue:
+            type: binary
+            safety: unsafe
       ConjureLockDescriptor:
         alias: binary
         safety: unsafe

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -119,15 +119,18 @@ types:
             updated: ConjureUpdatedChangeMetadata
             deleted: ConjureDeletedChangeMetadata
             created: ConjureCreatedChangeMetadata
+      ConjureLockDescriptorListChecksum:
+        fields:
+          typeId:
+            type: integer
+            safety: safe
+          value:
+            type: binary
+            safety: unsafe
       ConjureLockRequestMetadata:
         fields:
           indexToChangeMetadata: map<integer, ConjureChangeMetadata>
-          checksumTypeId:
-            type: integer
-            safety: safe
-          checksumValue:
-            type: binary
-            safety: unsafe
+          lockListChecksum: ConjureLockDescriptorListChecksum
       ConjureLockDescriptor:
         alias: binary
         safety: unsafe

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -122,7 +122,7 @@ types:
       ConjureLockRequestMetadata:
         fields:
           indexToChangeMetadata: map<integer, ConjureChangeMetadata>
-          checksumType:
+          checksumTypeId:
             type: integer
             safety: safe
           checksumValue:


### PR DESCRIPTION
## General
**Before this PR**:

**After this PR**:
New conjure definitions exist to mirror `ChangeMetadata` and an index-encoded variant of `LockRequestMetadata`.
Logic to convert from `ConjureLockRequestMetadata` to `LockRequestMetadata` and back is in `ConjureLockRequestMetadataUtils` . These methods use the index encoding utilities.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[LWMeta] Add Conjure metadata types and conversion methods
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
Is adding a new class to contain the client- and server-side conversions for metadata fine?

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No, this PR itself does not alter the existing API, However, changing the API is a one-liner after this PR (adding `optional<ConjureLockRequestMetadata>` to `ConjureLockRequest`).
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
I have added tests for the conversion between `LockRequestMetadata` and `ConjureLockRequestMetadata`.
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
Changes in this PR are not reachable from production code.

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Using a conjure union type causes overhead during serialization/deserialization. This might cause problems if there is no limit to the amount of metadata we can push onto requests.
initial JMH benchmarks suggest a throughput of roughly 10k ops/s for requests including 1000 locks, 500 locks with metadata and a balanced distribution of metadata type.
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:
`ConjureLockRequestMetadataUtils`

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
