### PR TITLE
[LWMeta] Discard metadata if too large

### DIFF
--- a/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/watch/LockRequestMetadata.java
@@ -33,6 +33,10 @@ public interface LockRequestMetadata {
     @Value.Parameter
     Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata();
 
+    default int size() {
+        return lockDescriptorToChangeMetadata().size();
+    }
+
     static LockRequestMetadata of(Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata) {
         return ImmutableLockRequestMetadata.of(lockDescriptorToChangeMetadata);
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 public class LockEventLogImpl implements LockEventLog {
     private static final SafeLogger log = SafeLoggerFactory.get(LockEventLogImpl.class);
 
-    // Our Sliding window can hold a maximum of 1000 values. If we never store more than 1000 metadata values at a time
+    // Our Sliding window can hold a maximum of 1000 values. If we never store more than 100 metadata values at a time
     // memory usage by metadata will be bounded by 100 * 1000 * MAX_CHANGE_METADATA bytes.
     // Assuming we are using ChangeMetadata that holds ~2KB max each, metadata cannot take up more than 200MB of memory.
     @VisibleForTesting
@@ -81,7 +81,10 @@ public class LockEventLogImpl implements LockEventLog {
         // how often this happens.
         int metadataSize = metadata.map(LockRequestMetadata::size).orElse(0);
         if (metadataSize > MAX_METADATA_SIZE) {
-            log.warn("Discarding metadata because it is too large", SafeArg.of("metadataSize", metadataSize));
+            log.warn(
+                    "Discarding metadata because it is too large",
+                    SafeArg.of("metadataSize", metadataSize),
+                    SafeArg.of("maxMetadataSize", MAX_METADATA_SIZE));
             metadata = Optional.empty();
         }
         slidingWindow.add(LockEvent.builder(locksTakenOut, lockToken, metadata));


### PR DESCRIPTION
## General
**Before this PR**:
There is no upper bound on the amount of metadata we can persist inside TimeLock
**After this PR**:
There is a fixed limit (100) for the amount of metadata we can store per LockEvent in the sliding window in TimeLock.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[LWMeta] Discard metadata if too large
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
This PR only acts as a safeguard, hence the check is done right before persisting the event in the sliding window. Ideally, AtlasDB does not even serialize metadata if it is too large (avoiding expensive transmission and processing on the TimeLock side). For this reason, the limit set in this PR might be too low. I would be comfortable raising it to 1000, thoughts?

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
This PR will make less sense if we do not impose limits on metadata on the Atlas side.
**What was existing testing like? What have you done to improve it?**:
I have added a simple uni test to see if metadata is properly discarded.
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
TimeLock should log a warning if it discards metadata.
**Has the safety of all log arguments been decided correctly?**:
Yes
**Will this change significantly affect our spending on metrics or logs?**:
No, ideally, the mentioned log is never triggered because Atlas takes care of limits. However, if someone were to manually send a request to TimeLock containing lots of metadata, we will discard it and log. 
**How would I tell that this PR does not work in production? (monitors, etc.)**:
This is misbehaving if nearly all metadata is discarded.
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Yes
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No, in fact not doing this might pose a problem at scale
## Development Process
**Where should we start reviewing?**:
`LockEventLogImpl`
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
