### PR TITLE
Do not wait for quorum of nodes available when performing schema version check

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -152,8 +152,6 @@ public final class CassandraKeyValueServices {
         throw new IllegalStateException(errorMessage);
     }
 
-    public void waitForSchemaVersionsAny() {}
-
     static void runWithWaitingForSchemas(
             RunnableCheckedException<TException> task,
             CassandraKeyValueServiceConfig config,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -98,10 +98,10 @@ public final class CassandraKeyValueServices {
      *     </li>
      * </ol>
      *
-     * @param schemaMutationTimeMillis      time to wait for nodes' schema versions to match.
+     * @param schemaMutationTimeMillis      Time to wait for nodes' schema versions to match.
      * @param client                        Cassandra client.
-     * @param unsafeSchemaChangeDescription description of the schema change that was performed prior to this check.
-     * @param availabilityRequirement Number of Cassandra nodes that must be reachable for schema consensus.
+     * @param unsafeSchemaChangeDescription Description of the schema change that was performed prior to this check.
+     * @param availabilityRequirement       Number of Cassandra nodes that must be reachable for schema consensus.
      * @throws IllegalStateException if we wait for more than schemaMutationTimeoutMillis specified in config.
      */
     static void waitForSchemaVersions(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -36,6 +36,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.util.Pair;
+import com.palantir.util.io.AvailabilityRequirement;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
@@ -66,9 +67,16 @@ public final class CassandraKeyValueServices {
         // Utility class
     }
 
+    static void waitForSchemaVersions(
+            int schemaMutationTimeMillis, CassandraClient client, String unsafeSchemaChangeDescription)
+            throws TException {
+        waitForSchemaVersions(
+                schemaMutationTimeMillis, client, unsafeSchemaChangeDescription, AvailabilityRequirement.QUORUM);
+    }
+
     /**
-     * Attempt to wait until a quorum of nodes has reached consensus on a schema version, and it is known that no
-     * other nodes currently disagree with this quorum.
+     * Attempt to wait until the specified number of nodes are available and there are no disagreements on schema
+     * version.
      * <p>
      * The goals of this method include:
      * <ol>
@@ -77,9 +85,12 @@ public final class CassandraKeyValueServices {
      *         Cassandra can more efficiently come to agreement.
      *     </li>
      *     <li>
-     *         Avoid performing schema mutations if they could potentially cause a split-brain in terms of how the
-     *         schema evolves. This is achieved by ensuring a quorum of reachable nodes agree on the version. There
-     *         is of course a check-then-act race condition, but Cassandra is able to eventually recover.
+     *         Avoid performing schema mutations if our availability requirements are not met. This is to prevent a
+     *         split-brain situation in respect to the schema. While this _should_ be a safe state to be in, there is
+     *         little-to-no risk to availability for waiting for consensus and availability. If the specified
+     *         availability requirements are not met, then it is very likely Cassandra is an outage anyways, which
+     *         means it is ok for a service to not start up. There is of course a check-then-act race condition, but
+     *         Cassandra is able to eventually recover.
      *     </li>
      *     <li>
      *         Allowing schema mutations to take place in the presence of failures (the KVS needs to be able to
@@ -90,10 +101,14 @@ public final class CassandraKeyValueServices {
      * @param schemaMutationTimeMillis      time to wait for nodes' schema versions to match.
      * @param client                        Cassandra client.
      * @param unsafeSchemaChangeDescription description of the schema change that was performed prior to this check.
+     * @param availabilityRequirement Number of Cassandra nodes that must be reachable for schema consensus.
      * @throws IllegalStateException if we wait for more than schemaMutationTimeoutMillis specified in config.
      */
     static void waitForSchemaVersions(
-            int schemaMutationTimeMillis, CassandraClient client, String unsafeSchemaChangeDescription)
+            int schemaMutationTimeMillis,
+            CassandraClient client,
+            String unsafeSchemaChangeDescription,
+            AvailabilityRequirement availabilityRequirement)
             throws TException {
         long start = System.currentTimeMillis();
         long sleepTime = INITIAL_SLEEP_TIME;
@@ -102,7 +117,7 @@ public final class CassandraKeyValueServices {
             // This may only include some of the nodes if the coordinator hasn't shaken hands with someone; however,
             // this existed largely as a defense against performance issues with concurrent schema modifications.
             versions = client.describe_schema_versions();
-            if (majorityOfClusterHasConsistentSchemaVersionAndNoDivergentNodes(versions)) {
+            if (clusterSatisfiesAvailabilityRequirementAndNoDivergentSchemas(versions, availabilityRequirement)) {
                 return;
             }
             sleepTime = sleepAndGetNextBackoffTime(sleepTime);
@@ -137,6 +152,8 @@ public final class CassandraKeyValueServices {
         throw new IllegalStateException(errorMessage);
     }
 
+    public void waitForSchemaVersionsAny() {}
+
     static void runWithWaitingForSchemas(
             RunnableCheckedException<TException> task,
             CassandraKeyValueServiceConfig config,
@@ -148,8 +165,8 @@ public final class CassandraKeyValueServices {
         waitForSchemaVersions(config.schemaMutationTimeoutMillis(), client, "after " + unsafeSchemaChangeDescription);
     }
 
-    private static boolean majorityOfClusterHasConsistentSchemaVersionAndNoDivergentNodes(
-            Map<String, List<String>> versions) {
+    private static boolean clusterSatisfiesAvailabilityRequirementAndNoDivergentSchemas(
+            Map<String, List<String>> versions, AvailabilityRequirement availabilityRequirement) {
         if (getDistinctReachableSchemas(versions).size() != 1) {
             return false;
         }
@@ -158,7 +175,8 @@ public final class CassandraKeyValueServices {
         int numUnreachableNodes = Optional.ofNullable(versions.get(VERSION_UNREACHABLE))
                 .map(List::size)
                 .orElse(0);
-        return totalNodes - numUnreachableNodes >= (totalNodes / 2) + 1;
+        int availableNodes = totalNodes - numUnreachableNodes;
+        return availabilityRequirement.satisfies(availableNodes, totalNodes);
     }
 
     private static List<String> getDistinctReachableSchemas(Map<String, List<String>> versions) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -88,7 +88,7 @@ public final class CassandraKeyValueServices {
      *         Avoid performing schema mutations if our availability requirements are not met. This is to prevent a
      *         split-brain situation in respect to the schema. While this _should_ be a safe state to be in, there is
      *         little-to-no risk to availability for waiting for consensus and availability. If the specified
-     *         availability requirements are not met, then it is very likely Cassandra is an outage anyways, which
+     *         availability requirements are not met, then it is very likely Cassandra is in an outage anyways, which
      *         means it is ok for a service to not start up. There is of course a check-then-act race condition, but
      *         Cassandra is able to eventually recover.
      *     </li>

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -267,6 +267,8 @@ public final class CassandraVerifier {
             throws TException {
         try (CassandraClient client = CassandraClientFactory.getClientInternal(host, verifierConfig.clientConfig())) {
             KsDef ksDef = createKsDefForFresh(client, verifierConfig);
+            CassandraKeyValueServices.waitForSchemaVersions(
+                    verifierConfig.schemaMutationTimeoutMillis(), client, "before adding the initial empty keyspace");
             client.system_add_keyspace(ksDef);
             log.info("Created keyspace: {}", SafeArg.of("keyspace", verifierConfig.keyspace()));
             CassandraKeyValueServices.waitForSchemaVersions(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -239,10 +239,10 @@ public final class CassandraVerifier {
         }
     }
 
-    // swallows the expected TException subtype NotFoundException, throws connection problem related ones
-    private static boolean keyspaceAlreadyExists(CassandraServer host, CassandraVerifierConfig verifierConfig)
+    @VisibleForTesting
+    static boolean keyspaceAlreadyExists(CassandraClient client, CassandraVerifierConfig verifierConfig)
             throws TException {
-        try (CassandraClient client = CassandraClientFactory.getClientInternal(host, verifierConfig.clientConfig())) {
+        try {
             client.describe_keyspace(verifierConfig.keyspace());
             CassandraKeyValueServices.waitForSchemaVersions(
                     verifierConfig.schemaMutationTimeoutMillis(),
@@ -252,6 +252,14 @@ public final class CassandraVerifier {
             return true;
         } catch (NotFoundException e) {
             return false;
+        }
+    }
+
+    // swallows the expected TException subtype NotFoundException, throws connection problem related ones
+    private static boolean keyspaceAlreadyExists(CassandraServer host, CassandraVerifierConfig verifierConfig)
+            throws TException {
+        try (CassandraClient client = CassandraClientFactory.getClientInternal(host, verifierConfig.clientConfig())) {
+            return keyspaceAlreadyExists(client, verifierConfig);
         }
     }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -40,6 +40,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.util.io.AvailabilityRequirement;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.HashSet;
@@ -246,7 +247,8 @@ public final class CassandraVerifier {
             CassandraKeyValueServices.waitForSchemaVersions(
                     verifierConfig.schemaMutationTimeoutMillis(),
                     client,
-                    "while checking if schemas diverged on startup");
+                    "while checking if schemas diverged on startup",
+                    AvailabilityRequirement.ANY);
             return true;
         } catch (NotFoundException e) {
             return false;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -240,6 +240,7 @@ public final class CassandraVerifier {
     }
 
     @VisibleForTesting
+    // swallows the expected TException subtype NotFoundException, throws connection problem related ones
     static boolean keyspaceAlreadyExists(CassandraClient client, CassandraVerifierConfig verifierConfig)
             throws TException {
         try {
@@ -255,7 +256,6 @@ public final class CassandraVerifier {
         }
     }
 
-    // swallows the expected TException subtype NotFoundException, throws connection problem related ones
     private static boolean keyspaceAlreadyExists(CassandraServer host, CassandraVerifierConfig verifierConfig)
             throws TException {
         try (CassandraClient client = CassandraClientFactory.getClientInternal(host, verifierConfig.clientConfig())) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
@@ -23,8 +23,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import java.net.InetSocketAddress;
+import com.palantir.util.io.AvailabilityRequirement;
 import org.apache.thrift.TException;
 import org.junit.Test;
 
@@ -33,13 +32,6 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     private static final int WAITING_SCHEMA_MUTATION_TIMEOUT_MILLIS = 10000;
 
     private static CassandraClient client = mock(CassandraClient.class);
-
-    private static final ImmutableSet<InetSocketAddress> FIVE_SERVERS = ImmutableSet.of(
-            InetSocketAddress.createUnresolved("1", 1),
-            InetSocketAddress.createUnresolved("2", 1),
-            InetSocketAddress.createUnresolved("3", 1),
-            InetSocketAddress.createUnresolved("4", 1),
-            InetSocketAddress.createUnresolved("5", 1));
     private static final String TABLE = "table";
     private static final String VERSION_1 = "v1";
     private static final String VERSION_2 = "v2";
@@ -51,59 +43,80 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     @Test
     public void waitSucceedsForSameSchemaVersion() throws TException {
         when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_1, ALL_NODES));
-        assertWaitForSchemaVersionsDoesNotThrow();
+        assertWaitForSchemaVersionsDoesNotThrow(AvailabilityRequirement.QUORUM);
+        assertWaitForSchemaVersionsDoesNotThrow(AvailabilityRequirement.ANY);
     }
 
     @Test
     public void waitThrowsForAllUnknownSchemaVersion() throws TException {
         when(client.describe_schema_versions()).thenReturn(ImmutableMap.of());
-        assertWaitForSchemaVersionsThrows();
+        assertWaitForSchemaVersionsThrows(AvailabilityRequirement.QUORUM);
+        assertWaitForSchemaVersionsThrows(AvailabilityRequirement.ANY);
     }
 
     @Test
     public void waitThrowsForAllUnreachableSchemaVersion() throws TException {
         when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, ALL_NODES));
-        assertWaitForSchemaVersionsThrows();
-    }
-
-    @Test
-    public void waitSucceedsWithClusterHavingDownsizedAtRuntime() throws TException {
-        when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_1, REST_OF_NODES));
-        assertWaitForSchemaVersionsDoesNotThrow();
-    }
-
-    @Test
-    public void waitFailsOnMinorityOnSameVersionAndRestUnreachable() throws TException {
-        when(client.describe_schema_versions())
-                .thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES));
-        assertWaitForSchemaVersionsThrows();
-    }
-
-    @Test
-    public void waitSucceedsForQuorumOnlyWithUnknownSchemaVersion() throws TException {
-        when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_1, QUORUM_OF_NODES));
-        assertWaitForSchemaVersionsDoesNotThrow();
-    }
-
-    @Test
-    public void waitSucceedsForQuorumOnlyWithUnreachableSchemaVersion() throws TException {
-        when(client.describe_schema_versions())
-                .thenReturn(ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_UNREACHABLE, REST_OF_NODES));
-        assertWaitForSchemaVersionsDoesNotThrow();
+        assertWaitForSchemaVersionsThrows(AvailabilityRequirement.QUORUM);
+        assertWaitForSchemaVersionsThrows(AvailabilityRequirement.ANY);
     }
 
     @Test
     public void waitThrowsForDifferentSchemaVersion() throws TException {
         when(client.describe_schema_versions())
                 .thenReturn(ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_2, REST_OF_NODES));
-        assertWaitForSchemaVersionsThrows();
+        assertWaitForSchemaVersionsThrows(AvailabilityRequirement.QUORUM);
+        assertWaitForSchemaVersionsThrows(AvailabilityRequirement.ANY);
+    }
+
+    @Test
+    public void waitSucceedsWithClusterHavingDownsizedAtRuntime() throws TException {
+        when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_1, REST_OF_NODES));
+        assertWaitForSchemaVersionsDoesNotThrow(AvailabilityRequirement.QUORUM);
+    }
+
+    @Test
+    public void waitFailsForQuorumOnMinorityOnSameVersionAndRestUnreachable() throws TException {
+        when(client.describe_schema_versions())
+                .thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES));
+        assertWaitForSchemaVersionsThrows(AvailabilityRequirement.QUORUM);
+    }
+
+    @Test
+    public void waitSucceedsForQuorumOnlyWithUnknownSchemaVersion() throws TException {
+        when(client.describe_schema_versions()).thenReturn(ImmutableMap.of(VERSION_1, QUORUM_OF_NODES));
+        assertWaitForSchemaVersionsDoesNotThrow(AvailabilityRequirement.QUORUM);
+    }
+
+    @Test
+    public void waitSucceedsForQuorumOnlyWithUnreachableSchemaVersion() throws TException {
+        when(client.describe_schema_versions())
+                .thenReturn(ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_UNREACHABLE, REST_OF_NODES));
+        assertWaitForSchemaVersionsDoesNotThrow(AvailabilityRequirement.QUORUM);
     }
 
     @Test
     public void waitSucceedsForQuorumOnlyWithUnknownAndUnreachableSchemaVersion() throws TException {
         when(client.describe_schema_versions())
                 .thenReturn(ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_UNREACHABLE, ImmutableList.of("5")));
-        assertWaitForSchemaVersionsDoesNotThrow();
+        assertWaitForSchemaVersionsDoesNotThrow(AvailabilityRequirement.QUORUM);
+    }
+
+    @Test
+    public void waitChecksForQuorumByDefault() throws TException {
+        when(client.describe_schema_versions())
+                .thenReturn(ImmutableMap.of(VERSION_UNREACHABLE, QUORUM_OF_NODES, VERSION_1, REST_OF_NODES));
+        assertThatThrownBy(() -> CassandraKeyValueServices.waitForSchemaVersions(
+                        NO_WAITING_SCHEMA_MUTATION_TIMEOUT_MILLIS, client, TABLE))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Cassandra cluster cannot come to agreement on schema versions");
+    }
+
+    @Test
+    public void waitSucceedsForAnyWithOnlyOneReachableHost() throws TException {
+        when(client.describe_schema_versions())
+                .thenReturn(ImmutableMap.of(VERSION_1, ImmutableList.of("5"), VERSION_UNREACHABLE, QUORUM_OF_NODES));
+        assertWaitForSchemaVersionsDoesNotThrow(AvailabilityRequirement.ANY);
     }
 
     @Test
@@ -117,18 +130,21 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
                         ImmutableMap.of(VERSION_1, QUORUM_OF_NODES, VERSION_UNREACHABLE, REST_OF_NODES),
                         ImmutableMap.of(VERSION_1, ALL_NODES));
 
-        CassandraKeyValueServices.waitForSchemaVersions(WAITING_SCHEMA_MUTATION_TIMEOUT_MILLIS, waitingClient, TABLE);
+        CassandraKeyValueServices.waitForSchemaVersions(
+                WAITING_SCHEMA_MUTATION_TIMEOUT_MILLIS, waitingClient, TABLE, AvailabilityRequirement.QUORUM);
         verify(waitingClient, times(4)).describe_schema_versions();
     }
 
-    private void assertWaitForSchemaVersionsThrows() {
+    private void assertWaitForSchemaVersionsThrows(AvailabilityRequirement availabilityRequirement) {
         assertThatThrownBy(() -> CassandraKeyValueServices.waitForSchemaVersions(
-                        NO_WAITING_SCHEMA_MUTATION_TIMEOUT_MILLIS, client, TABLE))
+                        NO_WAITING_SCHEMA_MUTATION_TIMEOUT_MILLIS, client, TABLE, availabilityRequirement))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Cassandra cluster cannot come to agreement on schema versions");
     }
 
-    private void assertWaitForSchemaVersionsDoesNotThrow() throws TException {
-        CassandraKeyValueServices.waitForSchemaVersions(NO_WAITING_SCHEMA_MUTATION_TIMEOUT_MILLIS, client, TABLE);
+    private void assertWaitForSchemaVersionsDoesNotThrow(AvailabilityRequirement availabilityRequirement)
+            throws TException {
+        CassandraKeyValueServices.waitForSchemaVersions(
+                NO_WAITING_SCHEMA_MUTATION_TIMEOUT_MILLIS, client, TABLE, availabilityRequirement);
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
@@ -35,7 +35,7 @@ public class CassandraKeyValueServicesSchemaConsensusTest {
     private static final String TABLE = "table";
     private static final String VERSION_1 = "v1";
     private static final String VERSION_2 = "v2";
-    private static final String VERSION_UNREACHABLE = "UNREACHABLE";
+    private static final String VERSION_UNREACHABLE = CassandraKeyValueServices.VERSION_UNREACHABLE;
     private static final ImmutableList<String> QUORUM_OF_NODES = ImmutableList.of("1", "2", "3");
     private static final ImmutableList<String> REST_OF_NODES = ImmutableList.of("4", "5");
     private static final ImmutableList<String> ALL_NODES = ImmutableList.of("1", "2", "3", "4", "5");

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -274,6 +274,19 @@ public class CassandraVerifierTest {
                 .isInstanceOf(IllegalStateException.class);
     }
 
+    @Test
+    public void keyspaceAlreadyExistsOnlyChecksForAnyAvailableNodes() throws TException {
+        CassandraVerifierConfig verifierConfig =
+                getVerifierConfigBuilderWithDefaults(defaultTopology(HOST_1)).build();
+        when(client.describe_schema_versions())
+                .thenReturn(ImmutableMap.of(
+                        "A",
+                        ImmutableList.of(HOST_1),
+                        CassandraKeyValueServices.VERSION_UNREACHABLE,
+                        ImmutableList.of(HOST_1, HOST_2, HOST_3)));
+        CassandraVerifier.keyspaceAlreadyExists(client, verifierConfig);
+    }
+
     private TokenRange mockRangeWithDetails(EndpointDetails... details) {
         TokenRange mockRange = new TokenRange();
         mockRange.setEndpoint_details(Arrays.asList(details));

--- a/atlasdb-commons/src/main/java/com/palantir/util/io/AvailabilityRequirement.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/io/AvailabilityRequirement.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.util.io;
+
+public enum AvailabilityRequirement {
+    ANY {
+        @Override
+        protected int calculateRequired(int total) {
+            return 1;
+        }
+    },
+    QUORUM {
+        @Override
+        protected int calculateRequired(int total) {
+            return (total / 2) + 1;
+        }
+    };
+
+    protected abstract int calculateRequired(int total);
+
+    public boolean satisfies(int available, int total) {
+        return available >= calculateRequired(total);
+    }
+}

--- a/atlasdb-commons/src/main/java/com/palantir/util/io/AvailabilityRequirement.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/io/AvailabilityRequirement.java
@@ -16,6 +16,9 @@
 
 package com.palantir.util.io;
 
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+
 public enum AvailabilityRequirement {
     ANY {
         @Override
@@ -33,6 +36,16 @@ public enum AvailabilityRequirement {
     protected abstract int calculateRequired(int total);
 
     public boolean satisfies(int available, int total) {
+        Preconditions.checkArgument(
+                available >= 0 && total >= 0,
+                "Available and total must be non-negative.",
+                SafeArg.of("available", available),
+                SafeArg.of("total", total));
+        Preconditions.checkArgument(
+                available <= total,
+                "Available must be less than or equal to total.",
+                SafeArg.of("available", available),
+                SafeArg.of("total", total));
         return available >= calculateRequired(total);
     }
 }

--- a/atlasdb-commons/src/main/java/com/palantir/util/io/AvailabilityRequirement.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/io/AvailabilityRequirement.java
@@ -35,7 +35,7 @@ public enum AvailabilityRequirement {
 
     protected abstract int calculateRequired(int total);
 
-    public boolean satisfies(int available, int total) {
+    public final boolean satisfies(int available, int total) {
         Preconditions.checkArgument(
                 available >= 0 && total >= 0,
                 "Available and total must be non-negative.",

--- a/atlasdb-commons/src/test/java/com/palantir/util/io/AvailabilityRequirementTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/io/AvailabilityRequirementTest.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.util.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public final class AvailabilityRequirementTest {
+    @Test
+    public void anySatisfiesGreaterThanZero() {
+        assertThat(AvailabilityRequirement.ANY.satisfies(1, 10)).isTrue();
+    }
+
+    @Test
+    public void anySatisfiesWhenEquivalentToTotal() {
+        assertThat(AvailabilityRequirement.ANY.satisfies(10, 10)).isTrue();
+    }
+
+    @Test
+    public void anyDoesNotSatisfyWhenZero() {
+        assertThat(AvailabilityRequirement.ANY.satisfies(0, 10)).isFalse();
+    }
+
+    @Test
+    public void quorumSatisfiesWhenHasMajority() {
+        assertThat(AvailabilityRequirement.QUORUM.satisfies(2, 3)).isTrue();
+        assertThat(AvailabilityRequirement.QUORUM.satisfies(4, 6)).isTrue();
+        assertThat(AvailabilityRequirement.QUORUM.satisfies(5, 9)).isTrue();
+    }
+
+    @Test
+    public void quorumDoesNotSatisfyWhenItDoesNotHaveMajority() {
+        assertThat(AvailabilityRequirement.QUORUM.satisfies(1, 3)).isFalse();
+        assertThat(AvailabilityRequirement.QUORUM.satisfies(3, 6)).isFalse();
+    }
+
+    @Test
+    public void quorumSatisfiesWhenHasTotal() {
+        assertThat(AvailabilityRequirement.QUORUM.satisfies(10, 10)).isTrue();
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/util/io/AvailabilityRequirementTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/util/io/AvailabilityRequirementTest.java
@@ -20,6 +20,7 @@ import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptio
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import org.junit.Test;
 
 public final class AvailabilityRequirementTest {
@@ -30,12 +31,14 @@ public final class AvailabilityRequirementTest {
 
     @Test
     public void anySatisfiesWhenEquivalentToTotal() {
+        assertThat(AvailabilityRequirement.ANY.satisfies(1, 1)).isTrue();
         assertThat(AvailabilityRequirement.ANY.satisfies(10, 10)).isTrue();
     }
 
     @Test
     public void anyDoesNotSatisfyWhenZero() {
         assertThat(AvailabilityRequirement.ANY.satisfies(0, 10)).isFalse();
+        assertThat(AvailabilityRequirement.ANY.satisfies(0, 0)).isFalse();
     }
 
     @Test
@@ -47,12 +50,15 @@ public final class AvailabilityRequirementTest {
 
     @Test
     public void quorumDoesNotSatisfyWhenItDoesNotHaveMajority() {
+        assertThat(AvailabilityRequirement.QUORUM.satisfies(0, 0)).isFalse();
+        assertThat(AvailabilityRequirement.QUORUM.satisfies(0, 1)).isFalse();
         assertThat(AvailabilityRequirement.QUORUM.satisfies(1, 3)).isFalse();
         assertThat(AvailabilityRequirement.QUORUM.satisfies(3, 6)).isFalse();
     }
 
     @Test
     public void quorumSatisfiesWhenHasTotal() {
+        assertThat(AvailabilityRequirement.QUORUM.satisfies(1, 1)).isTrue();
         assertThat(AvailabilityRequirement.QUORUM.satisfies(10, 10)).isTrue();
     }
 
@@ -74,14 +80,14 @@ public final class AvailabilityRequirementTest {
     @Test
     public void satisfiesThrowsWhenAvailableIsGreaterThanTotal() {
         assertThatLoggableExceptionThrownBy(() -> AvailabilityRequirement.ANY.satisfies(11, 10))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(SafeIllegalArgumentException.class)
                 .hasMessageContaining("Available must be less than or equal to total.")
                 .hasExactlyArgs(SafeArg.of("available", 11), SafeArg.of("total", 10));
     }
 
     private static void assertThatNegativeArgumentsExceptionThrowsForArguments(int available, int total) {
         assertThatLoggableExceptionThrownBy(() -> AvailabilityRequirement.ANY.satisfies(available, total))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(SafeIllegalArgumentException.class)
                 .hasMessageContaining("Available and total must be non-negative.")
                 .hasExactlyArgs(SafeArg.of("available", available), SafeArg.of("total", total));
     }

--- a/changelog/@unreleased/pr-6667.v2.yml
+++ b/changelog/@unreleased/pr-6667.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Do not wait for a quorum of nodes to be available for Cassandra's schema
+    version on start up unless when performing DDL operations.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6667


### PR DESCRIPTION
## General
**Before this PR**:
On service start up, services were unable to perform requests / finish starting up as they had more than a quorum of nodes unreachable. It is expected for some requests to fail in this scenario, what is not expected is that all requests fail. This is due to the fact that during atlas initialization, we ensure that a quorum of nodes are reachable when checking schema versions, which always happens even if a DDL operation will not be performed. 

Granted, in the scenario where a user does not have a quorum of nodes reachable, then it will be an outage anyways. However, there can be edge cases which can occur, specifically for a multi-dc setup, in which this breaks despite there not being an outage. This check isn't too important anyways, as we conform to a single schema in atlas, so we don't need to worry about changing columns. In addition, the table id we use is deterministically generated, thus we do not need to worry about conflicts/clashes, they should "merge" fine. 

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Do not wait for a quorum of nodes to be available for Cassandra's schema version on start up unless when performing DDL operations.
==COMMIT_MSG==

**Priority**:
P0

**Concerns / possible downsides (what feedback would you like?)**:
- Test coverage is... meh, but seeing as this is only restricting the check, it should be sufficient.

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
Yes, we expect Cassandra to allow us to specify the columnfamily id upon table creation. I'd imagine this should still be the case for Cassandra 3/4, and consistent metadata is coming in 5, which side-steps this problem altogether.

**Does this PR need a schema migration?**
Nope

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
Yes, we expect Cassandra to allow us to specify the columnfamily id upon table creation using cqlsh. I'd expect for an error/exception to throw if this weren't the case. 

**What was existing testing like? What have you done to improve it?**:
Added additional unit tests 

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Logs! 

**Has the safety of all log arguments been decided correctly?**:
Yes

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Logs!

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback -- but notify me as this is necessary for an internal migration. 

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No, would only help.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:
Now

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
