### PR TITLE
[LWMeta] Pass Metadata through SnapshotTransaction

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ChangeMetadataAnnotatedValue.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/ChangeMetadataAnnotatedValue.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.api;
+
+import com.palantir.lock.watch.ChangeMetadata;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ChangeMetadataAnnotatedValue {
+    @Value.Parameter
+    byte[] value();
+
+    @Value.Parameter
+    ChangeMetadata metadata();
+
+    static ChangeMetadataAnnotatedValue of(byte[] value, ChangeMetadata metadata) {
+        return ImmutableChangeMetadataAnnotatedValue.of(value, metadata);
+    }
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -27,6 +27,7 @@ import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.common.annotation.Idempotent;
 import com.palantir.common.base.BatchingVisitable;
+import com.palantir.lock.watch.ChangeMetadata;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -272,12 +273,37 @@ public interface Transaction {
     void put(TableReference tableRef, Map<Cell, byte[]> values);
 
     /**
+     * Behaves like {@link Transaction#put}, but additionally store {@link ChangeMetadata} for cells. This metadata is
+     * forwarded to TimeLock when acquiring locks at the beginning of the commit protocol.
+     * If two cells in the same row have metadata and the {@link ConflictHandler} for the table acquires row locks,
+     * {@link Transaction#commit} will fail.
+     *
+     * @param tableRef the table into which to put the values and metadata
+     * @param metadataAnnotatedValues the metadata-enriched values to append to the table
+     */
+    @Idempotent
+    void putWithMetadata(TableReference tableRef, Map<Cell, ChangeMetadataAnnotatedValue> metadataAnnotatedValues);
+
+    /**
      * Deletes values from the key-value store.
      * @param tableRef the table from which to delete the values
      * @param keys the set of cells to delete from the store
      */
     @Idempotent
     void delete(TableReference tableRef, Set<Cell> keys);
+
+    /**
+     * Behaves like {@link Transaction#delete}, but additionally stores {@link ChangeMetadata} for the deleted cells.
+     * This metadata is forwarded to TimeLock when acquiring locks at the beginning of the commit protocol.
+     * If two cells in the same row have metadata and the {@link ConflictHandler} for the table acquires row locks,
+     * {@link Transaction#commit} will fail.
+     *
+     * @param tableRef the table from which to delete the values and for which to store metadata
+     * @param keysWithMetadata the cells to delete associated with the metadata that should be stored for
+     * them
+     */
+    @Idempotent
+    void deleteWithMetadata(TableReference tableRef, Map<Cell, ChangeMetadata> keysWithMetadata);
 
     @Idempotent
     TransactionType getTransactionType();

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/expectations/ExpectationsData.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/expectations/ExpectationsData.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.api.expectations;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ExpectationsData {
+    long ageMillis();
+
+    TransactionReadInfo readInfo();
+
+    TransactionCommitLockInfo commitLockInfo();
+
+    TransactionMetadataInfo metadataInfo();
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/expectations/TransactionMetadataInfo.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/expectations/TransactionMetadataInfo.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.api.expectations;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface TransactionMetadataInfo {
+
+    /**
+     * The number of {@link com.palantir.lock.watch.ChangeMetadata} objects stored internally in a transaction.
+     */
+    long changeMetadataStored();
+
+    /**
+     * The number of {@link com.palantir.lock.watch.ChangeMetadata} objects attached to cell-level {@link com.palantir.lock.LockDescriptor}s
+     * when requesting commit locks.
+     */
+    long cellChangeMetadataSent();
+
+    /**
+     * The number of {@link com.palantir.lock.watch.ChangeMetadata} objects attached to row-level {@link com.palantir.lock.LockDescriptor}s
+     * when requesting commit locks.
+     */
+    long rowChangeMetadataSent();
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ExpectationsAwareTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ExpectationsAwareTransaction.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.transaction.impl;
 
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.expectations.TransactionCommitLockInfo;
+import com.palantir.atlasdb.transaction.api.expectations.TransactionMetadataInfo;
 import com.palantir.atlasdb.transaction.api.expectations.TransactionReadInfo;
 
 /**
@@ -37,6 +38,8 @@ public interface ExpectationsAwareTransaction extends Transaction {
      * Returns transaction commit lock information.
      */
     TransactionCommitLockInfo getCommitLockInfo();
+
+    TransactionMetadataInfo getMetadataInfo();
 
     /**
      * Update TEX data collection metrics for (post-mortem) transactions.

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingExpectationsAwareTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingExpectationsAwareTransaction.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.transaction.impl;
 
 import com.palantir.atlasdb.transaction.api.expectations.TransactionCommitLockInfo;
+import com.palantir.atlasdb.transaction.api.expectations.TransactionMetadataInfo;
 import com.palantir.atlasdb.transaction.api.expectations.TransactionReadInfo;
 
 public abstract class ForwardingExpectationsAwareTransaction extends ForwardingTransaction
@@ -38,6 +39,11 @@ public abstract class ForwardingExpectationsAwareTransaction extends ForwardingT
     @Override
     public TransactionCommitLockInfo getCommitLockInfo() {
         return delegate().getCommitLockInfo();
+    }
+
+    @Override
+    public TransactionMetadataInfo getMetadataInfo() {
+        return delegate().getMetadataInfo();
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -24,6 +24,7 @@ import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.transaction.api.ChangeMetadataAnnotatedValue;
 import com.palantir.atlasdb.transaction.api.ConstraintCheckable;
 import com.palantir.atlasdb.transaction.api.GetRangesQuery;
 import com.palantir.atlasdb.transaction.api.Transaction;
@@ -31,6 +32,7 @@ import com.palantir.atlasdb.transaction.api.TransactionFailedException;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.common.base.BatchingVisitable;
+import com.palantir.lock.watch.ChangeMetadata;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -128,8 +130,19 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
     }
 
     @Override
+    public void putWithMetadata(
+            TableReference tableRef, Map<Cell, ChangeMetadataAnnotatedValue> metadataAnnotatedValues) {
+        delegate().putWithMetadata(tableRef, metadataAnnotatedValues);
+    }
+
+    @Override
     public void delete(TableReference tableRef, Set<Cell> keys) {
         delegate().delete(tableRef, keys);
+    }
+
+    @Override
+    public void deleteWithMetadata(TableReference tableRef, Map<Cell, ChangeMetadata> keys) {
+        delegate().deleteWithMetadata(tableRef, keys);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -83,6 +83,7 @@ import com.palantir.atlasdb.table.description.exceptions.AtlasDbConstraintExcept
 import com.palantir.atlasdb.tracing.TraceStatistics;
 import com.palantir.atlasdb.transaction.TransactionConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ChangeMetadataAnnotatedValue;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.ConstraintCheckable;
 import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
@@ -131,8 +132,11 @@ import com.palantir.lock.v2.LockRequest;
 import com.palantir.lock.v2.LockResponse;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.v2.TimelockService;
+import com.palantir.lock.watch.ChangeMetadata;
+import com.palantir.lock.watch.LockRequestMetadata;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
@@ -158,7 +162,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.NavigableSet;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -174,6 +177,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -246,6 +250,8 @@ public class SnapshotTransaction extends AbstractTransaction
     protected final long timeCreated = System.currentTimeMillis();
 
     protected final ConcurrentMap<TableReference, ConcurrentNavigableMap<Cell, byte[]>> writesByTable =
+            new ConcurrentHashMap<>();
+    protected final ConcurrentMap<TableReference, ConcurrentNavigableMap<Cell, ChangeMetadata>> metadataByTable =
             new ConcurrentHashMap<>();
     protected final TransactionConflictDetectionManager conflictDetectionManager;
     private final AtomicLong byteCount = new AtomicLong();
@@ -1376,6 +1382,11 @@ public class SnapshotTransaction extends AbstractTransaction
         return writesByTable.computeIfAbsent(tableRef, unused -> new ConcurrentSkipListMap<>());
     }
 
+    @VisibleForTesting
+    ConcurrentNavigableMap<Cell, ChangeMetadata> getChangeMetadataForWrites(TableReference tableRef) {
+        return metadataByTable.computeIfAbsent(tableRef, unused -> new ConcurrentSkipListMap<>());
+    }
+
     /**
      * This includes deleted writes as zero length byte arrays, be sure to strip them out.
      *
@@ -1765,18 +1776,42 @@ public class SnapshotTransaction extends AbstractTransaction
 
     @Override
     public final void delete(TableReference tableRef, Set<Cell> cells) {
+        deleteInternal(tableRef, cells, ImmutableMap.of());
+    }
+
+    @Override
+    public void deleteWithMetadata(TableReference tableRef, Map<Cell, ChangeMetadata> cellsWithMetadata) {
+        deleteInternal(tableRef, cellsWithMetadata.keySet(), cellsWithMetadata);
+    }
+
+    private void deleteInternal(TableReference tableRef, Set<Cell> cells, Map<Cell, ChangeMetadata> metadata) {
         getCache().delete(tableRef, cells);
-        putInternal(tableRef, Cells.constantValueMap(cells, PtBytes.EMPTY_BYTE_ARRAY));
+        putInternal(tableRef, Cells.constantValueMap(cells, PtBytes.EMPTY_BYTE_ARRAY), metadata);
     }
 
     @Override
     public void put(TableReference tableRef, Map<Cell, byte[]> values) {
-        ensureNoEmptyValues(values);
-        getCache().write(tableRef, values);
-        putInternal(tableRef, values);
+        putWithMetadataInternal(tableRef, values, ImmutableMap.of());
     }
 
-    public void putInternal(TableReference tableRef, Map<Cell, byte[]> values) {
+    @Override
+    public void putWithMetadata(
+            TableReference tableRef, Map<Cell, ChangeMetadataAnnotatedValue> metadataAnnotatedValues) {
+        Map<Cell, byte[]> valuesOnly =
+                Maps.transformValues(metadataAnnotatedValues, ChangeMetadataAnnotatedValue::value);
+        Map<Cell, ChangeMetadata> metadataOnly =
+                Maps.transformValues(metadataAnnotatedValues, ChangeMetadataAnnotatedValue::metadata);
+        putWithMetadataInternal(tableRef, valuesOnly, metadataOnly);
+    }
+
+    private void putWithMetadataInternal(
+            TableReference tableRef, Map<Cell, byte[]> values, Map<Cell, ChangeMetadata> metadata) {
+        ensureNoEmptyValues(values);
+        getCache().write(tableRef, values);
+        putInternal(tableRef, values, metadata);
+    }
+
+    public void putInternal(TableReference tableRef, Map<Cell, byte[]> values, Map<Cell, ChangeMetadata> metadata) {
         Preconditions.checkArgument(!AtlasDbConstants.HIDDEN_TABLES.contains(tableRef));
         markTableAsInvolvedInThisTransaction(tableRef);
 
@@ -1790,8 +1825,9 @@ public class SnapshotTransaction extends AbstractTransaction
             ensureUncommitted();
 
             ConcurrentNavigableMap<Cell, byte[]> writes = getLocalWrites(tableRef);
+            ConcurrentNavigableMap<Cell, ChangeMetadata> metadataForWrites = getChangeMetadataForWrites(tableRef);
 
-            putWritesAndLogIfTooLarge(values, writes);
+            putWritesAndLogIfTooLarge(values, writes, metadata, metadataForWrites);
         } finally {
             numWriters.decrementAndGet();
         }
@@ -1806,11 +1842,28 @@ public class SnapshotTransaction extends AbstractTransaction
         }
     }
 
-    private void putWritesAndLogIfTooLarge(Map<Cell, byte[]> values, SortedMap<Cell, byte[]> writes) {
+    private void putWritesAndLogIfTooLarge(
+            Map<Cell, byte[]> values,
+            ConcurrentNavigableMap<Cell, byte[]> writes,
+            Map<Cell, ChangeMetadata> metadata,
+            ConcurrentNavigableMap<Cell, ChangeMetadata> metadataForWrites) {
         for (Map.Entry<Cell, byte[]> e : values.entrySet()) {
             byte[] val = MoreObjects.firstNonNull(e.getValue(), PtBytes.EMPTY_BYTE_ARRAY);
             Cell cell = e.getKey();
-            if (writes.put(cell, val) == null) {
+            AtomicBoolean wasNull = new AtomicBoolean(false);
+            boolean hasMetadata = metadata.containsKey(cell);
+            writes.compute(cell, (k, oldVal) -> {
+                wasNull.set(oldVal == null);
+                // If we are not writing metadata for a value, we have to remove any previously stored metadata since
+                // it may not be valid for the new value.
+                if (hasMetadata) {
+                    metadataForWrites.put(cell, metadata.get(cell));
+                } else {
+                    metadataForWrites.remove(cell);
+                }
+                return val;
+            });
+            if (wasNull.get()) {
                 long toAdd = val.length + Cells.getApproxSizeOfCell(cell);
                 long newVal = byteCount.addAndGet(toAdd);
                 if (newVal >= TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES
@@ -2458,12 +2511,14 @@ public class SnapshotTransaction extends AbstractTransaction
      * This method should acquire any locks needed to do proper concurrency control at commit time.
      */
     protected LockToken acquireLocksForCommit() {
-        Set<LockDescriptor> lockDescriptors = getLocksForWrites();
+        LocksAndMetadata locksAndMetadata = getLocksAndMetadataForWrites();
+        Set<LockDescriptor> lockDescriptors = locksAndMetadata.lockDescriptors();
         TransactionConfig currentTransactionConfig = transactionConfig.get();
 
         // TODO(fdesouza): Revert this once PDS-95791 is resolved.
         long lockAcquireTimeoutMillis = currentTransactionConfig.getLockAcquireTimeoutMillis();
-        LockRequest request = LockRequest.of(lockDescriptors, lockAcquireTimeoutMillis);
+        Optional<LockRequestMetadata> metadata = locksAndMetadata.metadata();
+        LockRequest request = LockRequest.of(lockDescriptors, lockAcquireTimeoutMillis, metadata);
 
         RuntimeException stackTraceSnapshot = new SafeRuntimeException("I exist to show you the stack trace");
         LockResponse lockResponse = timelockService.lock(
@@ -2509,38 +2564,81 @@ public class SnapshotTransaction extends AbstractTransaction
                 stackTraceSnapshot);
     }
 
-    protected Set<LockDescriptor> getLocksForWrites() {
-        Set<LockDescriptor> result = new HashSet<>();
+    protected LocksAndMetadata getLocksAndMetadataForWrites() {
+        Set<LockDescriptor> lockDescriptors = new HashSet<>();
+        Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata = new HashMap<>();
         long cellLockCount = 0L;
         long rowLockCount = 0L;
         for (TableReference tableRef : writesByTable.keySet()) {
             ConflictHandler conflictHandler = getConflictHandlerForTable(tableRef);
-            if (conflictHandler.lockCellsForConflicts()) {
-                NavigableSet<Cell> cellsToLock = getLocalWrites(tableRef).keySet();
-                for (Cell cell : cellsToLock) {
-                    result.add(AtlasCellLockDescriptor.of(
-                            tableRef.getQualifiedName(), cell.getRowName(), cell.getColumnName()));
-                }
-                cellLockCount += cellsToLock.size();
-            }
 
-            if (conflictHandler.lockRowsForConflicts()) {
-                Cell lastCell = null;
-                for (Cell cell : getLocalWrites(tableRef).keySet()) {
-                    if (lastCell == null || !Arrays.equals(lastCell.getRowName(), cell.getRowName())) {
-                        result.add(AtlasRowLockDescriptor.of(tableRef.getQualifiedName(), cell.getRowName()));
-                        rowLockCount++;
-                    }
-                    lastCell = cell;
-                }
+            int previousLockCount = lockDescriptors.size();
+            if (conflictHandler.lockCellsForConflicts()) {
+                collectCellLocks(lockDescriptors, lockDescriptorToChangeMetadata, tableRef);
             }
+            cellLockCount += lockDescriptors.size() - previousLockCount;
+
+            previousLockCount = lockDescriptors.size();
+            if (conflictHandler.lockRowsForConflicts()) {
+                collectRowLocks(lockDescriptors, lockDescriptorToChangeMetadata, tableRef);
+            }
+            rowLockCount += lockDescriptors.size() - previousLockCount;
         }
-        result.add(AtlasRowLockDescriptor.of(
+        lockDescriptors.add(AtlasRowLockDescriptor.of(
                 TransactionConstants.TRANSACTION_TABLE.getQualifiedName(),
                 TransactionConstants.getValueForTimestamp(getStartTimestamp())));
         cellCommitLocksRequested = cellLockCount;
         rowCommitLocksRequested = rowLockCount + 1;
-        return result;
+        return LocksAndMetadata.of(
+                lockDescriptors,
+                // For now, lock request metadata only consists of change metadata. If it is absent, we can save
+                // computation by not doing an index encoding
+                lockDescriptorToChangeMetadata.isEmpty()
+                        ? Optional.empty()
+                        : Optional.of(LockRequestMetadata.of(lockDescriptorToChangeMetadata)));
+    }
+
+    private void collectCellLocks(
+            Set<LockDescriptor> lockDescriptors,
+            Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata,
+            TableReference tableRef) {
+        Map<Cell, ChangeMetadata> changeMetadataForWrites = getChangeMetadataForWrites(tableRef);
+        for (Cell cell : getLocalWrites(tableRef).keySet()) {
+            LockDescriptor lockDescriptor =
+                    AtlasCellLockDescriptor.of(tableRef.getQualifiedName(), cell.getRowName(), cell.getColumnName());
+            lockDescriptors.add(lockDescriptor);
+            if (changeMetadataForWrites.containsKey(cell)) {
+                lockDescriptorToChangeMetadata.put(lockDescriptor, changeMetadataForWrites.get(cell));
+            }
+        }
+    }
+
+    private void collectRowLocks(
+            Set<LockDescriptor> lockDescriptors,
+            Map<LockDescriptor, ChangeMetadata> lockDescriptorToChangeMetadata,
+            TableReference tableRef) {
+        Map<Cell, ChangeMetadata> changeMetadataForWrites = getChangeMetadataForWrites(tableRef);
+        Cell lastCell = null;
+        for (Cell cell : getLocalWrites(tableRef).keySet()) {
+            LockDescriptor rowLockDescriptor =
+                    AtlasRowLockDescriptor.of(tableRef.getQualifiedName(), cell.getRowName());
+            if (changeMetadataForWrites.containsKey(cell)) {
+                if (lockDescriptorToChangeMetadata.containsKey(rowLockDescriptor)) {
+                    throw new SafeIllegalStateException(
+                            "Two different cells in the same row have metadata and we create locks on row level.",
+                            UnsafeArg.of("tableRef", tableRef),
+                            UnsafeArg.of("rowName", cell.getRowName()),
+                            UnsafeArg.of("existingMetadata", lockDescriptorToChangeMetadata.get(rowLockDescriptor)),
+                            UnsafeArg.of("newMetadata", changeMetadataForWrites.get(cell)));
+                } else {
+                    lockDescriptorToChangeMetadata.put(rowLockDescriptor, changeMetadataForWrites.get(cell));
+                }
+            }
+            if (lastCell == null || !Arrays.equals(lastCell.getRowName(), cell.getRowName())) {
+                lockDescriptors.add(rowLockDescriptor);
+            }
+            lastCell = cell;
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -2838,5 +2936,19 @@ public class SnapshotTransaction extends AbstractTransaction
                     return txnTaskResult;
                 },
                 MoreExecutors.directExecutor());
+    }
+
+    @Unsafe
+    @org.immutables.value.Value.Immutable
+    public interface LocksAndMetadata {
+        @org.immutables.value.Value.Parameter
+        Set<LockDescriptor> lockDescriptors();
+
+        @org.immutables.value.Value.Parameter
+        Optional<LockRequestMetadata> metadata();
+
+        static LocksAndMetadata of(Set<LockDescriptor> lockDescriptors, Optional<LockRequestMetadata> metadata) {
+            return ImmutableLocksAndMetadata.of(lockDescriptors, metadata);
+        }
     }
 }

--- a/atlasdb-impl-shared/src/main/metrics/expectations.yml
+++ b/atlasdb-impl-shared/src/main/metrics/expectations.yml
@@ -23,3 +23,15 @@ namespaces:
       rowCommitLocksRequested:
         docs: Number of row-level commit locks requested as part of the commit protocol
         type: histogram
+      changeMetadataStored:
+        docs: Number of change metadata objects stored locally in the transaction
+        type: histogram
+      cellChangeMetadataSent:
+        docs: Number of change metadata objects attached to cell-level lock descriptors when requesting commit locks
+        type: histogram
+      rowChangeMetadataSent:
+        docs: Number of change metadata objects attached to row-level lock descriptors when requesting commit locks
+        type: histogram
+
+
+

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/LockRequest.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/LockRequest.java
@@ -52,6 +52,11 @@ public interface LockRequest {
                 lockDescriptors, acquireTimeoutMs, Optional.of(clientDescription), Optional.empty());
     }
 
+    static LockRequest of(
+            Set<LockDescriptor> lockDescriptors, long acquireTimeoutMs, Optional<LockRequestMetadata> metadata) {
+        return ImmutableLockRequest.of(lockDescriptors, acquireTimeoutMs, Optional.empty(), metadata);
+    }
+
     @Value.Check
     default void check() {
         Preconditions.checkState(getAcquireTimeoutMs() >= 0, "Acquire timeout cannot be negative.");

--- a/timelock-api/build.gradle
+++ b/timelock-api/build.gradle
@@ -28,9 +28,3 @@ subprojects {
     }
     tasks.licenseMain.enabled = false
 }
-
-conjure {
-    java {
-        excludeEmptyOptionals = true
-    }
-}


### PR DESCRIPTION
## General
**Before this PR**:

**After this PR**:

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[LWMeta] Pass Metadata through SnapshotTransaction
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
- There is an alternative to the way this PR guarantees the atomicity of putting metadata by storing metadata-annotated values instead of just byte arrays.
- We have to propagate metadata from cell level to row level. This involves checking that no row has more than one metadata object associated with any of its cells. But where should we ensure this invariant? This PR will fail during commit if a row contains multiple metadata objects, but it might be better to fail as early as possible, i.e. in the call to `putWithMetadata`. This will require us to change the way we store metadata or add additional data structures.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
With this PR it is possible for Atlas users to send metadata to TimeLock. Before we merge this PR, we need to ensure the proper product dependencies are in place.
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
We generally use metadata with `ConflictHandler.SERIALIZABLE` and will always use row locks only.
**What was existing testing like? What have you done to improve it?**:
Added tests for all of the logic this PR adds
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
We have to ensure that putting the metadata together with a value is a single atomic operation. This PR achieves this by leveraging the `ConcurrentMap::compute` function and storing the metadata inside the compute method. This guarantees that the thread that wins the value race also wins the metadata race.
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Metrics for metadata! (And TimeLock does no complain)
**Has the safety of all log arguments been decided correctly?**:
Yes
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
No metrics despite metadata being used.
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Yes
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Generally, this PR does not add significant complexity. Determining the row locks we should acquire has become a bit less efficient since we need to check for duplicate metadata.
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
We might need to rethink how we ensure the invariant that no two cells in a row can have metadata (if using row locks).
## Development Process
**Where should we start reviewing?**:
'Transaction.java'

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
I tried refactoring out the transaction-internal metadata storage and the way we handle metadata during commit. However, these turned out to be very closely coupled which makes changes very tedious.
Also, a majority of this PR is tests.

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
