### PR TITLE
Reduce observability overhead cost

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -129,3 +129,26 @@ acceptedBreaks:
       new: "parameter <T> long com.palantir.atlasdb.keyvalue.cassandra.thrift.ThriftObjectSizeUtils::getCollectionSize(java.util.Collection<T>,\
         \ ===java.util.function.ToLongFunction<T>===)"
       justification: "Avoid autoboxing long to Long"
+  "0.899.0":
+    com.palantir.atlasdb:atlasdb-cassandra:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void com.palantir.atlasdb.keyvalue.cassandra.RangeLoader::<init>(com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.TracingQueryRunner, ===com.palantir.atlasdb.util.MetricsManager===,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.ReadConsistencyProvider)"
+      new: "parameter void com.palantir.atlasdb.keyvalue.cassandra.RangeLoader::<init>(com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.TracingQueryRunner, ===com.palantir.atlasdb.keyvalue.cassandra.ReadConsistencyProvider===,\
+        \ java.util.function.Function<java.util.Map<com.palantir.atlasdb.keyvalue.api.Cell,\
+        \ com.palantir.atlasdb.keyvalue.api.Value>, com.palantir.atlasdb.keyvalue.cassandra.ResultsExtractor<com.palantir.atlasdb.keyvalue.api.Value>>)"
+      justification: "Reuse notLatestVisibleValueCellFilterCounter"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void com.palantir.atlasdb.keyvalue.cassandra.RangeLoader::<init>(com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.TracingQueryRunner, com.palantir.atlasdb.util.MetricsManager,\
+        \ ===com.palantir.atlasdb.keyvalue.cassandra.ReadConsistencyProvider===)"
+      new: "parameter void com.palantir.atlasdb.keyvalue.cassandra.RangeLoader::<init>(com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPool,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.TracingQueryRunner, com.palantir.atlasdb.keyvalue.cassandra.ReadConsistencyProvider,\
+        \ ===java.util.function.Function<java.util.Map<com.palantir.atlasdb.keyvalue.api.Cell,\
+        \ com.palantir.atlasdb.keyvalue.api.Value>, com.palantir.atlasdb.keyvalue.cassandra.ResultsExtractor<com.palantir.atlasdb.keyvalue.api.Value>>===)"
+      justification: "Reuse notLatestVisibleValueCellFilterCounter"
+    - code: "java.method.removed"
+      old: "method com.codahale.metrics.Counter com.palantir.atlasdb.keyvalue.cassandra.ResultsExtractor<T>::getNotLatestVisibleValueCellFilterCounter(java.lang.Class<?>)"
+      justification: "Reuse notLatestVisibleValueCellFilterCounter"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServices.java
@@ -28,7 +28,6 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.table.description.TableMetadata;
-import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.RunnableCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.common.visitor.Visitor;
@@ -49,6 +48,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.Column;
@@ -408,11 +408,11 @@ public final class CassandraKeyValueServices {
 
     static class StartTsResultsCollector implements ThreadSafeResultVisitor {
         private final Map<Cell, Value> collectedResults = new ConcurrentHashMap<>();
-        private final ValueExtractor extractor;
+        private final ResultsExtractor<Value> extractor;
         private final long startTs;
 
-        StartTsResultsCollector(MetricsManager metricsManager, long startTs) {
-            this.extractor = new ValueExtractor(metricsManager, collectedResults);
+        StartTsResultsCollector(long startTs, Function<Map<Cell, Value>, ResultsExtractor<Value>> extractorFactory) {
+            this.extractor = extractorFactory.apply(collectedResults);
             this.startTs = startTs;
         }
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ResultsExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ResultsExtractor.java
@@ -15,8 +15,6 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import com.codahale.metrics.Counter;
-import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
@@ -109,10 +107,4 @@ public abstract class ResultsExtractor<T> {
             long startTs, ColumnSelection selection, byte[] row, byte[] col, byte[] val, long ts);
 
     public abstract Map<Cell, T> asMap();
-
-    protected Counter getNotLatestVisibleValueCellFilterCounter(Class<?> clazz) {
-        // TODO(hsaraogi): add table names as a tag
-        return metricsManager.registerOrGetCounter(
-                clazz, AtlasDbMetricNames.CellFilterMetrics.NOT_LATEST_VISIBLE_VALUE);
-    }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ValueExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ValueExtractor.java
@@ -21,21 +21,17 @@ import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.tracing.TraceStatistics;
 import com.palantir.atlasdb.util.MetricsManager;
-import java.util.HashMap;
 import java.util.Map;
 
 class ValueExtractor extends ResultsExtractor<Value> {
     private final Map<Cell, Value> collector;
-    private final Counter notLatestVisibleValueCellFilterCounter =
-            getNotLatestVisibleValueCellFilterCounter(ValueExtractor.class);
+    private final Counter notLatestVisibleValueCellFilterCounter;
 
-    ValueExtractor(MetricsManager metricsManager, Map<Cell, Value> collector) {
+    ValueExtractor(
+            MetricsManager metricsManager, Map<Cell, Value> collector, Counter notLatestVisibleValueCellFilterCounter) {
         super(metricsManager);
         this.collector = collector;
-    }
-
-    static ValueExtractor create(MetricsManager metricsManager) {
-        return new ValueExtractor(metricsManager, new HashMap<>());
+        this.notLatestVisibleValueCellFilterCounter = notLatestVisibleValueCellFilterCounter;
     }
 
     @Override

--- a/changelog/@unreleased/pr-6677.v2.yml
+++ b/changelog/@unreleased/pr-6677.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: "Reuse notLatestVisibleValueCellFilterCounter \n\nAvoid expensive metric
+    name computation for each value extraction by\nregistering the notLatestVisibleValueCellFilterCounter
+    once and reusing\nit throughout the lifetime.\n\nNote that this includes several
+    internal API changes; however, these\nshould not be an issue for any known AtlasDB
+    consumers.\n\nCellLoader.loadWithTs minimizes unobserved tracing overhead"
+  links:
+  - https://github.com/palantir/atlasdb/pull/6677


### PR DESCRIPTION
## General
**Before this PR**:

While reviewing JFRs from high volume AtlasDB service 🎿 ⛰️ , observed significant allocations from metric name lookup during instantiation of Cassandra result extractors. This counter metric should be registered once and injected into the `CassandraKeyValueServiceImpl` and reused for all result extractors created from that `CassandraKeyValueService`.

https://github.com/palantir/atlasdb/blob/4e050a9cb4f8f2b45b8b700df082f442d2fec694/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ResultsExtractor.java#L113-L117

https://github.com/palantir/atlasdb/blob/4e050a9cb4f8f2b45b8b700df082f442d2fec694/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ValueExtractor.java#L27-L35

Similarly, there are some expensive allocations in `CellLoader.loadWithTs` for tracing metadata context. When specific invocations are not observable by tracing consumers, we should not pay this cost.

https://github.com/palantir/atlasdb/blob/4e050a9cb4f8f2b45b8b700df082f442d2fec694/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoader.java#L98-L108



**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Reuse notLatestVisibleValueCellFilterCounter 

Avoid expensive metric name computation for each value extraction by
registering the notLatestVisibleValueCellFilterCounter once and reusing
it throughout the lifetime.

Note that this includes several internal API changes; however, these
should not be an issue for any known AtlasDB consumers.

CellLoader.loadWithTs minimizes unobserved tracing overhead

==COMMIT_MSG==

**Priority**: P1


**Concerns / possible downsides (what feedback would you like?)**:
Note that this includes several internal API changes; however, these should not be an issue for any known AtlasDB consumers.


**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
