### PR TITLE
unwind dummy leaderconfig being passed around

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -152,3 +152,24 @@ acceptedBreaks:
     - code: "java.method.removed"
       old: "method com.codahale.metrics.Counter com.palantir.atlasdb.keyvalue.cassandra.ResultsExtractor<T>::getNotLatestVisibleValueCellFilterCounter(java.lang.Class<?>)"
       justification: "Reuse notLatestVisibleValueCellFilterCounter"
+  "0.900.0":
+    com.palantir.atlasdb:atlasdb-api:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method com.palantir.atlasdb.keyvalue.api.KeyValueService com.palantir.atlasdb.spi.AtlasDbFactory::createRawKeyValueService(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.spi.KeyValueServiceConfig, com.palantir.refreshable.Refreshable<java.util.Optional<com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig>>,\
+        \ java.util.Optional<com.palantir.atlasdb.config.LeaderConfig>, java.util.Optional<java.lang.String>,\
+        \ java.util.function.LongSupplier, boolean)"
+      new: "method com.palantir.atlasdb.keyvalue.api.KeyValueService com.palantir.atlasdb.spi.AtlasDbFactory::createRawKeyValueService(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.spi.KeyValueServiceConfig, com.palantir.refreshable.Refreshable<java.util.Optional<com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig>>,\
+        \ java.util.Optional<java.lang.String>, java.util.function.LongSupplier, boolean)"
+      justification: "all usage or implementations of the two broken methods are entirely\
+        \ at compile time of the consumer or within this repo itself"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method com.palantir.atlasdb.keyvalue.api.KeyValueService com.palantir.atlasdb.timestamp.DbTimeLockFactory::createRawKeyValueService(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.spi.KeyValueServiceConfig, com.palantir.refreshable.Refreshable<java.util.Optional<com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig>>,\
+        \ com.palantir.atlasdb.config.LeaderConfig, boolean)"
+      new: "method com.palantir.atlasdb.keyvalue.api.KeyValueService com.palantir.atlasdb.timestamp.DbTimeLockFactory::createRawKeyValueService(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.spi.KeyValueServiceConfig, com.palantir.refreshable.Refreshable<java.util.Optional<com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig>>,\
+        \ boolean)"
+      justification: "all usage or implementations of the two broken methods are entirely\
+        \ at compile time of the consumer or within this repo itself"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -173,3 +173,13 @@ acceptedBreaks:
         \ boolean)"
       justification: "all usage or implementations of the two broken methods are entirely\
         \ at compile time of the consumer or within this repo itself"
+    com.palantir.atlasdb:atlasdb-cassandra:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method com.palantir.atlasdb.keyvalue.api.KeyValueService com.palantir.atlasdb.cassandra.CassandraAtlasDbFactory::createRawKeyValueService(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.spi.KeyValueServiceConfig, com.palantir.refreshable.Refreshable<java.util.Optional<com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig>>,\
+        \ java.util.Optional<com.palantir.atlasdb.config.LeaderConfig>, java.util.Optional<java.lang.String>,\
+        \ java.util.function.LongSupplier, boolean)"
+      new: "method com.palantir.atlasdb.keyvalue.api.KeyValueService com.palantir.atlasdb.cassandra.CassandraAtlasDbFactory::createRawKeyValueService(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.spi.KeyValueServiceConfig, com.palantir.refreshable.Refreshable<java.util.Optional<com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig>>,\
+        \ java.util.Optional<java.lang.String>, java.util.function.LongSupplier, boolean)"
+      justification: "will only be a compile break at worst for users and consumers"

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.atlasdb.spi;
 
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -44,7 +43,6 @@ public interface AtlasDbFactory {
      *
      * @param config Configuration file.
      * @param runtimeConfig Runtime configuration file.
-     * @param leaderConfig If the implementation supports it, the optional leader configuration.
      * @param namespace If the implementation supports it, this is the namespace to use when the namespace in config is
      * absent. If both are present, they must match.
      * @param freshTimestampSource If present, a source of fresh timestamps, which may be relevant for some KVS
@@ -57,7 +55,6 @@ public interface AtlasDbFactory {
             MetricsManager metricsManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            Optional<LeaderConfig> leaderConfig,
             Optional<String> namespace,
             LongSupplier freshTimestampSource,
             boolean initializeAsync);

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.timestamp;
 
 import com.palantir.atlasdb.config.DbTimestampCreationSetting;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeriesProvider;
@@ -40,7 +39,6 @@ public interface DbTimeLockFactory {
             MetricsManager metricManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            LeaderConfig leaderConfig,
             boolean initializeAsync);
 
     ManagedTimestampService createManagedTimestampService(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.cassandra;
 
 import com.google.auto.service.AutoService;
 import com.palantir.atlasdb.AtlasDbConstants;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
@@ -48,7 +47,6 @@ public class CassandraAtlasDbFactory implements AtlasDbFactory {
             MetricsManager metricsManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            Optional<LeaderConfig> unused,
             Optional<String> namespace,
             LongSupplier freshTimestampSource,
             boolean initializeAsync) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -366,7 +366,6 @@ public abstract class TransactionManagers {
                 metricsManager,
                 installConfig,
                 runtime.map(AtlasDbRuntimeConfig::keyValueService),
-                config().leader(),
                 config().namespace(),
                 Optional.empty(),
                 config().initializeAsync(),

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.memory;
 
 import com.google.auto.service.AutoService;
 import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
@@ -57,7 +56,6 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
      *
      * @param config Configuration file.
      * @param runtimeConfig unused.
-     * @param leaderConfig unused.
      * @param unused unused.
      * @param unusedLongSupplier unused.
      * @param initializeAsync unused. Async initialization has not been implemented and is not propagated.
@@ -68,7 +66,6 @@ public class InMemoryAtlasDbFactory implements AtlasDbFactory {
             MetricsManager metricsManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            Optional<LeaderConfig> leaderConfig,
             Optional<String> unused,
             LongSupplier unusedLongSupplier,
             boolean initializeAsync) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/memory/InMemoryDbTimeLockFactory.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/memory/InMemoryDbTimeLockFactory.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.memory;
 
 import com.google.auto.service.AutoService;
 import com.palantir.atlasdb.config.DbTimestampCreationSetting;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeries;
@@ -49,7 +48,6 @@ public class InMemoryDbTimeLockFactory implements DbTimeLockFactory {
             MetricsManager metricManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            LeaderConfig leaderConfig,
             boolean _initializeAsync) {
         return new InMemoryKeyValueService(true);
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedAtlasDbFactory.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedAtlasDbFactory.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.factory;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.Lists;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
@@ -62,7 +61,6 @@ public class AutoServiceAnnotatedAtlasDbFactory implements AtlasDbFactory {
             MetricsManager metricsManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            Optional<LeaderConfig> leaderConfig,
             Optional<String> unused,
             LongSupplier unusedLongSupplier,
             boolean initializeAsync) {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.mock;
 
 import com.palantir.atlasdb.AtlasDbConstants;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceConfigHelper;
@@ -36,7 +35,6 @@ public class ServiceDiscoveringAtlasSupplierTest {
     private final KeyValueServiceConfigHelper kvsConfig = () -> AutoServiceAnnotatedAtlasDbFactory.TYPE;
     private final KeyValueServiceConfigHelper invalidKvsConfig = () -> "should not be found kvs";
     private final AtlasDbFactory delegate = new AutoServiceAnnotatedAtlasDbFactory();
-    private final Optional<LeaderConfig> leaderConfig = Optional.of(mock(LeaderConfig.class));
     private final MetricsManager metrics = MetricsManagers.createForTests();
 
     @Test
@@ -49,7 +47,6 @@ public class ServiceDiscoveringAtlasSupplierTest {
                         metrics,
                         kvsConfig,
                         Refreshable.only(Optional.empty()),
-                        leaderConfig,
                         Optional.empty(),
                         AtlasDbFactory.THROWING_FRESH_TIMESTAMP_SOURCE,
                         AtlasDbFactory.DEFAULT_INITIALIZE_ASYNC));
@@ -94,7 +91,6 @@ public class ServiceDiscoveringAtlasSupplierTest {
                 metrics,
                 providedKvsConfig,
                 Refreshable.only(Optional.empty()),
-                leaderConfig,
                 Optional.empty(),
                 Optional.empty(),
                 AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC,

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactory.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactory.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.memory;
 
 import com.google.auto.service.AutoService;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.AsyncInitializeableInMemoryKvs;
@@ -46,7 +45,6 @@ public class InMemoryAsyncAtlasDbFactory implements AtlasDbFactory {
             MetricsManager unusedMetricsManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> unusedRuntimeConfig,
-            Optional<LeaderConfig> unusedLeaderConfig,
             Optional<String> unused,
             LongSupplier unusedLongSupplier,
             boolean initializeAsync) {

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactoryTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactoryTest.java
@@ -80,7 +80,6 @@ public class InMemoryAsyncAtlasDbFactoryTest {
                 new InMemoryAsyncAtlasDbConfig(eventuallySucceed),
                 Refreshable.only(Optional.empty()),
                 Optional.empty(),
-                Optional.empty(),
                 null,
                 initializeAsync);
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactoryTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactoryTest.java
@@ -59,12 +59,6 @@ public class InMemoryAtlasDbFactoryTest {
 
     private KeyValueService createRawKeyValueService(boolean initializeAsync) {
         return factory.createRawKeyValueService(
-                null,
-                null,
-                Refreshable.only(Optional.empty()),
-                Optional.empty(),
-                Optional.empty(),
-                null,
-                initializeAsync);
+                null, null, Refreshable.only(Optional.empty()), Optional.empty(), null, initializeAsync);
     }
 }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java
@@ -16,7 +16,6 @@
 package com.palantir.atlasdb.containers;
 
 import com.datastax.driver.core.Cluster;
-import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CqlCapableConfig;
@@ -24,8 +23,6 @@ import com.palantir.atlasdb.cassandra.ImmutableCassandraCredentialsConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.cassandra.ImmutableCqlCapableConfig;
-import com.palantir.atlasdb.config.ImmutableLeaderConfig;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueService;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
 import com.palantir.atlasdb.keyvalue.cassandra.async.DefaultCassandraAsyncKeyValueServiceFactory;
@@ -37,7 +34,6 @@ import com.palantir.refreshable.Refreshable;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -48,13 +44,6 @@ public class CassandraContainer extends Container {
     static final String PASSWORD = "cassandra";
     private static final String CONTAINER_NAME = "cassandra";
     private static final String THROWAWAY_CONTAINER_NAME = "cassandra2";
-
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    static final Optional<LeaderConfig> LEADER_CONFIG = Optional.of(ImmutableLeaderConfig.builder()
-            .quorumSize(1)
-            .localServer("localhost")
-            .leaders(ImmutableSet.of("localhost"))
-            .build());
 
     private final CassandraKeyValueServiceConfig config;
     private final String dockerComposeFile;

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfig.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/ServicesConfig.java
@@ -46,7 +46,6 @@ public abstract class ServicesConfig {
                 metrics,
                 atlasDbConfig().keyValueService(),
                 Refreshable.only(atlasDbRuntimeConfig().keyValueService()),
-                atlasDbConfig().leader(),
                 atlasDbConfig().namespace(),
                 Optional.empty(),
                 atlasDbConfig().initializeAsync(),

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbTimestampStoreInvalidatorCreationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbTimestampStoreInvalidatorCreationTest.java
@@ -19,13 +19,11 @@ package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
 import static com.palantir.atlasdb.spi.AtlasDbFactory.NO_OP_FAST_FORWARD_TIMESTAMP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.SimpleTimeLimiter;
 import com.google.common.util.concurrent.TimeLimiter;
 import com.palantir.atlasdb.AtlasDbConstants;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.factory.ServiceDiscoveringAtlasSupplier;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.InvalidationRunner;
@@ -49,7 +47,6 @@ import org.junit.Test;
 
 public class DbTimestampStoreInvalidatorCreationTest {
     private final MetricsManager metrics = MetricsManagers.createForTests();
-    private final Optional<LeaderConfig> leaderConfig = Optional.of(mock(LeaderConfig.class));
 
     @ClassRule
     public static final TestResourceManager TRM = new TestResourceManager(DbKvsPostgresTestSuite::createKvs);
@@ -124,7 +121,6 @@ public class DbTimestampStoreInvalidatorCreationTest {
                 metrics,
                 providedKvsConfig,
                 Refreshable.only(Optional.empty()),
-                leaderConfig,
                 Optional.empty(),
                 tableReference,
                 AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC,

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.keyvalue.dbkvs;
 
 import com.google.auto.service.AutoService;
 import com.palantir.atlasdb.AtlasDbConstants;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionManagerAwareDbKvs;
@@ -53,7 +52,6 @@ public class DbAtlasDbFactory implements AtlasDbFactory {
      *
      * @param config Configuration file.
      * @param runtimeConfig unused.
-     * @param leaderConfig unused.
      * @param namespace unused.
      * @param unusedLongSupplier unused.
      * @param initializeAsync initialize asynchronously
@@ -64,7 +62,6 @@ public class DbAtlasDbFactory implements AtlasDbFactory {
             MetricsManager metricsManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            Optional<LeaderConfig> leaderConfig,
             Optional<String> namespace,
             LongSupplier unusedLongSupplier,
             boolean initializeAsync) {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/RelationalDbTimeLockFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/RelationalDbTimeLockFactory.java
@@ -19,7 +19,6 @@ package com.palantir.atlasdb.keyvalue.dbkvs;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Preconditions;
 import com.palantir.atlasdb.config.DbTimestampCreationSetting;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeries;
@@ -54,13 +53,11 @@ public class RelationalDbTimeLockFactory implements DbTimeLockFactory {
             MetricsManager metricsManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            LeaderConfig leaderConfig,
             boolean initializeAsync) {
         return delegate.createRawKeyValueService(
                 metricsManager,
                 config,
                 runtimeConfig,
-                Optional.of(leaderConfig),
                 Optional.empty(), // This refers to an AtlasDB namespace - we use the config to talk to the db
                 AtlasDbFactory.THROWING_FRESH_TIMESTAMP_SOURCE, // This is how we give out timestamps!
                 initializeAsync);

--- a/timelock-agent/src/main/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplier.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplier.java
@@ -19,7 +19,6 @@ package com.palantir.timelock;
 import com.google.common.base.Suppliers;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.config.DbTimestampCreationSetting;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.factory.AtlasDbServiceDiscovery;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -49,11 +48,10 @@ public class ServiceDiscoveringDatabaseTimeLockSupplier implements AutoCloseable
             MetricsManager metricsManager,
             KeyValueServiceConfig config,
             Refreshable<Optional<KeyValueServiceRuntimeConfig>> runtimeConfig,
-            LeaderConfig leaderConfig,
             boolean initializeAsync) {
         DbTimeLockFactory dbTimeLockFactory = AtlasDbServiceDiscovery.createDbTimeLockFactoryOfCorrectType(config);
-        keyValueService = Suppliers.memoize(() -> dbTimeLockFactory.createRawKeyValueService(
-                metricsManager, config, runtimeConfig, leaderConfig, initializeAsync));
+        keyValueService = Suppliers.memoize(() ->
+                dbTimeLockFactory.createRawKeyValueService(metricsManager, config, runtimeConfig, initializeAsync));
         timestampServiceFactory = creationSetting -> dbTimeLockFactory.createManagedTimestampService(
                 keyValueService.get(), creationSetting, initializeAsync);
         timestampSeriesProvider = tableRef ->

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/DbBoundTimestampCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/DbBoundTimestampCreator.java
@@ -18,7 +18,6 @@ package com.palantir.timelock.paxos;
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.config.DbTimestampCreationSetting;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeries;
 import com.palantir.paxos.Client;
 import com.palantir.timelock.ServiceDiscoveringDatabaseTimeLockSupplier;
@@ -35,7 +34,7 @@ public final class DbBoundTimestampCreator implements TimestampCreator {
     }
 
     @Override
-    public Supplier<ManagedTimestampService> createTimestampService(Client client, LeaderConfig leaderConfig) {
+    public Supplier<ManagedTimestampService> createTimestampService(Client client) {
         return () -> serviceDiscoveringDatabaseTimeLockSupplier.getManagedTimestampService(
                 getTimestampCreationParameters(client));
     }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosTimestampCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosTimestampCreator.java
@@ -15,7 +15,6 @@
  */
 package com.palantir.timelock.paxos;
 
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.timelock.paxos.NetworkClientFactories;
 import com.palantir.paxos.Client;
 import com.palantir.timestamp.ManagedTimestampService;
@@ -29,7 +28,7 @@ public class PaxosTimestampCreator implements TimestampCreator {
     }
 
     @Override
-    public Supplier<ManagedTimestampService> createTimestampService(Client client, LeaderConfig unused) {
+    public Supplier<ManagedTimestampService> createTimestampService(Client client) {
         return () -> timestampServiceFactory.create(client);
     }
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimestampCreator.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimestampCreator.java
@@ -15,13 +15,12 @@
  */
 package com.palantir.timelock.paxos;
 
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.paxos.Client;
 import com.palantir.timestamp.ManagedTimestampService;
 import java.util.function.Supplier;
 
 public interface TimestampCreator extends AutoCloseable {
-    Supplier<ManagedTimestampService> createTimestampService(Client client, LeaderConfig leaderConfig);
+    Supplier<ManagedTimestampService> createTimestampService(Client client);
 
     @Override
     void close();

--- a/timelock-agent/src/test/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplierTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplierTest.java
@@ -19,11 +19,8 @@ package com.palantir.timelock;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.config.DbTimestampCreationSetting;
-import com.palantir.atlasdb.config.ImmutableLeaderConfig;
-import com.palantir.atlasdb.config.LeaderConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeries;
 import com.palantir.atlasdb.keyvalue.api.TimestampSeriesProvider;
@@ -43,15 +40,10 @@ public class ServiceDiscoveringDatabaseTimeLockSupplierTest {
 
     private final MetricsManager metricsManager = MetricsManagers.createForTests();
     private final KeyValueServiceConfig keyValueServiceConfig = new InMemoryAtlasDbConfig();
-    private final LeaderConfig leaderConfig = ImmutableLeaderConfig.builder()
-            .localServer("me")
-            .leaders(ImmutableList.of("me"))
-            .quorumSize(1)
-            .build();
 
     private final ServiceDiscoveringDatabaseTimeLockSupplier timeLockSupplier =
             new ServiceDiscoveringDatabaseTimeLockSupplier(
-                    metricsManager, keyValueServiceConfig, Refreshable.only(Optional.empty()), leaderConfig, false);
+                    metricsManager, keyValueServiceConfig, Refreshable.only(Optional.empty()), false);
 
     @Test
     public void canGetTimestampServiceForDifferentSeries() {


### PR DESCRIPTION
Attempting to break parts of #6674 into smaller self-enclosed changes. This one popped up where we just have a dummy `LeaderConfig` object we generate statically and pass around to a bunch of places but then never use...

I'm guessing the history here is that parts of some of the timelock implementation options may have used a LeaderConfig in the past but no longer do, and once we had no usage of it we forgot to rip it out of all the interfaces.

Before this change:
```
tpetracca50-mac:atlasdb tpetracca$ git grep "import com.palantir.atlasdb.config.LeaderConfig"
atlasdb-api/src/main/java/com/palantir/atlasdb/spi/AtlasDbFactory.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-api/src/main/java/com/palantir/atlasdb/timestamp/DbTimeLockFactory.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraAtlasDbFactory.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DefaultLockAndTimestampServiceFactory.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-config/src/main/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplier.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-config/src/main/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactory.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-config/src/main/java/com/palantir/atlasdb/memory/InMemoryDbTimeLockFactory.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AutoServiceAnnotatedAtlasDbFactory.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactory.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraContainer.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbTimestampStoreInvalidatorCreationTest.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/DbAtlasDbFactory.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/RelationalDbTimeLockFactory.java:import com.palantir.atlasdb.config.LeaderConfig;
timelock-agent/src/main/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplier.java:import com.palantir.atlasdb.config.LeaderConfig;
timelock-agent/src/main/java/com/palantir/timelock/paxos/DbBoundTimestampCreator.java:import com.palantir.atlasdb.config.LeaderConfig;
timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosTimestampCreator.java:import com.palantir.atlasdb.config.LeaderConfig;
timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java:import com.palantir.atlasdb.config.LeaderConfig;
timelock-agent/src/main/java/com/palantir/timelock/paxos/TimestampCreator.java:import com.palantir.atlasdb.config.LeaderConfig;
timelock-agent/src/test/java/com/palantir/timelock/ServiceDiscoveringDatabaseTimeLockSupplierTest.java:import com.palantir.atlasdb.config.LeaderConfig;
```

After this change:
```
tpetracca50-mac:atlasdb tpetracca$ git grep "import com.palantir.atlasdb.config.LeaderConfig"
atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DefaultLockAndTimestampServiceFactory.java:import com.palantir.atlasdb.config.LeaderConfig;
atlasdb-config/src/main/java/com/palantir/atlasdb/factory/Leaders.java:import com.palantir.atlasdb.config.LeaderConfig;
```

==COMMIT_MSG==
unwind dummy leaderconfig being passed around
==COMMIT_MSG==