### PR TITLE
Fix TimeLockMigrationEteTest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           root: .
           paths: [ . ]
 
-  test-suite:
+  test:
     parameters:
       suite:
         type: integer
@@ -104,12 +104,6 @@ jobs:
       - attach_workspace: { at: . }
       - run: ./gradlew --scan --profile --stacktrace --continue publishToMavenLocal
 
-  test:
-    docker: [ { image: 'busybox:1.34.1' } ]
-    resource_class: small
-    steps:
-      - run: {command: echo "Ran all required tests successfully"}
-
   deploy:
     docker:
       - image: cimg/openjdk:11.0.10-node
@@ -149,29 +143,11 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-suite:
-          requires: [build]
-          matrix:
-            alias: test-no-tl
-            parameters:
-              # intentionally excluding 13 (TimeLock migration ETE test) from this collection
-              suite: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14]
-          filters:
-            tags:
-              only: /.*/
-      - test-suite:
-          requires: [build]
-          matrix:
-            alias: test-tl
-            parameters:
-              suite: [13]
-          filters:
-            branches:
-              only: /(tlmete.*|develop)/
-            tags:
-              only: /.*/
       - test:
-          requires: [test-tl, test-no-tl]
+          requires: [build]
+          matrix:
+            parameters:
+              suite: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           root: .
           paths: [ . ]
 
-  test:
+  test-suite:
     parameters:
       suite:
         type: integer
@@ -104,6 +104,12 @@ jobs:
       - attach_workspace: { at: . }
       - run: ./gradlew --scan --profile --stacktrace --continue publishToMavenLocal
 
+  test:
+    docker: [ { image: 'busybox:1.34.1' } ]
+    resource_class: small
+    steps:
+      - run: {command: echo "Ran all required tests successfully"}
+
   deploy:
     docker:
       - image: cimg/openjdk:11.0.10-node
@@ -143,11 +149,29 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test:
+      - test-suite:
           requires: [build]
           matrix:
+            alias: test-no-tl
             parameters:
-              suite: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+              # intentionally excluding 13 (TimeLock migration ETE test) from this collection
+              suite: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14]
+          filters:
+            tags:
+              only: /.*/
+      - test-suite:
+          requires: [build]
+          matrix:
+            alias: test-tl
+            parameters:
+              suite: [13]
+          filters:
+            branches:
+              only: /(tlmete.*|develop)/
+            tags:
+              only: /.*/
+      - test:
+          requires: [test-tl, test-no-tl]
           filters:
             tags:
               only: /.*/

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/TimeLockMigrationEteTest.java
@@ -100,6 +100,7 @@ public class TimeLockMigrationEteTest {
             SslConfiguration.of(Paths.get("var/security/trustStore.jks"));
     public static final TrustContext TRUST_CONTEXT = SslSocketFactories.createTrustContext(SSL_CONFIGURATION);
 
+    private static final long ID = 1L;
     private static final Todo TODO = ImmutableTodo.of("some stuff to do");
     private static final Todo TODO_2 = ImmutableTodo.of("more stuff to do");
     private static final Todo TODO_3 = ImmutableTodo.of("even more stuff to do");
@@ -126,17 +127,14 @@ public class TimeLockMigrationEteTest {
     }
 
     @Test
-    public void automaticallyMigratesTimestampsAndFailsOnRestart() throws Exception {
-        TimestampService timestampClient = createEteClientFor(TimestampService.class);
+    public void automaticallyMigratesTimestampsAndFailsOnRestart() {
         TodoResource todoClient = createEteClientFor(TodoResource.class);
 
-        todoClient.addTodo(TODO);
+        long embeddedTimestamp = todoClient.addTodoWithIdAndReturnTimestamp(ID, TODO);
         softAssertions
                 .assertThat(todoClient.getTodoList())
                 .as("contains one todo pre-migration")
                 .contains(TODO);
-
-        long embeddedTimestamp = timestampClient.getFreshTimestamp();
         softAssertions
                 .assertThat(embeddedTimestamp)
                 .as("can get a timestamp before migration")


### PR DESCRIPTION
After merging https://github.com/palantir/atlasdb/pull/6673 `TimeLockMigrationEteTest` is failing on `develop`. This wasn't cause in the PR because [this test is only run on `develop`](https://github.com/palantir/atlasdb/blob/9fbe798096c9c15531e10bcd50b25f622037741a/.circleci/config.yml#L152-L172).