### PR TITLE
fix: fix TransactionManagers ABI break

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -193,3 +193,59 @@ acceptedBreaks:
       new: "method void com.palantir.atlasdb.transaction.api.Transaction::putWithMetadata(com.palantir.atlasdb.keyvalue.api.TableReference,\
         \ java.util.Map<com.palantir.atlasdb.keyvalue.api.Cell, com.palantir.atlasdb.transaction.api.ValueAndChangeMetadata>)"
       justification: "Adding new metadata interface methods"
+  "0.909.0":
+    com.palantir.atlasdb:atlasdb-config:
+    - code: "java.class.removed"
+      old: "class com.palantir.atlasdb.factory.ImmutableLocalPaxosServices"
+      justification: "None of the impacted classes are used or inherited from any\
+        \ other library or product"
+    - code: "java.class.removed"
+      old: "class com.palantir.atlasdb.factory.ImmutableRemotePaxosServerSpec"
+      justification: "None of the impacted classes are used or inherited from any\
+        \ other library or product"
+    - code: "java.class.removed"
+      old: "class com.palantir.atlasdb.factory.Leaders"
+      justification: "None of the impacted classes are used or inherited from any\
+        \ other library or product"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void com.palantir.atlasdb.factory.DefaultLockAndTimestampServiceFactory::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.AtlasDbConfig, com.palantir.refreshable.Refreshable<com.palantir.atlasdb.config.AtlasDbRuntimeConfig>,\
+        \ java.util.function.Consumer<java.lang.Object>, java.util.function.Supplier<com.palantir.lock.LockService>,\
+        \ java.util.function.Supplier<com.palantir.timestamp.ManagedTimestampService>,\
+        \ com.palantir.timestamp.TimestampStoreInvalidator, com.palantir.conjure.java.api.config.service.UserAgent,\
+        \ java.util.Optional<com.palantir.atlasdb.debug.LockDiagnosticComponents>,\
+        \ com.palantir.dialogue.clients.DialogueClients.ReloadingFactory, java.util.Optional<com.palantir.lock.client.metrics.TimeLockFeedbackBackgroundTask>,\
+        \ java.util.Optional<com.palantir.atlasdb.config.TimeLockRequestBatcherProviders>,\
+        \ java.util.Set<com.palantir.atlasdb.table.description.Schema>)"
+      new: "method void com.palantir.atlasdb.factory.DefaultLockAndTimestampServiceFactory::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.AtlasDbConfig, com.palantir.refreshable.Refreshable<com.palantir.atlasdb.config.AtlasDbRuntimeConfig>,\
+        \ java.util.function.Supplier<com.palantir.lock.LockService>, java.util.function.Supplier<com.palantir.timestamp.ManagedTimestampService>,\
+        \ com.palantir.timestamp.TimestampStoreInvalidator, com.palantir.conjure.java.api.config.service.UserAgent,\
+        \ java.util.Optional<com.palantir.atlasdb.debug.LockDiagnosticComponents>,\
+        \ com.palantir.dialogue.clients.DialogueClients.ReloadingFactory, java.util.Optional<com.palantir.lock.client.metrics.TimeLockFeedbackBackgroundTask>,\
+        \ java.util.Optional<com.palantir.atlasdb.config.TimeLockRequestBatcherProviders>,\
+        \ java.util.Set<com.palantir.atlasdb.table.description.Schema>)"
+      justification: "None of the impacted classes are used or inherited from any\
+        \ other library or product"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void com.palantir.atlasdb.factory.DefaultLockAndTimestampServiceFactory::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.AtlasDbConfig, com.palantir.refreshable.Refreshable<com.palantir.atlasdb.config.AtlasDbRuntimeConfig>,\
+        \ java.util.function.Consumer<java.lang.Object>, java.util.function.Supplier<com.palantir.lock.LockService>,\
+        \ java.util.function.Supplier<com.palantir.timestamp.ManagedTimestampService>,\
+        \ com.palantir.timestamp.TimestampStoreInvalidator, com.palantir.conjure.java.api.config.service.UserAgent,\
+        \ java.util.Optional<com.palantir.atlasdb.debug.LockDiagnosticComponents>,\
+        \ com.palantir.dialogue.clients.DialogueClients.ReloadingFactory, java.util.Optional<com.palantir.lock.client.metrics.TimeLockFeedbackBackgroundTask>,\
+        \ java.util.Optional<com.palantir.atlasdb.config.TimeLockRequestBatcherProviders>,\
+        \ java.util.Set<com.palantir.atlasdb.table.description.Schema>, java.util.function.Function<com.palantir.lock.v2.TimelockService,\
+        \ com.palantir.lock.client.TimeLockClient>)"
+      new: "method void com.palantir.atlasdb.factory.DefaultLockAndTimestampServiceFactory::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.AtlasDbConfig, com.palantir.refreshable.Refreshable<com.palantir.atlasdb.config.AtlasDbRuntimeConfig>,\
+        \ java.util.function.Supplier<com.palantir.lock.LockService>, java.util.function.Supplier<com.palantir.timestamp.ManagedTimestampService>,\
+        \ com.palantir.timestamp.TimestampStoreInvalidator, com.palantir.conjure.java.api.config.service.UserAgent,\
+        \ java.util.Optional<com.palantir.atlasdb.debug.LockDiagnosticComponents>,\
+        \ com.palantir.dialogue.clients.DialogueClients.ReloadingFactory, java.util.Optional<com.palantir.lock.client.metrics.TimeLockFeedbackBackgroundTask>,\
+        \ java.util.Optional<com.palantir.atlasdb.config.TimeLockRequestBatcherProviders>,\
+        \ java.util.Set<com.palantir.atlasdb.table.description.Schema>, java.util.function.Function<com.palantir.lock.v2.TimelockService,\
+        \ com.palantir.lock.client.TimeLockClient>)"
+      justification: "None of the impacted classes are used or inherited from any\
+        \ other library or product"

--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -87,3 +87,7 @@ dependencies {
     // Needed for Jersey Response-based tests
     testImplementation 'org.glassfish.jersey.core:jersey-common'
 }
+
+revapi {
+    oldVersion = '0.909.0'
+}

--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -1,4 +1,5 @@
 apply from: "../gradle/shared.gradle"
+apply plugin: 'com.palantir.revapi'
 
 dependencies {
     api project(':atlasdb-api')

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -170,11 +170,10 @@ public abstract class TransactionManagers {
     abstract Set<Schema> schemas();
 
     /**
-     * @deprecated This method is not used and should not be overriden from the default. It only exists because deleting
+     * This method is not used and should not be overriden from the default. It only exists because deleting
      * it would be an ABI break.
      */
     @Value.Default
-    @Deprecated
     Consumer<Object> registrar() {
         return resource -> {};
     }

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -169,6 +169,16 @@ public abstract class TransactionManagers {
 
     abstract Set<Schema> schemas();
 
+    /**
+     * @deprecated This method is not used and should not be overriden from the default. It only exists because deleting
+     * it would be an ABI break.
+     */
+    @Value.Default
+    @Deprecated
+    Consumer<Object> registrar() {
+        return resource -> {};
+    }
+
     @Value.Default
     LockServerOptions lockServerOptions() {
         return LockServerConfigs.DEFAULT;

--- a/changelog/@unreleased/pr-6698.v2.yml
+++ b/changelog/@unreleased/pr-6698.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: fix TransactionManagers ABI break
+  links:
+  - https://github.com/palantir/atlasdb/pull/6698


### PR DESCRIPTION
In #6674 I accidentally introduced an ABI break when I deleted the `TransactionManagers#registrar` interface method.
This both:
- fixes the break by bringing the method back
- applies revapi to `atlasdb-config` to prevent this from happening again

==COMMIT_MSG==
fix TransactionManagers ABI break
==COMMIT_MSG==
