### PR TITLE
use default revapi config

### DIFF
--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -87,7 +87,3 @@ dependencies {
     // Needed for Jersey Response-based tests
     testImplementation 'org.glassfish.jersey.core:jersey-common'
 }
-
-revapi {
-    oldVersion = '0.909.0'
-}


### PR DESCRIPTION
Now that #6698 has merged, we should use a standard rev-api config for `atlasdb-config` moving forward.

==COMMIT_MSG==
use default revapi config
==COMMIT_MSG==
