### PR TITLE
Maybe log SQLException error cause

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -35,6 +35,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.TimeZone;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -354,9 +355,15 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
                 }
             }
         } catch (PoolInitializationException e) {
+            Optional<Integer> maybeSqlErrorCode = Optional.ofNullable(e.getCause())
+                    .filter(cause -> cause instanceof SQLException)
+                    .map(cause -> (SQLException) cause)
+                    .map(SQLException::getErrorCode);
+
             log.error(
                     "Failed to initialize hikari data source",
                     SafeArg.of("connectionPoolName", connConfig.getConnectionPoolName()),
+                    SafeArg.of("causeSqlVendorErrorCode", maybeSqlErrorCode),
                     UnsafeArg.of("url", connConfig.getUrl()),
                     e);
 

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -17,8 +17,6 @@ package com.palantir.nexus.db.pool;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Streams;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -361,8 +359,9 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
         } catch (PoolInitializationException e) {
             // Intentionally ignoring suppressed exceptions
             // Keep duplicates to safeguard the full causality chain
-            List<Integer> vendorSqlErrorCodes = Streams.stream(
-                            Iterables.filter(Throwables.getCausalChain(e), SQLException.class))
+            List<Integer> vendorSqlErrorCodes = Throwables.getCausalChain(e).stream()
+                    .filter(SQLException.class::isInstance)
+                    .map(SQLException.class::cast)
                     .map(SQLException::getErrorCode)
                     .collect(Collectors.toList());
 

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/HikariCPConnectionManager.java
@@ -366,7 +366,8 @@ public class HikariCPConnectionManager extends BaseConnectionManager {
                     .collect(Collectors.toList());
 
             log.error(
-                    "Failed to initialize hikari data source",
+                    "Failed to initialize hikari data source. Please be aware that vendor SQL error codes,"
+                            + " particularly for Postgres, can be unreliable.",
                     SafeArg.of("connectionPoolName", connConfig.getConnectionPoolName()),
                     SafeArg.of("vendorSqlErrorCodes", vendorSqlErrorCodes),
                     UnsafeArg.of("url", connConfig.getUrl()),


### PR DESCRIPTION
## General
**Before this PR**:
Failures at the level of the Hikari data source manifest sometimes as `PoolInitializationException` exceptions. Important information for debugging often exists at the level of the cause exception which can be of type `? extends SQLException`. However, those exceptions have their messages automatically considered unsafe in most situations. This leads into possibly O(days) debugging times.
**After this PR**:
Log the vendor SQLException error code if the cause of Hikari initialization failure is of that type.
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P2
**Concerns / possible downsides (what feedback would you like?)**:
Hard to validate this in the field
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Ywa
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
N/A
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Logs on failure are more useful when the cause is a SQLException
**Has the safety of all log arguments been decided correctly?**:
Yes
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Logs on failure do not include more useful information when the cause is a SQLException
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Recall and rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:
Small
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
Small
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
