### PR TITLE
Acquire one lock per client for paxos

### DIFF
--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceMockingTest.java
@@ -37,6 +37,8 @@ public class PersistentTimestampServiceMockingTest {
 
     private static final TimestampRange RANGE = TimestampRange.createInclusiveRange(100, 200);
 
+    private final Object clientLock = new Object();
+
     private PersistentTimestamp timestamp = mock(PersistentTimestamp.class);
     private PersistentTimestampServiceImpl timestampService = new PersistentTimestampServiceImpl(timestamp);
 
@@ -86,7 +88,7 @@ public class PersistentTimestampServiceMockingTest {
         when(timestampBoundStore.getUpperLimit()).thenReturn(INITIAL_TIMESTAMP);
 
         PersistentTimestampService persistentTimestampService =
-                PersistentTimestampServiceImpl.create(timestampBoundStore);
+                PersistentTimestampServiceImpl.create(timestampBoundStore, () -> clientLock);
         long freshTimestamp = persistentTimestampService.getFreshTimestamp();
 
         assertThat(freshTimestamp).isGreaterThan(INITIAL_TIMESTAMP);

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTests.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentTimestampServiceTests.java
@@ -40,8 +40,9 @@ public class PersistentTimestampServiceTests extends AbstractTimestampServiceTes
 
     private PersistentTimestampService getSingletonTimestampService() {
         if (timestampBoundStore == null || persistentTimestampService == null) {
+            Object clientLock = new Object();
             timestampBoundStore = new InMemoryTimestampBoundStore();
-            persistentTimestampService = PersistentTimestampServiceImpl.create(timestampBoundStore);
+            persistentTimestampService = PersistentTimestampServiceImpl.create(timestampBoundStore, () -> clientLock);
         }
         return persistentTimestampService;
     }

--- a/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentUpperLimitTest.java
+++ b/timestamp-impl/src/test/java/com/palantir/timestamp/PersistentUpperLimitTest.java
@@ -16,14 +16,22 @@
 package com.palantir.timestamp;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,21 +40,28 @@ public class PersistentUpperLimitTest {
     private static final long INITIAL_UPPER_LIMIT = 10L;
     private static final long BUFFER = PersistentUpperLimit.BUFFER;
 
+    private final Object lock = new Object();
+
+    private final ExecutorService taskExecutor = Executors.newCachedThreadPool();
+
     private TimestampBoundStore boundStore;
     private PersistentUpperLimit upperLimit;
+    private Supplier<Object> clientLock;
 
     @Before
     public void setup() {
         boundStore = mock(TimestampBoundStore.class);
         when(boundStore.getUpperLimit()).thenReturn(INITIAL_UPPER_LIMIT);
-        upperLimit = new PersistentUpperLimit(boundStore);
+        clientLock = mock(Supplier.class);
+        when(clientLock.get()).thenReturn(lock);
+        upperLimit = new PersistentUpperLimit(boundStore, clientLock);
     }
 
     @Test
     public void shouldStartWithTheCurrentStoredLimit() {
         when(boundStore.getUpperLimit()).thenReturn(TIMESTAMP);
 
-        PersistentUpperLimit brandNewUpperLimit = new PersistentUpperLimit(boundStore);
+        PersistentUpperLimit brandNewUpperLimit = new PersistentUpperLimit(boundStore, () -> lock);
 
         assertThat(brandNewUpperLimit.get()).isEqualTo(TIMESTAMP);
     }
@@ -110,5 +125,45 @@ public class PersistentUpperLimitTest {
         }
 
         assertThat(upperLimit.get()).isEqualTo(INITIAL_UPPER_LIMIT);
+    }
+
+    @Test
+    public void increaseToAtLeastAcquiresLock() {
+        upperLimit.increaseToAtLeast(TIMESTAMP);
+        verify(clientLock, times(1)).get();
+    }
+
+    /**
+     * Force the first thread to run first and then have it wait to obtain the permit from the second thread. The
+     * second thread will not be able to release the permit, as the first thread is holding the lock.
+     */
+    @Test
+    public void increaseToAtLeastIsThreadSafe() throws InterruptedException {
+        Semaphore taskRunningSemaphore = new Semaphore(0);
+        Semaphore secondThreadSemaphore = new Semaphore(0);
+        doAnswer(invocation -> {
+                    taskRunningSemaphore.release();
+                    secondThreadSemaphore.tryAcquire(1L, TimeUnit.SECONDS);
+                    return null;
+                })
+                .when(boundStore)
+                .storeUpperLimit(anyLong());
+        TimestampBoundStore secondBoundStore = mock(TimestampBoundStore.class);
+        doAnswer(invocation -> {
+                    secondThreadSemaphore.release();
+                    return null;
+                })
+                .when(secondBoundStore)
+                .storeUpperLimit(anyLong());
+        PersistentUpperLimit identicalUpperLimit = new PersistentUpperLimit(secondBoundStore, clientLock);
+        Future<?> firstTask = taskExecutor.submit(() -> upperLimit.increaseToAtLeast(TIMESTAMP));
+        taskRunningSemaphore.tryAcquire(1, TimeUnit.SECONDS);
+        Future<?> secondTask = taskExecutor.submit(() -> identicalUpperLimit.increaseToAtLeast(TIMESTAMP));
+        assertThatCode(() -> firstTask.get(1L, TimeUnit.SECONDS)).doesNotThrowAnyException();
+        assertThatCode(() -> secondTask.get(1L, TimeUnit.SECONDS)).doesNotThrowAnyException();
+        assertThat(secondThreadSemaphore.availablePermits())
+                .as("First thread was able to obtain a lock, which means that multiple threads were running at the "
+                        + "same time, indicating that our lock was not acquired.")
+                .isEqualTo(1);
     }
 }


### PR DESCRIPTION
## General
**Before this PR**:
As multiple instances of a class can live due to some under-the-hood shenanigans in timelock, we can contend with ourselves. We should make ourselves resilient to this case, by simply having all classes acquire the same lock for a client (namespace). 

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow only one paxos request globally per namespace. 
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
