### PR TITLE
throw only once when leadership is lost

### DIFF
--- a/changelog/@unreleased/pr-6711.v2.yml
+++ b/changelog/@unreleased/pr-6711.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Throw not current leader exception only once per instance. This should
+    prevent multiple class creations, thus preventing resource contention and resource
+    leakage.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6711

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -220,7 +220,7 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
      * PaxosAcceptor.NO_LOG_ENTRY + 1 if nothing has been proposed or accepted yet.
      *
      * @param limit the new upper limit to be stored
-     * @throws IllegalArgumentException  if trying to persist a limit smaller than the agreed limit
+     * @throws IllegalArgumentException if trying to persist a limit smaller than the agreed limit
      * @throws NotCurrentLeaderException if the timestamp limit has changed out from under us
      */
     @Override
@@ -272,9 +272,9 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
     /**
      * Checks that the PaxosValue agreed upon by a quorum of nodes in our cluster was proposed by us.
      *
-     * @param limit  the limit our node has proposed
+     * @param limit the limit our node has proposed
      * @param newSeq the sequence number for which our node has proposed the limit
-     * @param value  PaxosValue agreed upon by a quorum of nodes, for sequence number newSeq
+     * @param value PaxosValue agreed upon by a quorum of nodes, for sequence number newSeq
      * @throws NotCurrentLeaderException if the agreed timestamp bound (PaxosValue) changed under us
      */
     private void checkAgreedBoundIsOurs(long limit, long newSeq, PaxosValue value) throws NotCurrentLeaderException {
@@ -306,7 +306,7 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
      * to handle cases where users hold or do not hold monitor locks, for instance.
      *
      * @param paxosException the PaxosRoundFailureException that caused us to wait
-     * @param backoffAction  the action to take (which consumes the time, in milliseconds, to wait for)
+     * @param backoffAction the action to take (which consumes the time, in milliseconds, to wait for)
      */
     private void waitForRandomBackoff(PaxosRoundFailureException paxosException, BackoffAction backoffAction) {
         long backoffTime = getRandomBackoffTime();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -39,12 +39,10 @@ import com.palantir.paxos.PaxosValue;
 import com.palantir.timestamp.DebugLogger;
 import com.palantir.timestamp.MultipleRunningTimestampServiceError;
 import com.palantir.timestamp.TimestampBoundStore;
-
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
-
 import org.immutables.value.Value;
 
 public class PaxosTimestampBoundStore implements TimestampBoundStore {
@@ -115,14 +113,14 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
     /**
      * Obtains agreement for a given sequence number, pulling in values from previous sequence numbers
      * if needed.
-     * <p>
+     *
      * The semantics of this method are as follows:
-     * - If any learner knows that a value has already been agreed for this sequence number, return said value.
-     * - Otherwise, poll learners for the state of the previous sequence number.
-     * - If this is unavailable, the cluster must have agreed on (seq - 2), so read it and then force (seq - 1)
-     * to that value.
-     * - Finally, force agreement for seq to be the same value as that agreed for (seq - 1).
-     * <p>
+     *  - If any learner knows that a value has already been agreed for this sequence number, return said value.
+     *  - Otherwise, poll learners for the state of the previous sequence number.
+     *     - If this is unavailable, the cluster must have agreed on (seq - 2), so read it and then force (seq - 1)
+     *       to that value.
+     *  - Finally, force agreement for seq to be the same value as that agreed for (seq - 1).
+     *
      * This method has a precondition that (seq - 2) must be agreed upon; note that numbers up to and including
      * PaxosAcceptor.NO_LOG_ENTRY are always considered agreed upon.
      *
@@ -151,16 +149,16 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
      * Forces agreement to be reached for a given sequence number; if the cluster hasn't reached agreement yet,
      * attempts to propose a given value. This method only returns when a value has been agreed upon for the provided
      * sequence number (though there are no guarantees as to whether said value is proposed by this node).
-     * <p>
+     *
      * The semantics of this method are as follows:
-     * - If any learner knows that a value has already been agreed for this sequence number, return said value.
-     * - Otherwise, propose the value oldState to the cluster. This call returns the value accepted by a
-     * quorum of nodes; return that value.
-     * <p>
+     *  - If any learner knows that a value has already been agreed for this sequence number, return said value.
+     *  - Otherwise, propose the value oldState to the cluster. This call returns the value accepted by a
+     *    quorum of nodes; return that value.
+     *
      * Callers of this method that supply a null oldState are responsible for ensuring that the cluster has already
      * agreed on a value with the provided sequence number.
      *
-     * @param seq      Sequence number to obtain agreement on
+     * @param seq Sequence number to obtain agreement on
      * @param oldState Value to propose, provided no learner has learned a value for this sequence number
      * @return Sequence and bound for the given sequence number; guaranteed nonnull
      * @throws NullPointerException if oldState is null and the cluster hasn't agreed on a value for seq yet
@@ -180,7 +178,8 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
             try {
                 byte[] acceptedValue = proposer.propose(seq, oldState == null ? null : PtBytes.toBytes(oldState));
                 // propose must never return null.  We only pass in null for things we know are agreed upon already.
-                Preconditions.checkNotNull(acceptedValue, "Proposed value can't be null, but was in sequence", SafeArg.of("seq", seq));
+                Preconditions.checkNotNull(
+                        acceptedValue, "Proposed value can't be null, but was in sequence", SafeArg.of("seq", seq));
                 return ImmutableSequenceAndBound.of(seq, PtBytes.toLong(acceptedValue));
             } catch (PaxosRoundFailureException e) {
                 waitForRandomBackoff(e, Thread::sleep);

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -224,7 +224,7 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
      */
     @Override
     public synchronized void storeUpperLimit(long limit) throws MultipleRunningTimestampServiceError {
-        Preconditions.checkState(hasLostLeadership, "Cannot store upper limit as leadership has been lost.");
+        Preconditions.checkState(!hasLostLeadership, "Cannot store upper limit as leadership has been lost.");
         long newSeq = PaxosAcceptor.NO_LOG_ENTRY + 1;
         if (agreedState != null) {
             Preconditions.checkArgument(

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.timelock.paxos;
 
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,6 +35,7 @@ import com.palantir.common.remoting.ServiceNotAvailableException;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.leader.proxy.ToggleableExceptionProxy;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.paxos.Client;
 import com.palantir.paxos.PaxosAcceptor;
 import com.palantir.paxos.PaxosAcceptorNetworkClient;
@@ -253,7 +255,8 @@ public class PaxosTimestampBoundStoreTest {
         additionalStore.storeUpperLimit(TIMESTAMP_1);
         assertThatThrownBy(() -> store.storeUpperLimit(TIMESTAMP_2)).isInstanceOf(NotCurrentLeaderException.class);
         assertThatLoggableExceptionThrownBy(() -> store.storeUpperLimit(TIMESTAMP_2))
-                .isInstanceOf(SafeIllegalStateException.class);
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasMessageContaining("Cannot store upper limit as leadership has been lost.");
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -241,10 +241,19 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @Test
-    public void throwsIfBoundUnexpectedlyChangedUnderUs() {
+    public void throwsNotCurrentLeaderExceptionIfBoundUnexpectedlyChangedUnderUs() {
         PaxosTimestampBoundStore additionalStore = createPaxosTimestampBoundStore(1);
         additionalStore.storeUpperLimit(TIMESTAMP_1);
         assertThatThrownBy(() -> store.storeUpperLimit(TIMESTAMP_2)).isInstanceOf(NotCurrentLeaderException.class);
+    }
+
+    @Test
+    public void throwsSafeIllegalStateExceptionIfCalledAfterNotCurrentLeaderException() {
+        PaxosTimestampBoundStore additionalStore = createPaxosTimestampBoundStore(1);
+        additionalStore.storeUpperLimit(TIMESTAMP_1);
+        assertThatThrownBy(() -> store.storeUpperLimit(TIMESTAMP_2)).isInstanceOf(NotCurrentLeaderException.class);
+        assertThatLoggableExceptionThrownBy(() -> store.storeUpperLimit(TIMESTAMP_2))
+                .isInstanceOf(SafeIllegalStateException.class);
     }
 
     @Test

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
@@ -16,9 +16,6 @@
 package com.palantir.timestamp;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.palantir.leader.NotCurrentLeaderException;
-import com.palantir.logsafe.Preconditions;
-import java.util.Optional;
 import javax.annotation.concurrent.GuardedBy;
 
 public class PersistentUpperLimit {
@@ -32,9 +29,6 @@ public class PersistentUpperLimit {
 
     @GuardedBy("this")
     private volatile long currentLimit;
-
-    @GuardedBy("this")
-    private volatile Optional<NotCurrentLeaderException> leadershipLostException = Optional.empty();
 
     private final TimestampBoundStore store;
 
@@ -64,17 +58,8 @@ public class PersistentUpperLimit {
     }
 
     private void storeUpperLimit(long upperLimit) {
-        Preconditions.checkState(
-                leadershipLostException.isEmpty(),
-                "Cannot store upper limit when not the leader",
-                leadershipLostException.get());
-        try {
-            DebugLogger.willStoreNewUpperLimit(upperLimit);
-            store.storeUpperLimit(upperLimit);
-            DebugLogger.didStoreNewUpperLimit(upperLimit);
-        } catch (NotCurrentLeaderException e) {
-            leadershipLostException = Optional.of(e);
-            throw e;
-        }
+        DebugLogger.willStoreNewUpperLimit(upperLimit);
+        store.storeUpperLimit(upperLimit);
+        DebugLogger.didStoreNewUpperLimit(upperLimit);
     }
 }

--- a/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
+++ b/timestamp-impl/src/main/java/com/palantir/timestamp/PersistentUpperLimit.java
@@ -16,7 +16,6 @@
 package com.palantir.timestamp;
 
 import com.google.common.annotations.VisibleForTesting;
-import javax.annotation.concurrent.GuardedBy;
 
 public class PersistentUpperLimit {
 
@@ -27,9 +26,7 @@ public class PersistentUpperLimit {
     @VisibleForTesting
     static final long BUFFER = 1_000_000;
 
-    @GuardedBy("this")
     private volatile long currentLimit;
-
     private final TimestampBoundStore store;
 
     public PersistentUpperLimit(TimestampBoundStore boundStore) {


### PR DESCRIPTION
## General
**Before this PR**:
Alternative to: https://github.com/palantir/atlasdb/pull/6708


**After this PR**:
==COMMIT_MSG==
Throw not current leader exception only once per instance. This should prevent multiple class creations, thus preventing resource contention and resource leakage. 
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
