### PR TITLE
[PDS-403847] CCPI Resource Management, Part 1: AsyncInitializer Resource Leak

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -76,7 +76,7 @@ public abstract class AsyncInitializer {
                     throwable);
             try {
                 cleanUpOnInitFailure();
-            } catch (Throwable cleanupThrowable) {
+            } catch (RuntimeException | Error cleanupThrowable) {
                 log.error(
                         "Failed to cleanup when initialization of {} failed after {} milliseconds",
                         SafeArg.of("className", getInitializingClassName()),
@@ -113,7 +113,7 @@ public abstract class AsyncInitializer {
                     SafeArg.of("className", getInitializingClassName()),
                     SafeArg.of("numberOfAttempts", numberOfInitializationAttempts),
                     SafeArg.of("initializationDuration", getMillisecondsSinceInitialization()));
-        } catch (Throwable throwable) {
+        } catch (RuntimeException | Error throwable) {
             log.info(
                     "Failed to initialize {} on the attempt {}",
                     SafeArg.of("className", getInitializingClassName()),
@@ -121,7 +121,7 @@ public abstract class AsyncInitializer {
                     throwable);
             try {
                 cleanUpOnInitFailure();
-            } catch (Throwable cleanupThrowable) {
+            } catch (RuntimeException | Error cleanupThrowable) {
                 log.error(
                         "Failed to cleanup when initialization of {} failed on attempt {} with {} milliseconds",
                         SafeArg.of("className", getInitializingClassName()),

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -71,7 +71,6 @@ public abstract class AsyncInitializer {
             log.info(
                     "Failed to initialize {} after {} milliseconds",
                     SafeArg.of("className", getInitializingClassName()),
-                    SafeArg.of("numberOfAttempts", numberOfInitializationAttempts++),
                     SafeArg.of("initializationDuration", getMillisecondsSinceInitialization()),
                     throwable);
             try {
@@ -80,7 +79,6 @@ public abstract class AsyncInitializer {
                 log.error(
                         "Failed to cleanup when initialization of {} failed after {} milliseconds",
                         SafeArg.of("className", getInitializingClassName()),
-                        SafeArg.of("numberOfAttempts", numberOfInitializationAttempts),
                         SafeArg.of("initializationDuration", getMillisecondsSinceInitialization()),
                         cleanupThrowable);
                 throwable.addSuppressed(cleanupThrowable);

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -67,7 +67,7 @@ public abstract class AsyncInitializer {
                     "Successfully initialized {} after {} milliseconds",
                     SafeArg.of("className", getInitializingClassName()),
                     SafeArg.of("initializationDuration", getMillisecondsSinceInitialization()));
-        } catch (Throwable throwable) {
+        } catch (RuntimeException | Error throwable) {
             log.info(
                     "Failed to initialize {} after {} milliseconds",
                     SafeArg.of("className", getInitializingClassName()),

--- a/changelog/@unreleased/pr-6716.v2.yml
+++ b/changelog/@unreleased/pr-6716.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix a resource leak by calling `cleanUpOnInitFailure()` if _synchronous_
+    initialization fails.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6716


### PR DESCRIPTION
## General
**Before this PR**:
The synchronous variant of `AsyncInitializer` can leak resources if the underlying object is not successfully initialized; the method `cleanUpOnInitFailure()` is not called on this path.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix a resource leak by calling `cleanUpOnInitFailure()` if _synchronous_ initialization fails.
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
- This is of course an API break, but I think reasonable as I'd argue the original behaviour is buggy.

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes: startup behaviour is node-local.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing in particular

**What was existing testing like? What have you done to improve it?**: Added three tests.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: It does not.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: It does not.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Added logging.

**Has the safety of all log arguments been decided correctly?**: Yes: what's permitted here are class names, attempt numbers and time intervals.

**Will this change significantly affect our spending on metrics or logs?**: No.

**How would I tell that this PR does not work in production? (monitors, etc.)**: No

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Yes, rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: I don't think so. Remove the framework entirely?

## Development Process
**Where should we start reviewing?**: The tests.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
