### PR TITLE
Add a workflow runner for executing workflows without validation. 

### DIFF
--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/workflow/WorkflowRunner.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/workflow/WorkflowRunner.java
@@ -16,16 +16,15 @@
 
 package com.palantir.atlasdb.workload.workflow;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
-/**
- * Run the provided workflow and validate that it is correct with the provided invariants.
- */
-public interface WorkflowValidatorRunner<WorkflowTypeT extends Workflow> {
-    void run(List<WorkflowAndInvariants<WorkflowTypeT>> workflowAndInvariants);
+public interface WorkflowRunner<WorkflowTypeT extends Workflow> {
+    Map<WorkflowTypeT, ListenableFuture<WorkflowHistory>> run(List<WorkflowTypeT> workflows);
 
-    default void run(WorkflowAndInvariants<WorkflowTypeT>... workflowAndInvariants) {
-        run(Arrays.asList(workflowAndInvariants));
+    default Map<WorkflowTypeT, ListenableFuture<WorkflowHistory>> run(WorkflowTypeT... workflows) {
+        return run(Arrays.asList(workflows));
     }
 }

--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
@@ -32,6 +32,7 @@ import com.palantir.atlasdb.workload.invariant.DurableWritesInvariantMetricRepor
 import com.palantir.atlasdb.workload.invariant.SerializableInvariantLogReporter;
 import com.palantir.atlasdb.workload.resource.AntithesisCassandraSidecarResource;
 import com.palantir.atlasdb.workload.runner.AntithesisWorkflowValidatorRunner;
+import com.palantir.atlasdb.workload.runner.DefaultWorkflowRunner;
 import com.palantir.atlasdb.workload.store.AtlasDbTransactionStoreFactory;
 import com.palantir.atlasdb.workload.store.InteractiveTransactionStore;
 import com.palantir.atlasdb.workload.store.TransactionStore;
@@ -157,7 +158,8 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
 
         waitForTransactionStoreFactoryToBeInitialized(transactionStoreFactory);
 
-        new AntithesisWorkflowValidatorRunner(MoreExecutors.listeningDecorator(antithesisWorkflowRunnerExecutorService))
+        new AntithesisWorkflowValidatorRunner(new DefaultWorkflowRunner(
+                        MoreExecutors.listeningDecorator(antithesisWorkflowRunnerExecutorService)))
                 .run(
                         createSingleRowTwoCellsWorkflowValidator(
                                 transactionStoreFactory, singleRowTwoCellsConfig, environment.lifecycle()),

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/runner/DefaultWorkflowRunner.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/runner/DefaultWorkflowRunner.java
@@ -1,0 +1,43 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.runner;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.palantir.atlasdb.workload.workflow.Workflow;
+import com.palantir.atlasdb.workload.workflow.WorkflowHistory;
+import com.palantir.atlasdb.workload.workflow.WorkflowRunner;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class DefaultWorkflowRunner implements WorkflowRunner<Workflow> {
+
+    private final ListeningExecutorService listeningExecutorService;
+
+    public DefaultWorkflowRunner(ListeningExecutorService listeningExecutorService) {
+        this.listeningExecutorService = listeningExecutorService;
+    }
+
+    @Override
+    public Map<Workflow, ListenableFuture<WorkflowHistory>> run(List<Workflow> workflows) {
+        return workflows.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(), workflow -> listeningExecutorService.submit(workflow::run)));
+    }
+}

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/DefaultWorkflowRunnerTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/DefaultWorkflowRunnerTest.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.runner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.atlasdb.workload.workflow.Workflow;
+import com.palantir.atlasdb.workload.workflow.WorkflowHistory;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import org.junit.Test;
+
+public class DefaultWorkflowRunnerTest {
+
+    private static final ListeningExecutorService EXECUTOR_SERVICE =
+            MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(8));
+
+    @Test
+    public void runExecutesAllWorkflows() {
+        List<Workflow> workflows = List.of(mock(Workflow.class), mock(Workflow.class));
+        DefaultWorkflowRunner runner = new DefaultWorkflowRunner(EXECUTOR_SERVICE);
+        runner.run(workflows);
+        workflows.forEach(workflow -> verify(workflow).run());
+    }
+
+    @Test
+    public void runMapsHistoryToTheCorrectWorkflow() {
+        Map<Workflow, WorkflowHistory> workflows = Map.of(
+                mock(Workflow.class), mock(WorkflowHistory.class), mock(Workflow.class), mock(WorkflowHistory.class));
+        workflows.entrySet().forEach(entry -> when(entry.getKey().run()).thenReturn(entry.getValue()));
+        DefaultWorkflowRunner runner = new DefaultWorkflowRunner(EXECUTOR_SERVICE);
+        Map<> runner.run(List.copyOf(workflows.keySet()));
+        workflows.forEach(workflow -> verify(workflow).run());
+    }
+}

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/DefaultWorkflowRunnerTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/DefaultWorkflowRunnerTest.java
@@ -16,21 +16,20 @@
 
 package com.palantir.atlasdb.workload.runner;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.workload.workflow.Workflow;
 import com.palantir.atlasdb.workload.workflow.WorkflowHistory;
-import one.util.streamex.EntryStream;
-import org.junit.Test;
-
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import one.util.streamex.EntryStream;
+import org.junit.Test;
 
 public class DefaultWorkflowRunnerTest {
 


### PR DESCRIPTION
## General
**Before this PR**:
Workflows running and validation are tightly coupled; after this, workflows can run independently of any said validation. This is ideal as we could make really interesting workflow runners _in the future_, such as checkpointable workflow runners, which would just work 'natrually' with the workflow validation runners. 

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds a workflow runner to just execute without validation. 
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
