### PR TITLE
[PDS-403847] CCPI Resource Management, Part 2: AbsentHosts Not Cleaned Up On Failed Starts

### DIFF
--- a/changelog/@unreleased/pr-6721.v2.yml
+++ b/changelog/@unreleased/pr-6721.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: If initialisation of the Cassandra client pool fails, an attempt is
+    made to shut down pools associated with hosts that are considered to be absent
+    as well.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6721


### PR DESCRIPTION
Thanks to @Sam-Kramer for the tip-off that one particularly directed service was exploding!

## General
**Before this PR**:
- If we do not have quorum when a cluster is created, then the nodes will be marked as absent because their host structure was inconsistent. We then fail initialisation on no servers being added to the pool (see `CassandraClientPoolImpl:373`). However, the implementation of `cleanUpOnInitFailure` does not call shutdown on the absent host tracker, meaning that those connections remained open.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
If initialisation of the Cassandra client pool fails, an attempt is made to shut down pools associated with hosts that are considered to be absent as well.
==COMMIT_MSG==

**Priority**: P1, blocks internal infrastructural migrations.

**Concerns / possible downsides (what feedback would you like?)**:
- I still don't like the heterogeneity of `shutdown()` vs `cleanUpOnInitFailure()`, but holding off from making more sweeping changes in the interests of (1) having limited bandwidth given other concerns, and (2) Chesterton's fence.

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No API breaks.

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No.

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes, the pool is in memory.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That future users will be careful. This isn't a great assumption but given resourcing pressure...

**What was existing testing like? What have you done to improve it?**: At time of writing I have been a horrible delinquent. I will add tests before we seek to merge this to production.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: No concurrent code as far as I know.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: We don't.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Metrics - thrift pools don't increase.

**Has the safety of all log arguments been decided correctly?**: No new log arguments.

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: Metrics - thrift pools continue to increase when an atlasdb service on a stack in the midst of the migration restarts.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: -

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: I don't think so

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: There's probably a piece to unify the shutdown and cleanup paths

## Development Process
**Where should we start reviewing?**: The one file.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
