### PR TITLE
Initialise poolSize with value -1

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolMetrics.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolMetrics.java
@@ -43,7 +43,7 @@ public class CassandraClientPoolMetrics {
     // Not bundled in with request metrics, as we seek to not produce host-level metrics for economic reasons.
     private final Counter poolExhaustionCounter;
 
-    private final AtomicLong poolSize = new AtomicLong(0L);
+    private final AtomicLong poolSize = new AtomicLong(-1L);
 
     public CassandraClientPoolMetrics(MetricsManager metricsManager) {
         this.metricsManager = metricsManager;


### PR DESCRIPTION
## General
**Before this PR**:
We initialise poolSize metric with a value 0; which might lead to a false positive signal.

**After this PR**:
Changing the value to -1 allows to simplify monitoring around Cassandra client pool metric value.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Initialize poolSize metrics with value -1 instead of 0
==COMMIT_MSG==

After this PR we can create a simple monitor that could be triggered when the metric is 0.

**Priority**: P1


## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: This PR does not rely on other products.

**Does this PR need a schema migration?** No.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
The assumption is that cassandra client pool metric will become 0 only when no cassandra hosts are available.

**What was existing testing like? What have you done to improve it?**: N/A

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A


## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: We see cassandra client pool metric value as -1 after initialisation.

**Has the safety of all log arguments been decided correctly?**: N/A

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: N/A

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Yes

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: N/A

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: N/A

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: N/A

## Development Process
**Where should we start reviewing?**: https://github.com/palantir/atlasdb/pull/6722/files#diff-ca8c8601f4351197d775d2e1e2a1888636359aca32c7d77a0ba780eb17623b8eR46

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
