### PR TITLE
Upgrade baseline 5.21.0

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RowColumnRangeExtractor.java
@@ -46,6 +46,7 @@ final class RowColumnRangeExtractor {
         private final Set<byte[]> emptyRows;
         private final Map<byte[], Integer> rowsToRawColumnCount;
 
+        @SuppressWarnings("NonApiType") // explicitly require LinkedHashMap to maintain ordering
         private RowColumnRangeResult(
                 Map<byte[], LinkedHashMap<Cell, Value>> results,
                 Map<byte[], Column> rowsToLastCompositeColumns,

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractGenericStreamStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractGenericStreamStore.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.stream;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Ints;
 import com.google.protobuf.ByteString;
 import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractGenericStreamStore.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/stream/AbstractGenericStreamStore.java
@@ -216,7 +216,7 @@ public abstract class AbstractGenericStreamStore<T> implements GenericStreamStor
     private void tryWriteStreamToFile(Transaction transaction, T id, StreamMetadata metadata, FileOutputStream fos)
             throws IOException {
         try (InputStream in = loadStream(transaction, id)) {
-            ByteStreams.copy(in, fos);
+            in.transferTo(fos);
         }
         fos.close();
     }

--- a/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/base/Throwables.java
@@ -275,9 +275,9 @@ public final class Throwables {
         PrintWriter printWriter = new PrintWriter(stringWriter);
         for (Map.Entry<Thread, StackTraceElement[]> entry : map.entrySet()) {
             Thread t = entry.getKey();
-            StackTraceElement elements[] = entry.getValue();
+            StackTraceElement[] elements = entry.getValue();
 
-            printWriter.println(new StringBuilder().append(t));
+            printWriter.println(t);
             printStackTrace(printWriter, elements);
             printWriter.println();
         }

--- a/atlasdb-commons/src/main/java/com/palantir/util/JMXUtils.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/JMXUtils.java
@@ -266,7 +266,19 @@ public final class JMXUtils {
 
         @Override
         public Socket createSocket(final String host, final int port) throws IOException {
-            return new Socket(host, port);
+            IOException exception = null;
+            for (InetAddress address : InetAddress.getAllByName(host)) {
+                try {
+                    return new Socket(address, port);
+                } catch (IOException e) {
+                    if (exception == null) {
+                        exception = e;
+                    } else {
+                        exception.addSuppressed(e);
+                    }
+                }
+            }
+            throw exception;
         }
     }
 

--- a/atlasdb-commons/src/main/java/com/palantir/util/crypto/Sha256Hash.java
+++ b/atlasdb-commons/src/main/java/com/palantir/util/crypto/Sha256Hash.java
@@ -75,7 +75,7 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
         try {
             MessageDigest digest = getMessageDigest();
             DigestInputStream digestInputStream = new DigestInputStream(is, digest);
-            ByteStreams.copy(digestInputStream, ByteStreams.nullOutputStream());
+            digestInputStream.transferTo(ByteStreams.nullOutputStream());
             digestInputStream.close();
             return createFrom(digest);
         } finally {

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -187,7 +187,7 @@ public class Containers extends ExternalResource {
     private static String getDockerComposeFile(String configResource) {
         try {
             File configFile = File.createTempFile("config", ".yml");
-            IOUtils.copy(Containers.class.getResourceAsStream(configResource), new FileOutputStream(configFile));
+            Containers.class.getResourceAsStream(configResource).transferTo(new FileOutputStream(configFile));
             return configFile.getPath();
         } catch (IOException e) {
             throw Throwables.propagate(e);

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.io.IOUtils;
 import org.awaitility.Awaitility;
 import org.junit.rules.ExternalResource;
 

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ThreeNodeCassandraCluster.java
@@ -25,14 +25,10 @@ import com.palantir.atlasdb.cassandra.ImmutableCqlCapableConfig;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceImpl;
 import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
-import com.palantir.logsafe.UnsafeArg;
-import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.refreshable.Refreshable;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.Map;
 
 public class ThreeNodeCassandraCluster extends Container {
@@ -64,23 +60,23 @@ public class ThreeNodeCassandraCluster extends Container {
                 .build();
     }
 
-    @SuppressWarnings("DnsLookup")
+    @SuppressWarnings({"AddressSelection", "DnsLookup"})
     public static Refreshable<CassandraKeyValueServiceRuntimeConfig> getRuntimeConfig(int replicationFactor) {
         return Refreshable.only(ImmutableCassandraKeyValueServiceRuntimeConfig.builder()
                 .servers(ImmutableCqlCapableConfig.builder()
                         .addThriftHosts(
-                                getInetSocketAddress(
+                                new InetSocketAddress(
                                         FIRST_CASSANDRA_CONTAINER_NAME, CassandraContainer.CASSANDRA_THRIFT_PORT),
-                                getInetSocketAddress(
+                                new InetSocketAddress(
                                         SECOND_CASSANDRA_CONTAINER_NAME, CassandraContainer.CASSANDRA_THRIFT_PORT),
-                                getInetSocketAddress(
+                                new InetSocketAddress(
                                         THIRD_CASSANDRA_CONTAINER_NAME, CassandraContainer.CASSANDRA_THRIFT_PORT))
                         .addCqlHosts(
-                                getInetSocketAddress(
+                                new InetSocketAddress(
                                         FIRST_CASSANDRA_CONTAINER_NAME, CassandraContainer.CASSANDRA_CQL_PORT),
-                                getInetSocketAddress(
+                                new InetSocketAddress(
                                         SECOND_CASSANDRA_CONTAINER_NAME, CassandraContainer.CASSANDRA_CQL_PORT),
-                                getInetSocketAddress(
+                                new InetSocketAddress(
                                         THIRD_CASSANDRA_CONTAINER_NAME, CassandraContainer.CASSANDRA_CQL_PORT))
                         .build())
                 .mutationBatchCount(10000)
@@ -88,18 +84,6 @@ public class ThreeNodeCassandraCluster extends Container {
                 .fetchBatchCount(1000)
                 .replicationFactor(replicationFactor)
                 .build());
-    }
-
-    private static InetSocketAddress getInetSocketAddress(String hostname, int port) throws IllegalArgumentException {
-        try {
-            for (InetAddress address : InetAddress.getAllByName(hostname)) {
-                return new InetSocketAddress(address, port);
-            }
-        } catch (UnknownHostException e) {
-            throw new SafeIllegalArgumentException(
-                    "No address found for host: ", e, UnsafeArg.of("hostname", hostname));
-        }
-        throw new SafeIllegalArgumentException("No address found for host: ", UnsafeArg.of("hostname", hostname));
     }
 
     @Override

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/ete/Gradle.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/ete/Gradle.java
@@ -56,7 +56,7 @@ public final class Gradle extends ExternalResource {
                     .redirectErrorStream(true)
                     .start();
             try (InputStream processInputStream = process.getInputStream()) {
-                IOUtils.copy(processInputStream, System.out);
+                processInputStream.transferTo(System.out);
             }
             assertThat(process.waitFor()).isEqualTo(0);
         } catch (IOException e) {

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/ete/Gradle.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/ete/Gradle.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.apache.commons.io.IOUtils;
 import org.junit.rules.ExternalResource;
 
 public final class Gradle extends ExternalResource {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.transaction.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Functions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -120,7 +121,6 @@ import org.eclipse.collections.api.map.primitive.MutableLongLongMap;
 import org.eclipse.collections.api.set.primitive.LongSet;
 import org.eclipse.collections.api.set.primitive.MutableLongSet;
 import org.immutables.value.Value;
-import org.jetbrains.annotations.VisibleForTesting;
 
 /**
  * This class will track all reads to verify that there are no read-write conflicts at commit time.

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionConflictDetectionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionConflictDetectionManagerTest.java
@@ -27,7 +27,6 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.Optional;
-import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,7 +49,6 @@ public final class TransactionConflictDetectionManagerTest {
     public void before() {
         conflictDetectionManager = new TransactionConflictDetectionManager(new ConflictDetectionManager(delegate) {
             @Override
-            @Nullable
             public Optional<ConflictHandler> get(TableReference tableReference) {
                 try {
                     return delegate.load(tableReference);

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/DockerizedDatabase.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/DockerizedDatabase.java
@@ -29,7 +29,6 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 
 public final class DockerizedDatabase implements Closeable {
 

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/DockerizedDatabase.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/DockerizedDatabase.java
@@ -59,7 +59,7 @@ public final class DockerizedDatabase implements Closeable {
         URL resource = clazz.getResource("/" + resourcePath);
         File file = File.createTempFile(
                 FilenameUtils.getBaseName(resource.getFile()), FilenameUtils.getExtension(resource.getFile()));
-        IOUtils.copy(resource.openStream(), FileUtils.openOutputStream(file));
+        resource.openStream().transferTo(FileUtils.openOutputStream(file));
         file.deleteOnExit();
         return file;
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.netflix.nebula:gradle-info-plugin:12.1.6'
         classpath 'com.netflix.nebula:nebula-publishing-plugin:20.3.0'
-        classpath 'com.palantir.baseline:gradle-baseline-java:5.18.0'
+        classpath 'com.palantir.baseline:gradle-baseline-java:5.21.0'
         classpath 'com.palantir.gradle.conjure:gradle-conjure:5.41.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:2.15.0'
         classpath 'com.palantir.gradle.docker:gradle-docker:0.32.0'

--- a/flake-rule/src/test/java/com/palantir/flake/example/StringSupplierTest.java
+++ b/flake-rule/src/test/java/com/palantir/flake/example/StringSupplierTest.java
@@ -26,10 +26,9 @@ import org.junit.Test;
 
 public class StringSupplierTest {
     private static final String TEST_STRING = "123";
-    private static final String EMPTY_STRING = "";
 
     private static final Supplier<String> FLAKY_STRING_SUPPLIER =
-            () -> ThreadLocalRandom.current().nextBoolean() ? TEST_STRING : EMPTY_STRING;
+            () -> ThreadLocalRandom.current().nextBoolean() ? TEST_STRING : "";
 
     @Rule
     public FlakeRetryingRule flakeRetryingRule = new FlakeRetryingRule();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/LockV1Resource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/LockV1Resource.java
@@ -157,6 +157,7 @@ public class LockV1Resource {
     @Idempotent
     @Nullable
     @Handle(method = HttpMethod.POST, path = "/{namespace}/lock/refresh-grant")
+    @SuppressWarnings("NullableOptional") // null and empty are same over the wire
     public Optional<HeldLocksGrant> refreshGrant(
             @Safe @PathParam("namespace") @Handle.PathParam String namespace, @Handle.Body HeldLocksGrant grant) {
         return Optional.ofNullable(getLockService(namespace).refreshGrant(grant));
@@ -169,6 +170,7 @@ public class LockV1Resource {
     @Idempotent
     @Nullable
     @Handle(method = HttpMethod.POST, path = "/{namespace}/lock/refresh-grant-id")
+    @SuppressWarnings("NullableOptional") // null and empty are same over the wire
     public Optional<HeldLocksGrant> refreshGrant(
             @Safe @PathParam("namespace") @Handle.PathParam String namespace, @Handle.Body BigInteger grantId) {
         return Optional.ofNullable(getLockService(namespace).refreshGrant(grantId));
@@ -241,6 +243,7 @@ public class LockV1Resource {
     @Idempotent
     @Nullable
     @Handle(method = HttpMethod.POST, path = "/{namespace}/lock/min-locked-in-version-id")
+    @SuppressWarnings("NullableOptional") // null and empty are same over the wire
     public Optional<Long> getMinLockedInVersionId(@Safe @PathParam("namespace") @Handle.PathParam String namespace) {
         return Optional.ofNullable(getLockService(namespace).getMinLockedInVersionId());
     }
@@ -303,6 +306,7 @@ public class LockV1Resource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Nullable
     @Handle(method = HttpMethod.POST, path = "/{namespace}/lock/lock/{client}")
+    @SuppressWarnings("NullableOptional") // null and empty are same over the wire
     public Optional<LockRefreshToken> lock(
             @Safe @PathParam("namespace") @Handle.PathParam String namespace,
             @Safe @PathParam("client") @Handle.PathParam String client,
@@ -317,6 +321,7 @@ public class LockV1Resource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Nullable
     @Handle(method = HttpMethod.POST, path = "/{namespace}/lock/lock")
+    @SuppressWarnings("NullableOptional") // null and empty are same over the wire
     public Optional<LockRefreshToken> lock(
             @Safe @PathParam("namespace") @Handle.PathParam String namespace, @Handle.Body LockRequest request)
             throws InterruptedException {
@@ -377,6 +382,7 @@ public class LockV1Resource {
     @Idempotent
     @Nullable
     @Handle(method = HttpMethod.POST, path = "/{namespace}/lock/min-locked-in-version/{client}")
+    @SuppressWarnings("NullableOptional") // null and empty are same over the wire
     public Optional<Long> getMinLockedInVersionId(
             @Safe @PathParam("namespace") @Handle.PathParam String namespace,
             @Safe @PathParam("client") @Handle.PathParam String client) {
@@ -390,6 +396,7 @@ public class LockV1Resource {
     @Idempotent
     @Nullable
     @Handle(method = HttpMethod.POST, path = "/{namespace}/lock/min-locked-in-version")
+    @SuppressWarnings("NullableOptional") // null and empty are same over the wire
     public Optional<Long> getMinLockedInVersionIdForAnonymousClientString(
             @Safe @PathParam("namespace") @Handle.PathParam String namespace) {
         return getMinLockedInVersionId(namespace, LockClient.ANONYMOUS.getClientId());

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/SqliteNamespaceLoader.java
@@ -26,7 +26,6 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 
 final class SqliteNamespaceLoader implements PersistentNamespaceLoader {
-    private static final String EMPTY_STRING = "";
 
     private final Jdbi jdbi;
 
@@ -46,7 +45,7 @@ final class SqliteNamespaceLoader implements PersistentNamespaceLoader {
 
         // Namespaces contain at least one character implying the empty string is lexicographically strictly smaller
         // than any namespace.
-        Optional<String> currentNamespace = getNextLexicographicallySmallestNamespace(EMPTY_STRING);
+        Optional<String> currentNamespace = getNextLexicographicallySmallestNamespace("");
         while (currentNamespace.isPresent()) {
             String namespaceString = currentNamespace.get();
             clients.add(Client.of(namespaceString));


### PR DESCRIPTION
## General
**Before this PR**:
Baseline was on 5.18.0

**After this PR**:

==COMMIT_MSG==
Upgrade baseline 5.21.0
==COMMIT_MSG==

https://github.com/palantir/gradle-baseline/releases

### 5.21.0

Type | Description | Link
-- | -- | --
Improvement | Upgrade error-prone to 2.21.1 (from 2.19.1) | #2628

### 5.20.0



Type | Description | Link
-- | -- | --
Improvement | Improve SafeLoggingPropagation on Immutables, taking into account fields from superinterfaces | #2629


### 5.19.0

Type | Description | Link
-- | -- | --
Improvement | Prefer InputStream.transferTo(OutputStream)Add error-prone check to automate migration to prefer InputStream.transferTo(OutputStream) instead of utility methods such as Guava's com.google.common.io.ByteStreams.copy(InputStream, OutputStream).Allow for optimization when underlying input stream (such as ByteArrayInputStream, ChannelInputStream) overrides transferTo(OutputStream) to avoid extra array allocations and copy larger chunks at a time (e.g. allowing 16KiB chunks via ApacheHttpClientBlockingChannel.ModulatingOutputStream from #1790).When running on JDK 21+, this also enables 16KiB byte chunk copies via InputStream.transferTo(OutputStream) perJDK-8299336, where as on JDK < 21 and when using Guava ByteStreams.copy 8KiB byte chunk copies are used.References:* palantir/hadoop-crypto#586* https://bugs.openjdk.org/browse/JDK-8299336* https://bugs.openjdk.org/browse/JDK-8067661* https://bugs.openjdk.org/browse/JDK-8265891* https://bugs.openjdk.org/browse/JDK-8273038* https://bugs.openjdk.org/browse/JDK-8279283* https://bugs.openjdk.org/browse/JDK-8296431Closes #2615 | #2615, #2616

Type	Description	Link
Improvement	Prefer InputStream.transferTo(OutputStream)

Add error-prone check to automate migration to prefer InputStream.transferTo(OutputStream) instead of utility methods such as Guava's com.google.common.io.ByteStreams.copy(InputStream, OutputStream).

Allow for optimization when underlying input stream (such as ByteArrayInputStream, ChannelInputStream) overrides transferTo(OutputStream) to avoid extra array allocations and copy larger chunks at a time (e.g. allowing 16KiB chunks via ApacheHttpClientBlockingChannel.ModulatingOutputStream from https://github.com/palantir/gradle-baseline/pull/1790).

When running on JDK 21+, this also enables 16KiB byte chunk copies via InputStream.transferTo(OutputStream) per
[JDK-8299336](https://bugs.openjdk.org/browse/JDK-8299336), where as on JDK < 21 and when using Guava ByteStreams.copy 8KiB byte chunk copies are used.

References:
* https://github.com/palantir/hadoop-crypto/pull/586
* https://bugs.openjdk.org/browse/JDK-8299336
* https://bugs.openjdk.org/browse/JDK-8067661
* https://bugs.openjdk.org/browse/JDK-8265891
* https://bugs.openjdk.org/browse/JDK-8273038
* https://bugs.openjdk.org/browse/JDK-8279283
* https://bugs.openjdk.org/browse/JDK-8296431

Closes https://github.com/palantir/gradle-baseline/issues/2615	https://github.com/palantir/gradle-baseline/issues/2615, https://github.com/palantir/gradle-baseline/pull/2616


**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
