### PR TITLE
Reduce TimestampStateStore contention

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LocksAndMetadata.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LocksAndMetadata.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import org.immutables.value.Value;
 
 @Unsafe
-@Value.Immutable
+@Value.Immutable(builder = false)
 public interface LocksAndMetadata {
     LocksAndMetadata EMPTY = LocksAndMetadata.of(Set.of(), Optional.empty());
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/Sequence.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/Sequence.java
@@ -30,15 +30,19 @@ import org.immutables.value.Value;
 @JsonSerialize(as = ImmutableSequence.class)
 @JsonDeserialize(as = ImmutableSequence.class)
 public interface Sequence extends Comparable<Sequence> {
+
+    Comparator<Sequence> SEQUENCE_COMPARATOR = Comparator.comparingLong(Sequence::value);
+
     @JsonProperty("sequence")
+    @Value.Parameter
     long value();
 
     static Sequence of(long value) {
-        return ImmutableSequence.builder().value(value).build();
+        return ImmutableSequence.of(value);
     }
 
     @Override
     default int compareTo(Sequence other) {
-        return Comparator.comparingLong(Sequence::value).compare(this, other);
+        return SEQUENCE_COMPARATOR.compare(this, other);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/Sequence.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/Sequence.java
@@ -19,19 +19,16 @@ package com.palantir.atlasdb.keyvalue.api.watch;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.util.Comparator;
 import org.immutables.value.Value;
 
 /**
  * Encapsulates the sequence or version number from {@link com.palantir.lock.watch.LockWatchVersion}. This is only
  * intended to be used internally.
  */
-@Value.Immutable
+@Value.Immutable(builder = false)
 @JsonSerialize(as = ImmutableSequence.class)
 @JsonDeserialize(as = ImmutableSequence.class)
 public interface Sequence extends Comparable<Sequence> {
-
-    Comparator<Sequence> SEQUENCE_COMPARATOR = Comparator.comparingLong(Sequence::value);
 
     @JsonProperty("sequence")
     @Value.Parameter
@@ -43,6 +40,6 @@ public interface Sequence extends Comparable<Sequence> {
 
     @Override
     default int compareTo(Sequence other) {
-        return SEQUENCE_COMPARATOR.compare(this, other);
+        return Long.compare(value(), other.value());
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/StartTimestamp.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/StartTimestamp.java
@@ -31,10 +31,11 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableStartTimestamp.class)
 public interface StartTimestamp extends Comparable<StartTimestamp> {
     @JsonProperty("start-ts")
+    @Value.Parameter
     long value();
 
     static StartTimestamp of(long value) {
-        return ImmutableStartTimestamp.builder().value(value).build();
+        return ImmutableStartTimestamp.of(value);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/StartTimestamp.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/StartTimestamp.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
  * Encapsulates a start timestamp to avoid the need to use excessive numbers of longs everywhere. This is only
  * intended to be used internally.
  */
-@Value.Immutable
+@Value.Immutable(builder = false)
 @JsonSerialize(as = ImmutableStartTimestamp.class)
 @JsonDeserialize(as = ImmutableStartTimestamp.class)
 public interface StartTimestamp extends Comparable<StartTimestamp> {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.keyvalue.api.watch;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SortedSetMultimap;
@@ -34,8 +35,10 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Collection;
 import java.util.NavigableMap;
+import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.immutables.value.Value;
 
@@ -67,16 +70,23 @@ final class TimestampStateStore {
     static final int MAXIMUM_SIZE = 20_000;
 
     private final NavigableMap<StartTimestamp, TimestampVersionInfo> timestampMap = new ConcurrentSkipListMap<>();
-    private final SortedSetMultimap<Sequence, StartTimestamp> livingVersions =
-            Multimaps.synchronizedSortedSetMultimap(TreeMultimap.create());
+    private final NavigableMap<Sequence, NavigableSet<StartTimestamp>> livingVersions = new ConcurrentSkipListMap<>();
 
     void putStartTimestamps(Collection<Long> startTimestamps, LockWatchVersion version) {
+        if (startTimestamps.isEmpty()) {
+            return;
+        }
+
         validateStateSize();
 
+        Sequence sequence = Sequence.of(version.version());
+        TimestampVersionInfo currentVersion = TimestampVersionInfo.of(version);
         startTimestamps.stream().map(StartTimestamp::of).forEach(startTimestamp -> {
-            TimestampVersionInfo previous = timestampMap.putIfAbsent(startTimestamp, TimestampVersionInfo.of(version));
+            TimestampVersionInfo previous = timestampMap.putIfAbsent(startTimestamp, currentVersion);
             Preconditions.checkArgument(previous == null, "Start timestamp already present in map");
-            livingVersions.put(Sequence.of(version.version()), startTimestamp);
+            livingVersions
+                    .computeIfAbsent(sequence, _seq -> new ConcurrentSkipListSet<>())
+                    .add(startTimestamp);
         });
     }
 
@@ -98,9 +108,16 @@ final class TimestampStateStore {
     }
 
     void remove(long startTimestamp) {
-        Optional.ofNullable(timestampMap.remove(StartTimestamp.of(startTimestamp)))
-                .ifPresent(entry -> livingVersions.remove(
-                        Sequence.of(entry.version().version()), StartTimestamp.of(startTimestamp)));
+        StartTimestamp startTs = StartTimestamp.of(startTimestamp);
+        TimestampVersionInfo entry = timestampMap.remove(startTs);
+        if (entry != null) {
+            Sequence seq = Sequence.of(entry.version().version());
+            NavigableSet<StartTimestamp> startTimestamps = livingVersions.get(seq);
+            if (startTimestamps != null && startTimestamps.remove(startTs)) {
+                // clean up if this was the last timestamp for sequence
+                livingVersions.remove(seq, ImmutableSortedSet.of());
+            }
+        }
     }
 
     void clear() {
@@ -124,9 +141,7 @@ final class TimestampStateStore {
      * impact performance.
      */
     Optional<Sequence> getEarliestLiveSequence() {
-        synchronized (livingVersions) {
-            return Optional.ofNullable(Iterables.getFirst(livingVersions.keySet(), null));
-        }
+        return Optional.ofNullable(Iterables.getFirst(livingVersions.keySet(), null));
     }
 
     @VisibleForTesting
@@ -138,18 +153,22 @@ final class TimestampStateStore {
     @VisibleForTesting
     TimestampStateStoreState getStateForTesting() {
         // This method doesn't need to read a thread-safe snapshot of timestampMap and livingVersions
+        SortedSetMultimap<Sequence, StartTimestamp> living = TreeMultimap.create();
+        livingVersions.forEach(living::putAll);
         return ImmutableTimestampStateStoreState.builder()
                 .timestampMap(timestampMap)
-                .livingVersions(livingVersions)
+                .livingVersions(living)
                 .build();
     }
 
     private void validateStateSize() {
-        if (timestampMap.size() > MAXIMUM_SIZE || livingVersions.size() > MAXIMUM_SIZE) {
+        int timestampMapSize = timestampMap.size();
+        int livingVersionsSize = livingVersions.size();
+        if (timestampMapSize > MAXIMUM_SIZE || livingVersionsSize > MAXIMUM_SIZE) {
             log.warn(
                     "Timestamp state store has exceeded its maximum size. This likely indicates a memory leak",
-                    SafeArg.of("timestampMapSize", timestampMap.size()),
-                    SafeArg.of("livingVersionsSize", livingVersions.size()),
+                    SafeArg.of("timestampMapSize", timestampMapSize),
+                    SafeArg.of("livingVersionsSize", livingVersionsSize),
                     SafeArg.of("maximumSize", MAXIMUM_SIZE),
                     SafeArg.of("minimumLiveTimestamp", timestampMap.firstEntry()),
                     SafeArg.of("maximumLiveTimestamp", timestampMap.lastEntry()),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Multimaps;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
 import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
@@ -37,6 +35,8 @@ import java.util.Collection;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -58,7 +58,7 @@ import org.immutables.value.Value;
  *    caller.
  * 2. The entries in the living versions multimap may not be independent (as a single version may correspond to many
  *    timestamps), but the update concurrency should be handled by the data structure.
- * 3. Calls to {@link #getEarliestLiveSequence()} are synchronised on the livingVersions map, and thus are blocking;
+ * 3. Calls to {@link #getEarliestLiveSequence()} uses a sorted snapshot of livingVersions map;
  *    this method should be called sparsely. Given that it is only used for retentioning events, which can be eventually
  *    consistent (as it is always correct to keep more events rather than less), this is acceptable for performance.
  */
@@ -70,7 +70,7 @@ final class TimestampStateStore {
     static final int MAXIMUM_SIZE = 20_000;
 
     private final NavigableMap<StartTimestamp, TimestampVersionInfo> timestampMap = new ConcurrentSkipListMap<>();
-    private final NavigableMap<Sequence, NavigableSet<StartTimestamp>> livingVersions = new ConcurrentSkipListMap<>();
+    private final ConcurrentMap<Sequence, NavigableSet<StartTimestamp>> livingVersions = new ConcurrentHashMap<>();
 
     void putStartTimestamps(Collection<Long> startTimestamps, LockWatchVersion version) {
         if (startTimestamps.isEmpty()) {
@@ -113,7 +113,7 @@ final class TimestampStateStore {
         if (entry != null) {
             Sequence seq = Sequence.of(entry.version().version());
             NavigableSet<StartTimestamp> startTimestamps = livingVersions.get(seq);
-            if (startTimestamps != null && startTimestamps.remove(startTs)) {
+            if (startTimestamps != null && startTimestamps.remove(startTs) && startTimestamps.isEmpty()) {
                 // clean up if this was the last timestamp for sequence
                 livingVersions.remove(seq, ImmutableSortedSet.of());
             }
@@ -126,28 +126,20 @@ final class TimestampStateStore {
     }
 
     Optional<LockWatchVersion> getStartVersion(long startTimestamp) {
-        return Optional.ofNullable(timestampMap.get(StartTimestamp.of(startTimestamp)))
-                .map(TimestampVersionInfo::version);
+        return getTimestampInfo(startTimestamp).map(TimestampVersionInfo::version);
     }
 
     Optional<TimestampVersionInfo> getTimestampInfo(long startTimestamp) {
         return Optional.ofNullable(timestampMap.get(StartTimestamp.of(startTimestamp)));
     }
 
-    /**
-     * As per the documentation of {@link Multimaps#synchronizedSortedSetMultimap(SortedSetMultimap)}, we must
-     * synchronise on the collection when using any kind of collection view, including keySet. While this impacts the
-     * concurrency of this class, this method does not need to be called on every transaction, and thus should not
-     * impact performance.
-     */
     Optional<Sequence> getEarliestLiveSequence() {
-        return Optional.ofNullable(Iterables.getFirst(livingVersions.keySet(), null));
+        return livingVersions.keySet().stream().min(Sequence.SEQUENCE_COMPARATOR);
     }
 
     @VisibleForTesting
     Optional<CommitInfo> getCommitInfo(long startTimestamp) {
-        return Optional.ofNullable(timestampMap.get(StartTimestamp.of(startTimestamp)))
-                .flatMap(TimestampVersionInfo::commitInfo);
+        return getTimestampInfo(startTimestamp).flatMap(TimestampVersionInfo::commitInfo);
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -59,7 +59,7 @@ import org.immutables.value.Value;
  *    caller.
  * 2. The entries in the living versions multimap may not be independent (as a single version may correspond to many
  *    timestamps), but the update concurrency should be handled by the data structure.
- * 3. Calls to {@link #getEarliestLiveSequence()} uses a sorted snapshot of livingVersions map;
+ * 3. Calls to {@link #getEarliestLiveSequence()} uses a snapshot of livingVersions map;
  *    this method should be called sparsely. Given that it is only used for retentioning events, which can be eventually
  *    consistent (as it is always correct to keep more events rather than less), this is acceptable for performance.
  */

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -32,6 +32,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
 import java.util.Optional;
@@ -134,7 +135,7 @@ final class TimestampStateStore {
     }
 
     Optional<Sequence> getEarliestLiveSequence() {
-        return livingVersions.keySet().stream().min(Sequence.SEQUENCE_COMPARATOR);
+        return livingVersions.keySet().stream().min(Comparator.naturalOrder());
     }
 
     @VisibleForTesting

--- a/changelog/@unreleased/pr-6741.v2.yml
+++ b/changelog/@unreleased/pr-6741.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce TimestampStateStore contention
+  links:
+  - https://github.com/palantir/atlasdb/pull/6741

--- a/lock-api/src/main/java/com/palantir/lock/client/TransactionStarterHelper.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TransactionStarterHelper.java
@@ -150,7 +150,9 @@ final class TransactionStarterHelper {
     static void updateCacheWithStartTransactionResponse(
             LockWatchCache cache, ConjureStartTransactionsResponse response) {
         Set<Long> startTimestamps = response.getTimestamps().stream().boxed().collect(Collectors.toSet());
-        cache.processStartTransactionsUpdate(startTimestamps, response.getLockWatchUpdate());
+        if (!startTimestamps.isEmpty()) {
+            cache.processStartTransactionsUpdate(startTimestamps, response.getLockWatchUpdate());
+        }
     }
 
     static void cleanUpCaches(LockWatchCache cache, Collection<StartIdentifiedAtlasDbTransactionResponse> responses) {


### PR DESCRIPTION
## General
**Before this PR**:

The `livingVersions synchronized SortedSetMultimap` in `TimestampStateStore` can become a scalability bottleneck with many concurrent transactions on large numbers of cores and multi-socket / multi-NUMA node hosts. One example from a 60 second JFR shows 382 threads contending on removing versions.

<img width="908" alt="image" src="https://github.com/palantir/atlasdb/assets/54594/b0d7d455-9678-40c8-9c97-0e2db7b6a354">


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Reduce TimestampStateStore contention
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
