### PR TITLE
ConflictDetectionManager should not cache negative lookups

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public class ConflictDetectionManager {
-    private final LoadingCache<TableReference, Optional<ConflictHandler>> cache;
+    private final LoadingCache<TableReference, ConflictHandler> cache;
 
     /**
      *  This class does not make the mistake of attempting cache invalidation,
@@ -38,19 +38,19 @@ public class ConflictDetectionManager {
      *
      *  (This has always been the behavior of this class; I'm simply calling it out)
      */
-    public ConflictDetectionManager(CacheLoader<TableReference, Optional<ConflictHandler>> loader) {
+    public ConflictDetectionManager(CacheLoader<TableReference, ConflictHandler> loader) {
         this.cache = Caffeine.newBuilder().maximumSize(100_000).build(loader);
     }
 
-    public void warmCacheWith(Map<TableReference, Optional<ConflictHandler>> preload) {
+    public void warmCacheWith(Map<TableReference, ConflictHandler> preload) {
         cache.putAll(preload);
     }
 
-    public Map<TableReference, Optional<ConflictHandler>> getCachedValues() {
+    public Map<TableReference, ConflictHandler> getCachedValues() {
         return cache.asMap();
     }
 
     public Optional<ConflictHandler> get(TableReference tableReference) {
-        return cache.get(tableReference);
+        return Optional.ofNullable(cache.get(tableReference));
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagers.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagers.java
@@ -22,7 +22,6 @@ import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.util.Optional;
 
 public final class ConflictDetectionManagers {
     private static final SafeLogger log = SafeLoggerFactory.get(ConflictDetectionManagers.class);
@@ -30,7 +29,7 @@ public final class ConflictDetectionManagers {
     private ConflictDetectionManagers() {}
 
     public static ConflictDetectionManager createWithNoConflictDetection() {
-        return new ConflictDetectionManager(tableReference -> Optional.of(ConflictHandler.IGNORE_ALL));
+        return new ConflictDetectionManager(tableReference -> ConflictHandler.IGNORE_ALL);
     }
 
     /**
@@ -64,9 +63,9 @@ public final class ConflictDetectionManagers {
                 log.error(
                         "Tried to make a transaction over a table that has no metadata: {}.",
                         LoggingArgs.tableRef("tableReference", tableReference));
-                return Optional.empty();
+                return null;
             } else {
-                return Optional.of(getConflictHandlerFromMetadata(metadata));
+                return getConflictHandlerFromMetadata(metadata);
             }
         });
         if (warmCache) {
@@ -82,9 +81,9 @@ public final class ConflictDetectionManagers {
                                                     log.debug("Metadata was null for a table. likely because the table"
                                                             + " is currently  being created. Skipping warming"
                                                             + " cache for the table.");
-                                                    return Optional.empty();
+                                                    return null;
                                                 } else {
-                                                    return Optional.of(getConflictHandlerFromMetadata(metadata));
+                                                    return getConflictHandlerFromMetadata(metadata);
                                                 }
                                             }));
                                 } catch (Throwable t) {

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -95,6 +95,7 @@ dependencies {
   testImplementation project(':lock-api')
   testImplementation project(':lock-api-objects')
   testImplementation project(':timelock-api:timelock-api-objects')
+  testImplementation 'org.junit.vintage:junit-vintage-engine'
 
   annotationProcessor 'org.immutables:value'
   compileOnly 'org.immutables:value::annotations'
@@ -125,6 +126,10 @@ dependencies {
   testImplementation 'one.util:streamex'
 
   testRuntimeOnly 'ch.qos.logback:logback-classic'
+}
+
+test {
+  useJUnitPlatform()
 }
 
 configurations.testImplementation {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManagerTest.java
@@ -1,0 +1,65 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.transaction.api.ConflictHandler;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class ConflictDetectionManagerTest {
+
+    private static final TableReference TABLE_REFERENCE =
+            TableReference.create(Namespace.EMPTY_NAMESPACE, "test_table");
+
+    @Mock
+    private CacheLoader<TableReference, ConflictHandler> delegate;
+
+    private ConflictDetectionManager conflictDetectionManager;
+
+    @Before
+    public void before() {
+        conflictDetectionManager = new ConflictDetectionManager(delegate);
+    }
+
+    @Test
+    public void testThatConflictDetectionManagerDoesNotCacheNegativeLookup() throws Exception {
+        when(delegate.load(TABLE_REFERENCE)).thenReturn(null).thenReturn(ConflictHandler.SERIALIZABLE);
+        assertThat(conflictDetectionManager.get(TABLE_REFERENCE)).isEmpty();
+        assertThat(conflictDetectionManager.get(TABLE_REFERENCE)).contains(ConflictHandler.SERIALIZABLE);
+    }
+
+    @Test
+    public void testThatConflictDetectionManagerCachesLookup() throws Exception {
+        when(delegate.load(TABLE_REFERENCE))
+                .thenReturn(ConflictHandler.SERIALIZABLE)
+                .thenReturn(null);
+        assertThat(conflictDetectionManager.get(TABLE_REFERENCE)).contains(ConflictHandler.SERIALIZABLE);
+        // No cache invalidation is performed, consequently we expect the same result. Should cache invalidation be
+        // added in the future, then we need to change this test.
+        assertThat(conflictDetectionManager.get(TABLE_REFERENCE)).contains(ConflictHandler.SERIALIZABLE);
+    }
+}

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -144,11 +144,11 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
     }
 
     private Transaction startTransactionWithOptions(TransactionOptions options) {
-        ImmutableMap<TableReference, Optional<ConflictHandler>> tablesToWriteWrite = ImmutableMap.of(
+        ImmutableMap<TableReference, ConflictHandler> tablesToWriteWrite = ImmutableMap.of(
                 TEST_TABLE,
-                Optional.of(ConflictHandler.SERIALIZABLE),
+                ConflictHandler.SERIALIZABLE,
                 TransactionConstants.TRANSACTION_TABLE,
-                Optional.of(ConflictHandler.IGNORE_ALL));
+                ConflictHandler.IGNORE_ALL);
         return new SerializableTransaction(
                 MetricsManagers.createForTests(),
                 keyValueService,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
@@ -154,11 +154,8 @@ public class CommitLockTest extends TransactionTestSetup {
     }
 
     private Transaction startTransaction(PreCommitCondition preCommitCondition, ConflictHandler conflictHandler) {
-        ImmutableMap<TableReference, Optional<ConflictHandler>> tablesToWriteWrite = ImmutableMap.of(
-                TEST_TABLE,
-                Optional.of(conflictHandler),
-                TransactionConstants.TRANSACTION_TABLE,
-                Optional.of(ConflictHandler.IGNORE_ALL));
+        ImmutableMap<TableReference, ConflictHandler> tablesToWriteWrite = ImmutableMap.of(
+                TEST_TABLE, conflictHandler, TransactionConstants.TRANSACTION_TABLE, ConflictHandler.IGNORE_ALL);
         return new SerializableTransaction(
                 MetricsManagers.createForTests(),
                 keyValueService,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestConflictDetectionManagers.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestConflictDetectionManagers.java
@@ -19,15 +19,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import java.util.Map;
-import java.util.Optional;
 
 public final class TestConflictDetectionManagers {
     private TestConflictDetectionManagers() {}
 
     @VisibleForTesting
-    static ConflictDetectionManager createWithStaticConflictDetection(
-            Map<TableReference, Optional<ConflictHandler>> staticMap) {
-        return new ConflictDetectionManager(tableReference ->
-                staticMap.getOrDefault(tableReference, Optional.of(ConflictHandler.RETRY_ON_WRITE_WRITE)));
+    static ConflictDetectionManager createWithStaticConflictDetection(Map<TableReference, ConflictHandler> staticMap) {
+        return new ConflictDetectionManager(
+                tableReference -> staticMap.getOrDefault(tableReference, ConflictHandler.RETRY_ON_WRITE_WRITE));
     }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManager.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManager.java
@@ -19,14 +19,13 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
-import java.util.Optional;
 
 public interface TestTransactionManager extends TransactionManager {
     Transaction commitAndStartNewTransaction(Transaction txn);
 
     Transaction createNewTransaction();
 
-    void overrideConflictHandlerForTable(TableReference table, Optional<ConflictHandler> conflictHandler);
+    void overrideConflictHandlerForTable(TableReference table, ConflictHandler conflictHandler);
 
     void setUnreadableTimestamp(long timestamp);
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -54,7 +54,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
     static final TransactionConfig TRANSACTION_CONFIG =
             ImmutableTransactionConfig.builder().build();
 
-    private final Map<TableReference, Optional<ConflictHandler>> conflictHandlerOverrides = new HashMap<>();
+    private final Map<TableReference, ConflictHandler> conflictHandlerOverrides = new HashMap<>();
     private final WrapperWithTracker<CallbackAwareTransaction> transactionWrapper;
     private final WrapperWithTracker<KeyValueService> keyValueServiceWrapper;
     private Optional<Long> unreadableTs = Optional.empty();
@@ -234,7 +234,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
     }
 
     @Override
-    public void overrideConflictHandlerForTable(TableReference table, Optional<ConflictHandler> conflictHandler) {
+    public void overrideConflictHandlerForTable(TableReference table, ConflictHandler conflictHandler) {
         conflictHandlerOverrides.put(table, conflictHandler);
     }
 
@@ -248,8 +248,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
         unreadableTs = Optional.of(timestamp);
     }
 
-    private Map<TableReference, Optional<ConflictHandler>> getConflictHandlerWithOverrides() {
-        Map<TableReference, Optional<ConflictHandler>> conflictHandlersWithOverrides = new HashMap<>();
+    private Map<TableReference, ConflictHandler> getConflictHandlerWithOverrides() {
+        Map<TableReference, ConflictHandler> conflictHandlersWithOverrides = new HashMap<>();
         conflictHandlersWithOverrides.putAll(conflictDetectionManager.getCachedValues());
         conflictHandlersWithOverrides.putAll(conflictHandlerOverrides);
         return conflictHandlersWithOverrides;

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrappingTestTransactionManager.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrappingTestTransactionManager.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.transaction.impl;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.Transaction;
-import java.util.Optional;
 
 public abstract class WrappingTestTransactionManager extends WrappingTransactionManager
         implements TestTransactionManager {
@@ -40,7 +39,7 @@ public abstract class WrappingTestTransactionManager extends WrappingTransaction
     }
 
     @Override
-    public void overrideConflictHandlerForTable(TableReference table, Optional<ConflictHandler> conflictHandler) {
+    public void overrideConflictHandlerForTable(TableReference table, ConflictHandler conflictHandler) {
         delegate.overrideConflictHandlerForTable(table, conflictHandler);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -49,7 +49,6 @@ import com.palantir.lock.LockService;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.timelock.paxos.InMemoryTimeLockRule;
 import com.palantir.timestamp.TimestampService;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import org.junit.After;
@@ -150,7 +149,7 @@ public class AtlasDbTestCase {
     }
 
     protected void overrideConflictHandlerForTable(TableReference table, ConflictHandler conflictHandler) {
-        txManager.overrideConflictHandlerForTable(table, Optional.of(conflictHandler));
+        txManager.overrideConflictHandlerForTable(table, conflictHandler);
     }
 
     protected void setConstraintCheckingMode(AtlasDbConstraintCheckingMode mode) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionTest.java
@@ -3269,7 +3269,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 NoOpCleaner.INSTANCE,
                 () -> transactionTs,
                 TestConflictDetectionManagers.createWithStaticConflictDetection(
-                        ImmutableMap.of(TABLE, Optional.of(ConflictHandler.RETRY_ON_WRITE_WRITE))),
+                        ImmutableMap.of(TABLE, ConflictHandler.RETRY_ON_WRITE_WRITE)),
                 SweepStrategyManagers.createDefault(keyValueService),
                 res.getImmutableTimestamp(),
                 Optional.of(res.getLock()),
@@ -3313,8 +3313,6 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
             boolean validateLocksOnReads,
             Map<TableReference, ConflictHandler> tableConflictHandlers) {
         PathTypeTracker pathTypeTracker = PathTypeTrackers.constructSynchronousTracker();
-        Map<TableReference, Optional<ConflictHandler>> optTableConflictHandlers =
-                Maps.transformValues(tableConflictHandlers, Optional::of);
         SnapshotTransaction transaction = new SnapshotTransaction(
                 metricsManager,
                 keyValueServiceWrapper.apply(keyValueService, pathTypeTracker),
@@ -3323,7 +3321,7 @@ public class SnapshotTransactionTest extends AtlasDbTestCase {
                 transactionService,
                 NoOpCleaner.INSTANCE,
                 startTs,
-                TestConflictDetectionManagers.createWithStaticConflictDetection(optTableConflictHandlers),
+                TestConflictDetectionManagers.createWithStaticConflictDetection(tableConflictHandlers),
                 SweepStrategyManagers.createDefault(keyValueService),
                 lockImmutableTimestampResponse.getImmutableTimestamp(),
                 Optional.of(lockImmutableTimestampResponse.getLock()),

--- a/changelog/@unreleased/pr-6743.v2.yml
+++ b/changelog/@unreleased/pr-6743.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: ConflictDetectionManager should not cache negative lookups
+  links:
+  - https://github.com/palantir/atlasdb/pull/6743


### PR DESCRIPTION
## General
**Before this PR**:

ConflictDetectionManager caches negative lookups, which is problematic for any use case, where tables are created/dropped dynamically.

**After this PR**:
ConflictDetectionManager does not cache negative lookups.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
No
**What was existing testing like? What have you done to improve it?**:
No test existed to check that negative lookups won't populate the test. Added such a test with this PR. Note, that it seemed that some of the tests were not executable locally until I added the relevant JUnit Runner.
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
No
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
No
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
An existing issue should disappear, furthermore tests for an internal product will now pass that previously failed.
**Has the safety of all log arguments been decided correctly?**:
Yes
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Yes, perform a recall and rollback.
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No.
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No.
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
We might want to limit dynamic table use cases in the long-term.
## Development Process
**Where should we start reviewing?**:
ConflictDetectionManager.java contains the actual change. Most of the change is propagating the method type change through the codebase. Lastly, I had to a JUnit Runner to actually get the tests to execute locally, which seemed surprising as I would have expected tests to just work. It would be good to check that this addition is indeed correct and ensures that all tests are running as expected.
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
