### PR TITLE
Generated hydrateFromBytes avoids boxing

### DIFF
--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
@@ -348,7 +348,6 @@ public final class AllValueTypesTestTable implements
                 UUID component10 = EncodingUtils.decodeUUID(__input, __index);
                 __index += 16;
                 byte[] blobComponent = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
-                __index += 0;
                 return new AllValueTypesTestRow(component0, component1, component2, component3, component4, component5, component8, component9, component10, blobComponent);
             }
         };
@@ -2133,5 +2132,5 @@ public final class AllValueTypesTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "8ED1ClYWxPcRFR8y49DacA==";
+    static String __CLASS_HASH = "IdCniyyd2ANmSMlwF1CWNQ==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/AllValueTypesTestTable.java
@@ -329,13 +329,13 @@ public final class AllValueTypesTestTable implements
             @Override
             public AllValueTypesTestRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long component0 = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long component0 = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(component0);
-                Long component1 = EncodingUtils.decodeSignedVarLong(__input, __index);
+                long component1 = EncodingUtils.decodeSignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfSignedVarLong(component1);
-                Long component2 = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long component2 = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long component3 = EncodingUtils.decodeLittleEndian(__input, __index);
+                long component3 = EncodingUtils.decodeLittleEndian(__input, __index);
                 __index += 8;
                 Sha256Hash component4 = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
                 __index += 32;
@@ -343,7 +343,7 @@ public final class AllValueTypesTestTable implements
                 __index += EncodingUtils.sizeOfVarString(component5);
                 byte[] component8 = EncodingUtils.decodeSizedBytes(__input, __index);
                 __index += EncodingUtils.sizeOfSizedBytes(component8);
-                Long component9 = EncodingUtils.decodeNullableFixedLong(__input,__index);
+                @Nullable Long component9 = EncodingUtils.decodeNullableFixedLong(__input,__index);
                 __index += 9;
                 UUID component10 = EncodingUtils.decodeUUID(__input, __index);
                 __index += 16;
@@ -2133,5 +2133,5 @@ public final class AllValueTypesTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Wiqs1OWnWhpAhvVYVCck2w==";
+    static String __CLASS_HASH = "8ED1ClYWxPcRFR8y49DacA==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
@@ -203,7 +203,6 @@ public final class HashComponentsTestTable implements
                 long component1 = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(component1);
                 String component2 = EncodingUtils.decodeVarString(__input, __index);
-                __index += EncodingUtils.sizeOfVarString(component2);
                 return new HashComponentsTestRow(hashOfRowComponents, component1, component2);
             }
         };
@@ -788,5 +787,5 @@ public final class HashComponentsTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "EB56JKTE/YiaAD0WFNYA8g==";
+    static String __CLASS_HASH = "JFCKFwjljsA/pF0RqDunaQ==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/HashComponentsTestTable.java
@@ -198,9 +198,9 @@ public final class HashComponentsTestTable implements
             @Override
             public HashComponentsTestRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long component1 = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long component1 = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(component1);
                 String component2 = EncodingUtils.decodeVarString(__input, __index);
                 __index += EncodingUtils.sizeOfVarString(component2);
@@ -788,5 +788,5 @@ public final class HashComponentsTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "mVbrY0jjQd3NuKOQiV/PKg==";
+    static String __CLASS_HASH = "EB56JKTE/YiaAD0WFNYA8g==";
 }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/SchemaApiTestTable.java
@@ -186,7 +186,6 @@ public final class SchemaApiTestTable implements
             public SchemaApiTestRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 String component1 = PtBytes.toString(__input, __index, __input.length-__index);
-                __index += 0;
                 return new SchemaApiTestRow(component1);
             }
         };
@@ -874,5 +873,5 @@ public final class SchemaApiTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "cFj0qWUr9nog+ayklatsig==";
+    static String __CLASS_HASH = "6T4/KZlHu1MZtFWb6dFK5w==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/CompactMetadataTable.java
@@ -186,7 +186,6 @@ public final class CompactMetadataTable implements
             public CompactMetadataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 String fullTableName = PtBytes.toString(__input, __index, __input.length-__index);
-                __index += 0;
                 return new CompactMetadataRow(fullTableName);
             }
         };
@@ -683,5 +682,5 @@ public final class CompactMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "PSwZcMysyzWemW+V1hGphQ==";
+    static String __CLASS_HASH = "QQRKeGa7eTFjhIPgfjpHCw==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepIdToNameTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepIdToNameTable.java
@@ -191,7 +191,6 @@ public final class SweepIdToNameTable implements
                 long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
                 String singleton = PtBytes.toString(__input, __index, __input.length-__index);
-                __index += 0;
                 return new SweepIdToNameRow(hashOfRowComponents, singleton);
             }
         };
@@ -291,7 +290,6 @@ public final class SweepIdToNameTable implements
             public SweepIdToNameColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 long tableId = EncodingUtils.decodeFlippedUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(tableId);
                 return new SweepIdToNameColumn(tableId);
             }
         };
@@ -756,5 +754,5 @@ public final class SweepIdToNameTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "zJX8CsYGyoPYsSpSvWpdAg==";
+    static String __CLASS_HASH = "cwSaXwKpPy2D0gsQd248bA==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepIdToNameTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepIdToNameTable.java
@@ -188,7 +188,7 @@ public final class SweepIdToNameTable implements
             @Override
             public SweepIdToNameRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
                 String singleton = PtBytes.toString(__input, __index, __input.length-__index);
                 __index += 0;
@@ -290,7 +290,7 @@ public final class SweepIdToNameTable implements
             @Override
             public SweepIdToNameColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long tableId = EncodingUtils.decodeFlippedUnsignedVarLong(__input, __index);
+                long tableId = EncodingUtils.decodeFlippedUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(tableId);
                 return new SweepIdToNameColumn(tableId);
             }
@@ -756,5 +756,5 @@ public final class SweepIdToNameTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "XRAvO+BpbFM1l4QIBkArjA==";
+    static String __CLASS_HASH = "zJX8CsYGyoPYsSpSvWpdAg==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepNameToIdTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepNameToIdTable.java
@@ -190,7 +190,7 @@ public final class SweepNameToIdTable implements
             @Override
             public SweepNameToIdRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
                 String table = PtBytes.toString(__input, __index, __input.length-__index);
                 __index += 0;
@@ -697,5 +697,5 @@ public final class SweepNameToIdTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ZVl8vtH0bWDeCq5tKMA3Aw==";
+    static String __CLASS_HASH = "xdwU7E4PMXeVmcQaEmcM7g==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepNameToIdTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepNameToIdTable.java
@@ -193,7 +193,6 @@ public final class SweepNameToIdTable implements
                 long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
                 String table = PtBytes.toString(__input, __index, __input.length-__index);
-                __index += 0;
                 return new SweepNameToIdRow(hashOfRowComponents, table);
             }
         };
@@ -697,5 +696,5 @@ public final class SweepNameToIdTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "xdwU7E4PMXeVmcQaEmcM7g==";
+    static String __CLASS_HASH = "/1iBN6AFRFn7Ox8jlME0uQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepPriorityTable.java
@@ -186,7 +186,6 @@ public final class SweepPriorityTable implements
             public SweepPriorityRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 String fullTableName = PtBytes.toString(__input, __index, __input.length-__index);
-                __index += 0;
                 return new SweepPriorityRow(fullTableName);
             }
         };
@@ -1253,5 +1252,5 @@ public final class SweepPriorityTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "rABMHBdCo+LhmxyLoeFFwQ==";
+    static String __CLASS_HASH = "jyafdmhR7jh18jwGpaXZSw==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
@@ -198,9 +198,9 @@ public final class SweepShardProgressTable implements
             @Override
             public SweepShardProgressRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long shard = EncodingUtils.decodeSignedVarLong(__input, __index);
+                long shard = EncodingUtils.decodeSignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfSignedVarLong(shard);
                 byte[] sweepConservative = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
                 __index += 0;
@@ -709,5 +709,5 @@ public final class SweepShardProgressTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "2Fj81SsG3WRpPjQ1kYDw3A==";
+    static String __CLASS_HASH = "9dlQJAgP79tNkzm2LTn+Dg==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepShardProgressTable.java
@@ -203,7 +203,6 @@ public final class SweepShardProgressTable implements
                 long shard = EncodingUtils.decodeSignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfSignedVarLong(shard);
                 byte[] sweepConservative = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
-                __index += 0;
                 return new SweepShardProgressRow(hashOfRowComponents, shard, sweepConservative);
             }
         };
@@ -709,5 +708,5 @@ public final class SweepShardProgressTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "9dlQJAgP79tNkzm2LTn+Dg==";
+    static String __CLASS_HASH = "SvNu5DSDRhu6PrqJw5CVSA==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
@@ -201,7 +201,6 @@ public final class SweepableCellsTable implements
                 long timestampPartition = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(timestampPartition);
                 byte[] metadata = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
-                __index += 0;
                 return new SweepableCellsRow(hashOfRowComponents, timestampPartition, metadata);
             }
         };
@@ -313,7 +312,6 @@ public final class SweepableCellsTable implements
                 long timestampModulus = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(timestampModulus);
                 long writeIndex = EncodingUtils.decodeSignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfSignedVarLong(writeIndex);
                 return new SweepableCellsColumn(timestampModulus, writeIndex);
             }
         };
@@ -791,5 +789,5 @@ public final class SweepableCellsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "kRRSsINJBszPwSYfxAlwFg==";
+    static String __CLASS_HASH = "6dECi+2I9ZH+Ov279pcYtQ==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableCellsTable.java
@@ -196,9 +196,9 @@ public final class SweepableCellsTable implements
             @Override
             public SweepableCellsRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long timestampPartition = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long timestampPartition = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(timestampPartition);
                 byte[] metadata = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
                 __index += 0;
@@ -310,9 +310,9 @@ public final class SweepableCellsTable implements
             @Override
             public SweepableCellsColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long timestampModulus = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long timestampModulus = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(timestampModulus);
-                Long writeIndex = EncodingUtils.decodeSignedVarLong(__input, __index);
+                long writeIndex = EncodingUtils.decodeSignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfSignedVarLong(writeIndex);
                 return new SweepableCellsColumn(timestampModulus, writeIndex);
             }
@@ -791,5 +791,5 @@ public final class SweepableCellsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "hMikiCT1ysKqkzSOdiKujg==";
+    static String __CLASS_HASH = "kRRSsINJBszPwSYfxAlwFg==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
@@ -220,7 +220,6 @@ public final class SweepableTimestampsTable implements
                 long timestampPartition = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(timestampPartition);
                 byte[] sweepConservative = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
-                __index += 0;
                 return new SweepableTimestampsRow(hashOfRowComponents, shard, timestampPartition, sweepConservative);
             }
         };
@@ -323,7 +322,6 @@ public final class SweepableTimestampsTable implements
             public SweepableTimestampsColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 long timestampModulus = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(timestampModulus);
                 return new SweepableTimestampsColumn(timestampModulus);
             }
         };
@@ -788,5 +786,5 @@ public final class SweepableTimestampsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "FKovEp3j6vAydV9KHfv/4Q==";
+    static String __CLASS_HASH = "XqySBVqRPmKhMv7rQgdCuw==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepableTimestampsTable.java
@@ -213,11 +213,11 @@ public final class SweepableTimestampsTable implements
             @Override
             public SweepableTimestampsRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long shard = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long shard = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(shard);
-                Long timestampPartition = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long timestampPartition = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(timestampPartition);
                 byte[] sweepConservative = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
                 __index += 0;
@@ -322,7 +322,7 @@ public final class SweepableTimestampsTable implements
             @Override
             public SweepableTimestampsColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long timestampModulus = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long timestampModulus = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(timestampModulus);
                 return new SweepableTimestampsColumn(timestampModulus);
             }
@@ -788,5 +788,5 @@ public final class SweepableTimestampsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "66qq5d5do+PszHk7DehVPA==";
+    static String __CLASS_HASH = "FKovEp3j6vAydV9KHfv/4Q==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TableClearsTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/TableClearsTable.java
@@ -186,7 +186,6 @@ public final class TableClearsTable implements
             public TableClearsRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 String table = PtBytes.toString(__input, __index, __input.length-__index);
-                __index += 0;
                 return new TableClearsRow(table);
             }
         };
@@ -683,5 +682,5 @@ public final class TableClearsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Wm/9d03F9WHgPC5jjTUOaA==";
+    static String __CLASS_HASH = "g9VvRKGTKPXfDJSGLE056Q==";
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ValueType.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/ValueType.java
@@ -24,6 +24,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.util.Pair;
 import com.palantir.util.crypto.Sha256Hash;
 import java.io.IOException;
+import java.util.Locale;
 
 public enum ValueType {
     /**
@@ -889,7 +890,12 @@ public enum ValueType {
     }
 
     public String getJavaClassName() {
-        return getJavaClass().getSimpleName();
+        Class<?> clazz = getJavaClass();
+        String simpleName = clazz.getSimpleName();
+        if (clazz.isPrimitive()) {
+            return simpleName.toLowerCase(Locale.ROOT);
+        }
+        return simpleName;
     }
 
     public String getJavaObjectClassName() {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/RowOrDynamicColumnRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/RowOrDynamicColumnRenderer.java
@@ -231,7 +231,9 @@ class RowOrDynamicColumnRenderer extends Renderer {
             {
                 line("int __index = 0;");
                 List<String> vars = new ArrayList<>();
-                for (NameComponentDescription comp : desc.getRowParts()) {
+                List<NameComponentDescription> rowParts = desc.getRowParts();
+                for (int i = 0; i < rowParts.size(); i++) {
+                    NameComponentDescription comp = rowParts.get(i);
                     String var = varName(comp);
                     vars.add(var);
                     if (comp.getOrder() == ValueByteOrder.ASCENDING) {
@@ -245,7 +247,9 @@ class RowOrDynamicColumnRenderer extends Renderer {
                                 comp.getType().getFlippedHydrateCode("__input", "__index"),
                                 ";");
                     }
-                    line("__index += ", comp.getType().getHydrateSizeCode(var), ";");
+                    if (i < rowParts.size() - 1) {
+                        line("__index += ", comp.getType().getHydrateSizeCode(var), ";");
+                    }
                 }
                 line("return new ", Name, "(", Joiner.on(", ").join(vars), ");");
             }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/RowOrDynamicColumnRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/RowOrDynamicColumnRenderer.java
@@ -235,10 +235,10 @@ class RowOrDynamicColumnRenderer extends Renderer {
                     String var = varName(comp);
                     vars.add(var);
                     if (comp.getOrder() == ValueByteOrder.ASCENDING) {
-                        line(TypeName(comp), " ", var, " = ", comp.getType().getHydrateCode("__input", "__index"), ";");
+                        line(typeName(comp), " ", var, " = ", comp.getType().getHydrateCode("__input", "__index"), ";");
                     } else {
                         line(
-                                TypeName(comp),
+                                typeName(comp),
                                 " ",
                                 var,
                                 " = ",

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/GenericRangeScanTestTable.java
@@ -184,7 +184,6 @@ public final class GenericRangeScanTestTable implements
             public GenericRangeScanTestRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 Sha256Hash component1 = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
-                __index += 32;
                 return new GenericRangeScanTestRow(component1);
             }
         };
@@ -276,7 +275,6 @@ public final class GenericRangeScanTestTable implements
             public GenericRangeScanTestColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 String component2 = PtBytes.toString(__input, __index, __input.length-__index);
-                __index += 0;
                 return new GenericRangeScanTestColumn(component2);
             }
         };
@@ -807,5 +805,5 @@ public final class GenericRangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "YkaZuzFs8LBGmT3/H/I5eg==";
+    static String __CLASS_HASH = "CrHC8CYd3pN7BfEmkYogJg==";
 }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/generated/RangeScanTestTable.java
@@ -186,7 +186,6 @@ public final class RangeScanTestTable implements
             public RangeScanTestRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 String component1 = PtBytes.toString(__input, __index, __input.length-__index);
-                __index += 0;
                 return new RangeScanTestRow(component1);
             }
         };
@@ -745,5 +744,5 @@ public final class RangeScanTestTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "1i+tNWsmUREmFNoXh6QUeg==";
+    static String __CLASS_HASH = "GZhYC3jIPXsOpLDysjUtCQ==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/LatestSnapshotTable.java
@@ -185,8 +185,7 @@ public final class LatestSnapshotTable implements
             @Override
             public LatestSnapshotRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long key = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
+                long key = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 return new LatestSnapshotRow(key);
             }
         };
@@ -683,5 +682,5 @@ public final class LatestSnapshotTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "IGBmCsqLmahL4VNCmymeTA==";
+    static String __CLASS_HASH = "6HLCCFK0eks9tZjKEzusHg==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/NamespacedTodoTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/NamespacedTodoTable.java
@@ -184,7 +184,6 @@ public final class NamespacedTodoTable implements
             public NamespacedTodoRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 String namespace = PtBytes.toString(__input, __index, __input.length-__index);
-                __index += 0;
                 return new NamespacedTodoRow(namespace);
             }
         };
@@ -275,8 +274,7 @@ public final class NamespacedTodoTable implements
             @Override
             public NamespacedTodoColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long todoId = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
+                long todoId = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 return new NamespacedTodoColumn(todoId);
             }
         };
@@ -741,5 +739,5 @@ public final class NamespacedTodoTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "hQ6/1zRsdc2LBKW0GTYdpw==";
+    static String __CLASS_HASH = "0KMTkWzIpSNPRHUjaRS78Q==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamHashAidxTable.java
@@ -184,7 +184,6 @@ public final class SnapshotsStreamHashAidxTable implements
             public SnapshotsStreamHashAidxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
-                __index += 32;
                 return new SnapshotsStreamHashAidxRow(hash);
             }
         };
@@ -275,8 +274,7 @@ public final class SnapshotsStreamHashAidxTable implements
             @Override
             public SnapshotsStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long streamId = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
+                long streamId = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 return new SnapshotsStreamHashAidxColumn(streamId);
             }
         };
@@ -741,5 +739,5 @@ public final class SnapshotsStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "D9OdSrGepZI1dcZ5KV7B0g==";
+    static String __CLASS_HASH = "CKw0OLIs4Oh7oquRushu3Q==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamIdxTable.java
@@ -183,8 +183,7 @@ public final class SnapshotsStreamIdxTable implements
             @Override
             public SnapshotsStreamIdxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
+                long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 return new SnapshotsStreamIdxRow(id);
             }
         };
@@ -276,7 +275,6 @@ public final class SnapshotsStreamIdxTable implements
             public SnapshotsStreamIdxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
-                __index += EncodingUtils.sizeOfSizedBytes(reference);
                 return new SnapshotsStreamIdxColumn(reference);
             }
         };
@@ -741,5 +739,5 @@ public final class SnapshotsStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Ql7tNJ0Z5v0pWFviP9dcuw==";
+    static String __CLASS_HASH = "XlUV87CuNtj1EjGNO3ciKQ==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamMetadataTable.java
@@ -185,8 +185,7 @@ public final class SnapshotsStreamMetadataTable implements
             @Override
             public SnapshotsStreamMetadataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
+                long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 return new SnapshotsStreamMetadataRow(id);
             }
         };
@@ -708,5 +707,5 @@ public final class SnapshotsStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "AgT8WHSuUvJzkk+inw4twg==";
+    static String __CLASS_HASH = "X1A0s/Ak7gFq6exUuTBR2g==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/SnapshotsStreamValueTable.java
@@ -193,10 +193,9 @@ public final class SnapshotsStreamValueTable implements
             @Override
             public SnapshotsStreamValueRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new SnapshotsStreamValueRow(id, blockId);
             }
         };
@@ -695,5 +694,5 @@ public final class SnapshotsStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "9m/lRuE/UHMttmLTS1Q8iQ==";
+    static String __CLASS_HASH = "UXSNiIqSbKHDYoqxIMkQ8w==";
 }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/todo/generated/TodoTable.java
@@ -185,8 +185,7 @@ public final class TodoTable implements
             @Override
             public TodoRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
+                long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 return new TodoRow(id);
             }
         };
@@ -683,5 +682,5 @@ public final class TodoTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "1g5OdW5n4H7icFXg1gG2Xg==";
+    static String __CLASS_HASH = "3328838I0NbftP+sl5/Wng==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/AuditedDataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/AuditedDataTable.java
@@ -185,8 +185,7 @@ public final class AuditedDataTable implements
             @Override
             public AuditedDataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
+                long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 return new AuditedDataRow(id);
             }
         };
@@ -683,5 +682,5 @@ public final class AuditedDataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "AkImLEM5fv/Ji8qCyRf5dw==";
+    static String __CLASS_HASH = "QG5ZCttRdnW+7PS1RevjMg==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamHashAidxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamHashAidxTable.java
@@ -184,7 +184,6 @@ public final class DataStreamHashAidxTable implements
             public DataStreamHashAidxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
-                __index += 32;
                 return new DataStreamHashAidxRow(hash);
             }
         };
@@ -275,8 +274,7 @@ public final class DataStreamHashAidxTable implements
             @Override
             public DataStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(streamId);
+                long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new DataStreamHashAidxColumn(streamId);
             }
         };
@@ -741,5 +739,5 @@ public final class DataStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "4xCW34HnUp0WcB647QLiyQ==";
+    static String __CLASS_HASH = "y4vXo2YnS6A50qub5RZtow==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamIdxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamIdxTable.java
@@ -188,10 +188,9 @@ public final class DataStreamIdxTable implements
             @Override
             public DataStreamIdxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new DataStreamIdxRow(hashOfRowComponents, id);
             }
         };
@@ -290,7 +289,6 @@ public final class DataStreamIdxTable implements
             public DataStreamIdxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
-                __index += EncodingUtils.sizeOfSizedBytes(reference);
                 return new DataStreamIdxColumn(reference);
             }
         };
@@ -755,5 +753,5 @@ public final class DataStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "Cv4WRWZ3CKVWR5IhFRmgLg==";
+    static String __CLASS_HASH = "qt/gzESF0v1CXmCRo7xDmA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamMetadataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamMetadataTable.java
@@ -190,10 +190,9 @@ public final class DataStreamMetadataTable implements
             @Override
             public DataStreamMetadataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new DataStreamMetadataRow(hashOfRowComponents, id);
             }
         };
@@ -722,5 +721,5 @@ public final class DataStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "AFwooxC06krTqFv58UfkcA==";
+    static String __CLASS_HASH = "n3Rdw9HOanL7KyRaXDxIfA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/DataStreamValueTable.java
@@ -198,12 +198,11 @@ public final class DataStreamValueTable implements
             @Override
             public DataStreamValueRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(id);
-                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new DataStreamValueRow(hashOfRowComponents, id, blockId);
             }
         };
@@ -710,5 +709,5 @@ public final class DataStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "hogeDv0tsmrHDkXuhcwteQ==";
+    static String __CLASS_HASH = "uLIifazHIhaTNcmyxPSogw==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamHashAidxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamHashAidxTable.java
@@ -184,7 +184,6 @@ public final class HotspottyDataStreamHashAidxTable implements
             public HotspottyDataStreamHashAidxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
-                __index += 32;
                 return new HotspottyDataStreamHashAidxRow(hash);
             }
         };
@@ -275,8 +274,7 @@ public final class HotspottyDataStreamHashAidxTable implements
             @Override
             public HotspottyDataStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long streamId = EncodingUtils.decodeSignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfSignedVarLong(streamId);
+                long streamId = EncodingUtils.decodeSignedVarLong(__input, __index);
                 return new HotspottyDataStreamHashAidxColumn(streamId);
             }
         };
@@ -741,5 +739,5 @@ public final class HotspottyDataStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "NOiRKvLXsadPhJ4N/aae6Q==";
+    static String __CLASS_HASH = "wD5i2Ej7LSFXwM9HGarLmg==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamIdxTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamIdxTable.java
@@ -183,8 +183,7 @@ public final class HotspottyDataStreamIdxTable implements
             @Override
             public HotspottyDataStreamIdxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeSignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfSignedVarLong(id);
+                long id = EncodingUtils.decodeSignedVarLong(__input, __index);
                 return new HotspottyDataStreamIdxRow(id);
             }
         };
@@ -276,7 +275,6 @@ public final class HotspottyDataStreamIdxTable implements
             public HotspottyDataStreamIdxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
-                __index += EncodingUtils.sizeOfSizedBytes(reference);
                 return new HotspottyDataStreamIdxColumn(reference);
             }
         };
@@ -741,5 +739,5 @@ public final class HotspottyDataStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "lWy4z6m1ZmwcuY4d/ez8Rw==";
+    static String __CLASS_HASH = "ZiQ90N0bbO0EUy1RQiuEsA==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamMetadataTable.java
@@ -185,8 +185,7 @@ public final class HotspottyDataStreamMetadataTable implements
             @Override
             public HotspottyDataStreamMetadataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeSignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfSignedVarLong(id);
+                long id = EncodingUtils.decodeSignedVarLong(__input, __index);
                 return new HotspottyDataStreamMetadataRow(id);
             }
         };
@@ -708,5 +707,5 @@ public final class HotspottyDataStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "KLkPI2rjlr8itPxC4ZWJLg==";
+    static String __CLASS_HASH = "HCyOLwlDFw+vVVcDaLLuhQ==";
 }

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamValueTable.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/blob/generated/HotspottyDataStreamValueTable.java
@@ -193,10 +193,9 @@ public final class HotspottyDataStreamValueTable implements
             @Override
             public HotspottyDataStreamValueRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeSignedVarLong(__input, __index);
+                long id = EncodingUtils.decodeSignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfSignedVarLong(id);
-                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new HotspottyDataStreamValueRow(id, blockId);
             }
         };
@@ -695,5 +694,5 @@ public final class HotspottyDataStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "9KSCRtbyVXFg2nb/7Wc8OA==";
+    static String __CLASS_HASH = "sfz69t78uujJz/42PiQM0g==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/KeyValueTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/KeyValueTable.java
@@ -186,7 +186,6 @@ public final class KeyValueTable implements
             public KeyValueRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 String key = PtBytes.toString(__input, __index, __input.length-__index);
-                __index += 0;
                 return new KeyValueRow(key);
             }
         };
@@ -745,5 +744,5 @@ public final class KeyValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "EvFEiQbULvhKQD1IWFw9Og==";
+    static String __CLASS_HASH = "sJ5seL0VJL4Lv9y+idSNvQ==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamHashAidxTable.java
@@ -184,7 +184,6 @@ public final class ValueStreamHashAidxTable implements
             public ValueStreamHashAidxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
-                __index += 32;
                 return new ValueStreamHashAidxRow(hash);
             }
         };
@@ -275,8 +274,7 @@ public final class ValueStreamHashAidxTable implements
             @Override
             public ValueStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(streamId);
+                long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new ValueStreamHashAidxColumn(streamId);
             }
         };
@@ -741,5 +739,5 @@ public final class ValueStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "JgFB0UN+4Pm4N3LOPvQBgQ==";
+    static String __CLASS_HASH = "n2MoW0MdcuhJSPi0iPVWyA==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamIdxTable.java
@@ -183,8 +183,7 @@ public final class ValueStreamIdxTable implements
             @Override
             public ValueStreamIdxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new ValueStreamIdxRow(id);
             }
         };
@@ -276,7 +275,6 @@ public final class ValueStreamIdxTable implements
             public ValueStreamIdxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
-                __index += EncodingUtils.sizeOfSizedBytes(reference);
                 return new ValueStreamIdxColumn(reference);
             }
         };
@@ -741,5 +739,5 @@ public final class ValueStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "bEOuPNCg8sYuyW4OuRhvww==";
+    static String __CLASS_HASH = "4JOzs4T2IPJl0wzMkF26Cw==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamMetadataTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamMetadataTable.java
@@ -185,8 +185,7 @@ public final class ValueStreamMetadataTable implements
             @Override
             public ValueStreamMetadataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new ValueStreamMetadataRow(id);
             }
         };
@@ -708,5 +707,5 @@ public final class ValueStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "lqzqHpNRg+/IVPQNyNYi8w==";
+    static String __CLASS_HASH = "wJtUD7x1V8oE47tDZQf1lQ==";
 }

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamValueTable.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/schema/generated/ValueStreamValueTable.java
@@ -193,10 +193,9 @@ public final class ValueStreamValueTable implements
             @Override
             public ValueStreamValueRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(id);
-                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new ValueStreamValueRow(id, blockId);
             }
         };
@@ -695,5 +694,5 @@ public final class ValueStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "uFwDglAaZjBu9w6E/JkGTA==";
+    static String __CLASS_HASH = "NJNhS6PvLJS+wg86/MRGjA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/ptobject/EncodingUtilsTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/ptobject/EncodingUtilsTest.java
@@ -54,20 +54,22 @@ public class EncodingUtilsTest {
         byte[] bytes = new byte[1000];
         for (int i = 0; i < 100; i++) {
             rand.nextBytes(bytes);
-            assertThat(EncodingUtils.flipAllBits(EncodingUtils.flipAllBits(bytes)))
-                    .isEqualTo(bytes);
+            byte[] flippedBits = EncodingUtils.flipAllBits(bytes);
+            assertThat(flippedBits).isNotEqualTo(bytes);
+            assertThat(EncodingUtils.flipAllBits(flippedBits)).isEqualTo(bytes);
         }
     }
 
     @Test
-    public void testVarString() throws Exception {
+    public void testVarString() {
         for (int i = 1; i < 100; i++) {
             byte[] bytes = new byte[1000];
             rand.nextBytes(bytes);
             String str = new String(bytes, StandardCharsets.UTF_8);
-            assertThat(EncodingUtils.decodeVarString(EncodingUtils.encodeVarString(str))
-                            .getBytes(StandardCharsets.UTF_8))
-                    .isEqualTo(str.getBytes(StandardCharsets.UTF_8));
+            assertThat(EncodingUtils.decodeVarString(EncodingUtils.encodeVarString(str)))
+                    .isEqualTo(str)
+                    .satisfies(decoded -> assertThat(decoded.getBytes(StandardCharsets.UTF_8))
+                            .isEqualTo(str.getBytes(StandardCharsets.UTF_8)));
             assertThat(EncodingUtils.encodeVarString(str)).hasSize(EncodingUtils.sizeOfVarString(str));
         }
     }
@@ -130,10 +132,8 @@ public class EncodingUtilsTest {
 
         while (map.size() < 3000) {
             long nextLong = rand.nextInt(1 << 20);
-            if (nextLong >= 0) {
-                byte[] encode = EncodingUtils.encodeVarLong(nextLong);
-                map.put(encode, nextLong);
-            }
+            byte[] encode = EncodingUtils.encodeVarLong(nextLong);
+            map.put(encode, nextLong);
         }
 
         map.put(EncodingUtils.encodeVarLong(0), 0L);
@@ -276,7 +276,7 @@ public class EncodingUtilsTest {
         for (int j = 0; j < 50; j++) {
             byte[] bytesToHash = new byte[256];
             rand.nextBytes(bytesToHash);
-            List<Object> defaultComponents = ImmutableList.<Object>of(
+            List<Object> defaultComponents = ImmutableList.of(
                     rand.nextLong(),
                     rand.nextLong(),
                     Sha256Hash.computeHash(bytesToHash),

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/DataTable.java
@@ -185,8 +185,7 @@ public final class DataTable implements
             @Override
             public DataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
+                long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 return new DataRow(id);
             }
         };
@@ -923,8 +922,7 @@ public final class DataTable implements
                 @Override
                 public Index1IdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
-                    Long value = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                    __index += 8;
+                    long value = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     return new Index1IdxRow(value);
                 }
             };
@@ -1044,8 +1042,7 @@ public final class DataTable implements
                     __index += EncodingUtils.sizeOfSizedBytes(rowName);
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(columnName);
-                    Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                    __index += 8;
+                    long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     return new Index1IdxColumn(rowName, columnName, id);
                 }
             };
@@ -1625,10 +1622,9 @@ public final class DataTable implements
                 @Override
                 public Index2IdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
-                    Long value = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                    long value = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     __index += 8;
-                    Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                    __index += 8;
+                    long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     return new Index2IdxRow(value, id);
                 }
             };
@@ -1742,7 +1738,6 @@ public final class DataTable implements
                     byte[] rowName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(rowName);
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
-                    __index += EncodingUtils.sizeOfSizedBytes(columnName);
                     return new Index2IdxColumn(rowName, columnName);
                 }
             };
@@ -2299,8 +2294,7 @@ public final class DataTable implements
                 @Override
                 public Index3IdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
-                    Long value = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                    __index += 8;
+                    long value = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     return new Index3IdxRow(value);
                 }
             };
@@ -2402,7 +2396,6 @@ public final class DataTable implements
                     byte[] rowName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(rowName);
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
-                    __index += EncodingUtils.sizeOfSizedBytes(columnName);
                     return new Index3IdxColumn(rowName, columnName);
                 }
             };
@@ -2967,10 +2960,9 @@ public final class DataTable implements
                 @Override
                 public Index4IdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
-                    Long value1 = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                    long value1 = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     __index += 8;
-                    Long value2 = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                    __index += 8;
+                    long value2 = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     return new Index4IdxRow(value1, value2);
                 }
             };
@@ -3084,7 +3076,6 @@ public final class DataTable implements
                     byte[] rowName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(rowName);
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
-                    __index += EncodingUtils.sizeOfSizedBytes(columnName);
                     return new Index4IdxColumn(rowName, columnName);
                 }
             };
@@ -3630,5 +3621,5 @@ public final class DataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "fgza/c8nH19LqrftPRIqiA==";
+    static String __CLASS_HASH = "3/I+XbButguZbFZ2R5qd5g==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/indexing/generated/TwoColumnsTable.java
@@ -185,8 +185,7 @@ public final class TwoColumnsTable implements
             @Override
             public TwoColumnsRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
+                long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 return new TwoColumnsRow(id);
             }
         };
@@ -941,8 +940,7 @@ public final class TwoColumnsTable implements
                 @Override
                 public FooToIdCondIdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
-                    Long foo = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                    __index += 8;
+                    long foo = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     return new FooToIdCondIdxRow(foo);
                 }
             };
@@ -1062,8 +1060,7 @@ public final class TwoColumnsTable implements
                     __index += EncodingUtils.sizeOfSizedBytes(rowName);
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(columnName);
-                    Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                    __index += 8;
+                    long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     return new FooToIdCondIdxColumn(rowName, columnName, id);
                 }
             };
@@ -1574,10 +1571,9 @@ public final class TwoColumnsTable implements
                 @Override
                 public FooToIdIdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
-                    Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                    long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     __index += 8;
-                    Long foo = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                    __index += 8;
+                    long foo = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     return new FooToIdIdxRow(hashOfRowComponents, foo);
                 }
             };
@@ -1704,8 +1700,7 @@ public final class TwoColumnsTable implements
                     __index += EncodingUtils.sizeOfSizedBytes(rowName);
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(columnName);
-                    Long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                    __index += 8;
+                    long id = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                     return new FooToIdIdxColumn(rowName, columnName, id);
                 }
             };
@@ -2200,5 +2195,5 @@ public final class TwoColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "KStjuJG0LJnDxQ1sOAdxdg==";
+    static String __CLASS_HASH = "FETKveB3dAVBAvG0TlmsZA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/KeyValueTable.java
@@ -186,7 +186,6 @@ public final class KeyValueTable implements
             public KeyValueRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 String key = PtBytes.toString(__input, __index, __input.length-__index);
-                __index += 0;
                 return new KeyValueRow(key);
             }
         };
@@ -683,5 +682,5 @@ public final class KeyValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "4kr4uM+Pm0pXXBnI3Rwp/g==";
+    static String __CLASS_HASH = "3bRq4HuEFy/cHMCOMOFptw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamHashAidxTable.java
@@ -184,7 +184,6 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
             public StreamTestMaxMemStreamHashAidxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
-                __index += 32;
                 return new StreamTestMaxMemStreamHashAidxRow(hash);
             }
         };
@@ -275,8 +274,7 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
             @Override
             public StreamTestMaxMemStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(streamId);
+                long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestMaxMemStreamHashAidxColumn(streamId);
             }
         };
@@ -741,5 +739,5 @@ public final class StreamTestMaxMemStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "QDCK4a9zv6EgLNkYkrAVPQ==";
+    static String __CLASS_HASH = "2xWa4F3zbEH5XTNUIe0kZQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamIdxTable.java
@@ -183,8 +183,7 @@ public final class StreamTestMaxMemStreamIdxTable implements
             @Override
             public StreamTestMaxMemStreamIdxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestMaxMemStreamIdxRow(id);
             }
         };
@@ -276,7 +275,6 @@ public final class StreamTestMaxMemStreamIdxTable implements
             public StreamTestMaxMemStreamIdxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
-                __index += EncodingUtils.sizeOfSizedBytes(reference);
                 return new StreamTestMaxMemStreamIdxColumn(reference);
             }
         };
@@ -741,5 +739,5 @@ public final class StreamTestMaxMemStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ZrY7oPqs4lWL5Vm3ZAOfyQ==";
+    static String __CLASS_HASH = "FAkSXmHk8gPsoI+9LOB3uA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamMetadataTable.java
@@ -185,8 +185,7 @@ public final class StreamTestMaxMemStreamMetadataTable implements
             @Override
             public StreamTestMaxMemStreamMetadataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestMaxMemStreamMetadataRow(id);
             }
         };
@@ -708,5 +707,5 @@ public final class StreamTestMaxMemStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "k1qnaFkT6dVNCXg3oBI4WQ==";
+    static String __CLASS_HASH = "Yg0fNncEuyxjhLhqzU42cA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestMaxMemStreamValueTable.java
@@ -193,10 +193,9 @@ public final class StreamTestMaxMemStreamValueTable implements
             @Override
             public StreamTestMaxMemStreamValueRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(id);
-                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestMaxMemStreamValueRow(id, blockId);
             }
         };
@@ -695,5 +694,5 @@ public final class StreamTestMaxMemStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "pYIryyxlhArJOo7k0Zv3dA==";
+    static String __CLASS_HASH = "lLPuYDp2Vb/e+lYgjC9m/A==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamHashAidxTable.java
@@ -184,7 +184,6 @@ public final class StreamTestStreamHashAidxTable implements
             public StreamTestStreamHashAidxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
-                __index += 32;
                 return new StreamTestStreamHashAidxRow(hash);
             }
         };
@@ -275,8 +274,7 @@ public final class StreamTestStreamHashAidxTable implements
             @Override
             public StreamTestStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(streamId);
+                long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestStreamHashAidxColumn(streamId);
             }
         };
@@ -741,5 +739,5 @@ public final class StreamTestStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "aO3hKAuHYd9vJquk5PiY1w==";
+    static String __CLASS_HASH = "Q4gpslGRh0a0XXgMSMihOw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamIdxTable.java
@@ -183,8 +183,7 @@ public final class StreamTestStreamIdxTable implements
             @Override
             public StreamTestStreamIdxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestStreamIdxRow(id);
             }
         };
@@ -276,7 +275,6 @@ public final class StreamTestStreamIdxTable implements
             public StreamTestStreamIdxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
-                __index += EncodingUtils.sizeOfSizedBytes(reference);
                 return new StreamTestStreamIdxColumn(reference);
             }
         };
@@ -741,5 +739,5 @@ public final class StreamTestStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "hWTBrXR/SoJCr/v5CGBp5Q==";
+    static String __CLASS_HASH = "vR8MQAURU4H5sKpVfEr/rQ==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamMetadataTable.java
@@ -185,8 +185,7 @@ public final class StreamTestStreamMetadataTable implements
             @Override
             public StreamTestStreamMetadataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestStreamMetadataRow(id);
             }
         };
@@ -708,5 +707,5 @@ public final class StreamTestStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "I4QsHKuDj4n21oCZPrbGRw==";
+    static String __CLASS_HASH = "N8Az5Pp05mvzafhLtq16mw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestStreamValueTable.java
@@ -193,10 +193,9 @@ public final class StreamTestStreamValueTable implements
             @Override
             public StreamTestStreamValueRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(id);
-                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestStreamValueRow(id, blockId);
             }
         };
@@ -695,5 +694,5 @@ public final class StreamTestStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "/Af3nGP1PVa3CpaveqZwGA==";
+    static String __CLASS_HASH = "IgW+W5zvnGsmgpCrVoi6kw==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamHashAidxTable.java
@@ -184,7 +184,6 @@ public final class StreamTestWithHashStreamHashAidxTable implements
             public StreamTestWithHashStreamHashAidxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
-                __index += 32;
                 return new StreamTestWithHashStreamHashAidxRow(hash);
             }
         };
@@ -275,8 +274,7 @@ public final class StreamTestWithHashStreamHashAidxTable implements
             @Override
             public StreamTestWithHashStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(streamId);
+                long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestWithHashStreamHashAidxColumn(streamId);
             }
         };
@@ -741,5 +739,5 @@ public final class StreamTestWithHashStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "lE3nxoiGnxh9y5ILD8Ji1Q==";
+    static String __CLASS_HASH = "uV/c4/sGT7PGbjN1h2Ib6g==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamIdxTable.java
@@ -188,10 +188,9 @@ public final class StreamTestWithHashStreamIdxTable implements
             @Override
             public StreamTestWithHashStreamIdxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestWithHashStreamIdxRow(hashOfRowComponents, id);
             }
         };
@@ -290,7 +289,6 @@ public final class StreamTestWithHashStreamIdxTable implements
             public StreamTestWithHashStreamIdxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
-                __index += EncodingUtils.sizeOfSizedBytes(reference);
                 return new StreamTestWithHashStreamIdxColumn(reference);
             }
         };
@@ -755,5 +753,5 @@ public final class StreamTestWithHashStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "R1lO5ziYaN0Udjl/IakPew==";
+    static String __CLASS_HASH = "/xb7vxYLuxuOkjCa2DXEWg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamMetadataTable.java
@@ -190,10 +190,9 @@ public final class StreamTestWithHashStreamMetadataTable implements
             @Override
             public StreamTestWithHashStreamMetadataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestWithHashStreamMetadataRow(hashOfRowComponents, id);
             }
         };
@@ -722,5 +721,5 @@ public final class StreamTestWithHashStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ZnMVClEGG1k/Y9BfO/PktA==";
+    static String __CLASS_HASH = "8L5voEwOJhQutdhTcazkpA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/StreamTestWithHashStreamValueTable.java
@@ -198,12 +198,11 @@ public final class StreamTestWithHashStreamValueTable implements
             @Override
             public StreamTestWithHashStreamValueRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(id);
-                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new StreamTestWithHashStreamValueRow(hashOfRowComponents, id, blockId);
             }
         };
@@ -709,5 +708,5 @@ public final class StreamTestWithHashStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "uywx4Vs+y/rXbP+WoU1Vqg==";
+    static String __CLASS_HASH = "Fnd+T8DEDUGmJFRXD1Y9eA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamHashAidxTable.java
@@ -184,7 +184,6 @@ public final class TestHashComponentsStreamHashAidxTable implements
             public TestHashComponentsStreamHashAidxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
-                __index += 32;
                 return new TestHashComponentsStreamHashAidxRow(hash);
             }
         };
@@ -275,8 +274,7 @@ public final class TestHashComponentsStreamHashAidxTable implements
             @Override
             public TestHashComponentsStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(streamId);
+                long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new TestHashComponentsStreamHashAidxColumn(streamId);
             }
         };
@@ -741,5 +739,5 @@ public final class TestHashComponentsStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "52McDDADyoK80XG2PM7xUQ==";
+    static String __CLASS_HASH = "gFnxCSc8R5vUhv7fKn4xgA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamIdxTable.java
@@ -188,10 +188,9 @@ public final class TestHashComponentsStreamIdxTable implements
             @Override
             public TestHashComponentsStreamIdxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new TestHashComponentsStreamIdxRow(hashOfRowComponents, id);
             }
         };
@@ -290,7 +289,6 @@ public final class TestHashComponentsStreamIdxTable implements
             public TestHashComponentsStreamIdxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
-                __index += EncodingUtils.sizeOfSizedBytes(reference);
                 return new TestHashComponentsStreamIdxColumn(reference);
             }
         };
@@ -755,5 +753,5 @@ public final class TestHashComponentsStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "tH6ZP3FAS46/RMntNor6tw==";
+    static String __CLASS_HASH = "jD4EkOE3MqOVtun01u4fzA==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamMetadataTable.java
@@ -190,10 +190,9 @@ public final class TestHashComponentsStreamMetadataTable implements
             @Override
             public TestHashComponentsStreamMetadataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new TestHashComponentsStreamMetadataRow(hashOfRowComponents, id);
             }
         };
@@ -722,5 +721,5 @@ public final class TestHashComponentsStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "j3IJu2gsDa9Zov5ZP9X4Mw==";
+    static String __CLASS_HASH = "zx2sGbz67NzBUnEXtCPJLg==";
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/schema/stream/generated/TestHashComponentsStreamValueTable.java
@@ -198,12 +198,11 @@ public final class TestHashComponentsStreamValueTable implements
             @Override
             public TestHashComponentsStreamValueRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(id);
-                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new TestHashComponentsStreamValueRow(hashOfRowComponents, id, blockId);
             }
         };
@@ -710,5 +709,5 @@ public final class TestHashComponentsStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "iDMBVL6YNzaq38VRV2lB/g==";
+    static String __CLASS_HASH = "7hsA1dNWx3h5PJxWO4cUIg==";
 }

--- a/changelog/@unreleased/pr-6747.v2.yml
+++ b/changelog/@unreleased/pr-6747.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Generated hydrateFromBytes avoids boxing
+  links:
+  - https://github.com/palantir/atlasdb/pull/6747

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamHashAidxTable.java
@@ -184,7 +184,6 @@ public final class UserPhotosStreamHashAidxTable implements
             public UserPhotosStreamHashAidxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
-                __index += 32;
                 return new UserPhotosStreamHashAidxRow(hash);
             }
         };
@@ -275,8 +274,7 @@ public final class UserPhotosStreamHashAidxTable implements
             @Override
             public UserPhotosStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(streamId);
+                long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new UserPhotosStreamHashAidxColumn(streamId);
             }
         };
@@ -741,5 +739,5 @@ public final class UserPhotosStreamHashAidxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "vICtXgN//uNG/gj7cFWrOQ==";
+    static String __CLASS_HASH = "JnZRT76MU0Zn6q7j/EQgAQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamIdxTable.java
@@ -183,8 +183,7 @@ public final class UserPhotosStreamIdxTable implements
             @Override
             public UserPhotosStreamIdxRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new UserPhotosStreamIdxRow(id);
             }
         };
@@ -276,7 +275,6 @@ public final class UserPhotosStreamIdxTable implements
             public UserPhotosStreamIdxColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
-                __index += EncodingUtils.sizeOfSizedBytes(reference);
                 return new UserPhotosStreamIdxColumn(reference);
             }
         };
@@ -741,5 +739,5 @@ public final class UserPhotosStreamIdxTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "evlQwEFn9nzK+VsNjgPIJA==";
+    static String __CLASS_HASH = "/X284H4p8I6Pjhn1TSkwmw==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamMetadataTable.java
@@ -185,8 +185,7 @@ public final class UserPhotosStreamMetadataTable implements
             @Override
             public UserPhotosStreamMetadataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new UserPhotosStreamMetadataRow(id);
             }
         };
@@ -708,5 +707,5 @@ public final class UserPhotosStreamMetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "7ViZjlUfW+7BKGwGDvuIww==";
+    static String __CLASS_HASH = "7bQqneesqNh3T9SoqwGaXQ==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserPhotosStreamValueTable.java
@@ -193,10 +193,9 @@ public final class UserPhotosStreamValueTable implements
             @Override
             public UserPhotosStreamValueRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(id);
-                Long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                __index += EncodingUtils.sizeOfUnsignedVarLong(blockId);
+                long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 return new UserPhotosStreamValueRow(id, blockId);
             }
         };
@@ -695,5 +694,5 @@ public final class UserPhotosStreamValueTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "vnCpFwiY6zZC+s1UYLuLCw==";
+    static String __CLASS_HASH = "+dac6YFPWfaIDO9CSbs0Pw==";
 }

--- a/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
+++ b/examples/profile-client/src/main/java/com/palantir/example/profile/schema/generated/UserProfileTable.java
@@ -186,7 +186,6 @@ public final class UserProfileTable implements
             public UserProfileRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 UUID id = EncodingUtils.decodeUUID(__input, __index);
-                __index += 16;
                 return new UserProfileRow(id);
             }
         };
@@ -1272,7 +1271,6 @@ public final class UserProfileTable implements
                 public CookiesIdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
                     String cookie = PtBytes.toString(__input, __index, __input.length-__index);
-                    __index += 0;
                     return new CookiesIdxRow(cookie);
                 }
             };
@@ -1393,7 +1391,6 @@ public final class UserProfileTable implements
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(columnName);
                     UUID id = EncodingUtils.decodeUUID(__input, __index);
-                    __index += 16;
                     return new CookiesIdxColumn(rowName, columnName, id);
                 }
             };
@@ -1965,8 +1962,7 @@ public final class UserProfileTable implements
                 @Override
                 public CreatedIdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
-                    Long time = EncodingUtils.decodeUnsignedVarLong(__input, __index);
-                    __index += EncodingUtils.sizeOfUnsignedVarLong(time);
+                    long time = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                     return new CreatedIdxRow(time);
                 }
             };
@@ -2087,7 +2083,6 @@ public final class UserProfileTable implements
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(columnName);
                     UUID id = EncodingUtils.decodeUUID(__input, __index);
-                    __index += 16;
                     return new CreatedIdxColumn(rowName, columnName, id);
                 }
             };
@@ -2659,8 +2654,7 @@ public final class UserProfileTable implements
                 @Override
                 public UserBirthdaysIdxRow hydrateFromBytes(byte[] __input) {
                     int __index = 0;
-                    Long birthday = EncodingUtils.decodeSignedVarLong(__input, __index);
-                    __index += EncodingUtils.sizeOfSignedVarLong(birthday);
+                    long birthday = EncodingUtils.decodeSignedVarLong(__input, __index);
                     return new UserBirthdaysIdxRow(birthday);
                 }
             };
@@ -2781,7 +2775,6 @@ public final class UserProfileTable implements
                     byte[] columnName = EncodingUtils.decodeSizedBytes(__input, __index);
                     __index += EncodingUtils.sizeOfSizedBytes(columnName);
                     UUID id = EncodingUtils.decodeUUID(__input, __index);
-                    __index += 16;
                     return new UserBirthdaysIdxColumn(rowName, columnName, id);
                 }
             };
@@ -3342,5 +3335,5 @@ public final class UserProfileTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "FUR78HF+b7t9uXpBh7oYCQ==";
+    static String __CLASS_HASH = "dBpLe0vVyWJzQunILdUN2g==";
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/LockRequest.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/LockRequest.java
@@ -210,7 +210,7 @@ public final class LockRequest implements Serializable {
         return tempHashCode;
     }
 
-    public static void setLocalServerName(String serverName) {
+    public static void setLocalServerName(@Nullable String serverName) {
         if (serverName == null || serverName.trim().isEmpty()) {
             localServerName = "";
             return;
@@ -428,8 +428,8 @@ public final class LockRequest implements Serializable {
                     + ", blockingDuration=" + blockingDuration //
                     + ", versionId=" + versionId //
                     + ", lockGroupBehavior=" + lockGroupBehavior //
-                    + ", lockCount=" + lockMap.size() //
-                    + ", firstLock=" + Iterables.getFirst(lockMap.entries(), "") //
+                    + ", lockCount=" + (lockMap == null ? 0 : lockMap.size()) //
+                    + ", firstLock=" + (lockMap == null ? null : Iterables.getFirst(lockMap.entries(), ""))
                     + '}';
         }
     }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsSerializableTable.java
@@ -186,7 +186,6 @@ public final class BlobsSerializableTable implements
             public BlobsSerializableRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 byte[] key = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
-                __index += 0;
                 return new BlobsSerializableRow(key);
             }
         };
@@ -683,5 +682,5 @@ public final class BlobsSerializableTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "X9vlVcKWG1PnG8EugUP/kA==";
+    static String __CLASS_HASH = "M0xZYbNR/OGopUZSedxAuA==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/BlobsTable.java
@@ -186,7 +186,6 @@ public final class BlobsTable implements
             public BlobsRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
                 byte[] key = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
-                __index += 0;
                 return new BlobsRow(key);
             }
         };
@@ -683,5 +682,5 @@ public final class BlobsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "RU6CLtTd3DluJLwkYHXzeQ==";
+    static String __CLASS_HASH = "8QBU7nHeHMWI4u84bl//Ng==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvDynamicColumnsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvDynamicColumnsTable.java
@@ -188,10 +188,9 @@ public final class KvDynamicColumnsTable implements
             @Override
             public KvDynamicColumnsRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
                 String bucket = EncodingUtils.decodeVarString(__input, __index);
-                __index += EncodingUtils.sizeOfVarString(bucket);
                 return new KvDynamicColumnsRow(hashOfRowComponents, bucket);
             }
         };
@@ -303,8 +302,7 @@ public final class KvDynamicColumnsTable implements
             @Override
             public KvDynamicColumnsColumn hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long key = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
+                long key = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 return new KvDynamicColumnsColumn(key);
             }
         };
@@ -835,5 +833,5 @@ public final class KvDynamicColumnsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "ujWl4A2gAakYQiWxv+hZew==";
+    static String __CLASS_HASH = "6UeFiCrulg3zpuNAUCy5cg==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvRowsTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/KvRowsTable.java
@@ -198,12 +198,11 @@ public final class KvRowsTable implements
             @Override
             public KvRowsRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
                 String bucket = EncodingUtils.decodeVarString(__input, __index);
                 __index += EncodingUtils.sizeOfVarString(bucket);
-                Long key = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
-                __index += 8;
+                long key = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 return new KvRowsRow(hashOfRowComponents, bucket, key);
             }
         };
@@ -801,5 +800,5 @@ public final class KvRowsTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "E7HBSSSWtvxMljBiJQ/8mg==";
+    static String __CLASS_HASH = "owA2qsWE9yiIOpBDbSVLzg==";
 }

--- a/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/MetadataTable.java
+++ b/timelock-server-benchmark-client/src/main/java/com/palantir/atlasdb/timelock/benchmarks/schema/generated/MetadataTable.java
@@ -190,10 +190,9 @@ public final class MetadataTable implements
             @Override
             public MetadataRow hydrateFromBytes(byte[] __input) {
                 int __index = 0;
-                Long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
+                long hashOfRowComponents = Long.MIN_VALUE ^ PtBytes.toLong(__input, __index);
                 __index += 8;
                 String key = EncodingUtils.decodeVarString(__input, __index);
-                __index += EncodingUtils.sizeOfVarString(key);
                 return new MetadataRow(hashOfRowComponents, key);
             }
         };
@@ -773,5 +772,5 @@ public final class MetadataTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "MVgxOXWoD/e8wdW5v1b6og==";
+    static String __CLASS_HASH = "4UGfCaUWZyukLfhe6pmMFQ==";
 }


### PR DESCRIPTION
## General
**Before this PR**:

While reviewing some generated AtlasDB table access code, noticed that the generated `hydrateFromBytes` methods were boxing `long` to `Long` unnecessarily. We can avoid this overhead by generating primitive friendly code. Also noticed many suppressed warnings in `EncodingUtils` around bit operations that could be cleaned up.

**After this PR**:
==COMMIT_MSG==
Generated hydrateFromBytes avoids boxing
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
