### PR TITLE
[Fix] Start running workload-server-distribution tests

### DIFF
--- a/atlasdb-workload-server-distribution/build.gradle
+++ b/atlasdb-workload-server-distribution/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.palantir.sls-java-service-distribution'
 apply plugin: 'com.palantir.external-publish-dist'
 apply from: "../gradle/shared.gradle"
+apply from: "../gradle/tests.gradle"
 apply from: "../gradle/docker.gradle"
 apply from: "../gradle/non-client-dist.gradle"
 


### PR DESCRIPTION
## General
**Before this PR**:
This test didn't run: https://output.circle-artifacts.com/output/job/9115198d-3acd-4ec4-b228-76df0522eee1/artifacts/0/home/circleci/artifacts/junit/atlasdb-workload-server-distribution/test/index.html
**After this PR**:
It now runs: https://output.circle-artifacts.com/output/job/43584388-5605-4744-b175-c88b3cd48259/artifacts/0/home/circleci/artifacts/junit/atlasdb-workload-server-distribution/test/index.html
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
How do we ensure that all tests run as a default, rather than seemingly opt in? This feels like something we can / should do at a build.gradle level, applying the dependency.
**Is documentation needed?**:
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
didn't work before, and if this breaks, you won't find out it sadly - that's a longer term thing we should address

**What was existing testing like? What have you done to improve it?**:
Didn't work before, should now work
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
