### PR TITLE
[PDS-417767] Prevent Atlas from running in JDK 21

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -156,11 +156,11 @@ import org.immutables.value.Value;
 @StagedBuilderStyle
 public abstract class TransactionManagers {
     static {
-        String javaVersion = System.getProperty("java.version");
+        int javaVersion = Runtime.version().feature();
         Preconditions.checkState(
-                !javaVersion.startsWith("21"),
-                "We are currently investigating an issue with"
-                        + " AtlasDB running under Java 21 (PDS-417767). Please use a JDK version < 21",
+                javaVersion != 21,
+                "We are currently investigating an issue with AtlasDB running under Java 21 (PDS-417767)."
+                        + " Please use a JDK version < 21",
                 SafeArg.of("javaVersion", javaVersion));
     }
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -155,6 +155,15 @@ import org.immutables.value.Value;
 @Value.Immutable
 @StagedBuilderStyle
 public abstract class TransactionManagers {
+    static {
+        String javaVersion = System.getProperty("java.version");
+        Preconditions.checkState(
+                !javaVersion.startsWith("21"),
+                "We are currently investigating an issue with"
+                        + " AtlasDB running under Java 21 (PDS-417767). Please use a JDK version < 21",
+                SafeArg.of("javaVersion", javaVersion));
+    }
+
     private static final SafeLogger log = SafeLoggerFactory.get(TransactionManagers.class);
     public static final LockClient LOCK_CLIENT = LockClient.of("atlas instance");
 

--- a/changelog/@unreleased/pr-6749.v2.yml
+++ b/changelog/@unreleased/pr-6749.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '[PDS-417767] Prevent Atlas from running in JDK 21'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6749


### PR DESCRIPTION
## General
**Before this PR**:
We're investigating a corruption event through what seems to be a fun JDK 21 / AVX 512 bug.

**After this PR**:
Blow up Atlas on 21, this should be caught in tests, we have internal tooling for failing compile
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==
Fails on 21
![image](https://github.com/palantir/atlasdb/assets/1812764/fa9c667f-c08e-4d13-aaff-38efd3d91ce8)

Not on 21: 
![image](https://github.com/palantir/atlasdb/assets/1812764/28b5fcaa-ca95-4b8c-8830-5ded1c987e2d)

**Priority**: P0

**Concerns / possible downsides (what feedback would you like?)**:
None
**Is documentation needed?**:
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
