### PR TITLE
Fix: AdjustableBackgroundTask aggressively closes executor

### DIFF
--- a/changelog/@unreleased/pr-6751.v2.yml
+++ b/changelog/@unreleased/pr-6751.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: AdjustableBackgroundTask aggressively closes executor
+  links:
+  - https://github.com/palantir/atlasdb/pull/6751

--- a/lock-impl/src/main/java/com/palantir/lock/impl/AdjustableBackgroundTask.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/AdjustableBackgroundTask.java
@@ -96,6 +96,6 @@ public final class AdjustableBackgroundTask implements Closeable {
 
     @Override
     public void close() {
-        scheduledExecutor.shutdown();
+        scheduledExecutor.shutdownNow();
     }
 }


### PR DESCRIPTION
## General
**Before this PR**:
AdjustableBackgroundTask (by default) submits a new delayed tasks every 5 minutes. In situations where lock service impl is created and destroyed quickly, platform threads are kept hanging for 5 minutes after previously used lock service impl is destroyed. This temporarily leaks threads and exposes the runtime to failure of creating new threads.
**After this PR**:
Use shutdownNow instead of shutdown to liberate threads.
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P1
**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Ywa
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
Added test
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Metrics for threads running from ABT
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Metrics for threads running from ABT
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Recall and rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
