### PR TITLE
Add CacheValue::toString

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheValue.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/CacheValue.java
@@ -63,6 +63,11 @@ public final class CacheValue {
     }
 
     @Override
+    public String toString() {
+        return CacheValue.class.getSimpleName() + "{value=" + value().map(Arrays::toString) + "}";
+    }
+
+    @Override
     public int hashCode() {
         // Optionals do return 0 for empty values, but the hash code uses Object, which bases array hash codes on the
         // reference, not the values.

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheValueTests.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/cache/CacheValueTests.java
@@ -52,4 +52,22 @@ public final class CacheValueTests {
         assertThat(presentValue).isNotEqualTo(emptyValue);
         assertThat(emptyValue).isNotEqualTo(presentValue);
     }
+
+    @Test
+    public void emptyValueToStringReturnsFormattedData() {
+        CacheValue emptyValue = CacheValue.empty();
+        assertThat(emptyValue.toString()).isEqualTo("CacheValue{value=Optional.empty}");
+    }
+
+    @Test
+    public void valueWithPresentButEmptyListToStringReturnsFormattedData() {
+        CacheValue withEmptyByteArray = CacheValue.of(new byte[0]);
+        assertThat(withEmptyByteArray.toString()).isEqualTo("CacheValue{value=Optional[[]]}");
+    }
+
+    @Test
+    public void valueWithPresentNonEmptyListToStringReturnsFormattedData() {
+        CacheValue cacheValue = CacheValue.of(new byte[] {0, -127, 126, 1, 10});
+        assertThat(cacheValue.toString()).isEqualTo("CacheValue{value=Optional[[0, -127, 126, 1, 10]]}");
+    }
 }

--- a/changelog/@unreleased/pr-6752.v2.yml
+++ b/changelog/@unreleased/pr-6752.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Add CacheValue::toString
+  links:
+  - https://github.com/palantir/atlasdb/pull/6752


### PR DESCRIPTION
## General
**Before this PR**:
CacheValue is (as unsafe) logged but it does not override toString. Ran into this while investigating some caching issues.
**After this PR**:
Override CacheValue::toString.
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P2
**Concerns / possible downsides (what feedback would you like?)**:
I looked at the git blame. `CacheValue` was first implemented as an immutable but was transferred to a concrete class due to issues with `equals`. No toString was added and there was no comment addressing that in the PRs in question. Immutables's implementation of toString uses MoreObjects::toStringHelper. I avoided using it given this is one object (and I believe the optional funkiness was weird to me).
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
Added test
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Logs
**Has the safety of all log arguments been decided correctly?**:
We do not log anything in this PR
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Logs
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Recall and rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
