### PR TITLE
[PDS-403847] [II.IV] Topology Validator++

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -269,3 +269,10 @@ acceptedBreaks:
         \ com.palantir.lock.client.TimeLockClient>)"
       justification: "None of the impacted classes are used or inherited from any\
         \ other library or product"
+  "0.936.0":
+    com.palantir.atlasdb:atlasdb-cassandra:
+    - code: "java.method.visibilityReduced"
+      old: "method void com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator::<init>(com.palantir.atlasdb.CassandraTopologyValidationMetrics)"
+      new: "method void com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator::<init>(com.palantir.atlasdb.CassandraTopologyValidationMetrics,\
+        \ java.util.function.Supplier<java.util.Set<java.lang.String>>)"
+      justification: "internal API"

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -69,8 +69,9 @@ public class CassandraClientPoolIntegrationTest {
                 CASSANDRA.getRuntimeConfig(),
                 CassandraClientPoolImpl.StartupChecks.RUN,
                 blacklist,
-                new CassandraTopologyValidator(
-                        CassandraTopologyValidationMetrics.of(metricsManager.getTaggedRegistry())),
+                CassandraTopologyValidator.create(
+                        CassandraTopologyValidationMetrics.of(metricsManager.getTaggedRegistry()),
+                        CASSANDRA.getRuntimeConfig()),
                 new CassandraAbsentHostTracker(CASSANDRA.getConfig().consecutiveAbsencesBeforePoolRemoval()));
     }
 
@@ -115,8 +116,9 @@ public class CassandraClientPoolIntegrationTest {
                 CASSANDRA.getRuntimeConfig(),
                 CassandraClientPoolImpl.StartupChecks.RUN,
                 blacklist,
-                new CassandraTopologyValidator(
-                        CassandraTopologyValidationMetrics.of(metricsManager.getTaggedRegistry())),
+                CassandraTopologyValidator.create(
+                        CassandraTopologyValidationMetrics.of(metricsManager.getTaggedRegistry()),
+                        CASSANDRA.getRuntimeConfig()),
                 new CassandraAbsentHostTracker(CASSANDRA.getConfig().consecutiveAbsencesBeforePoolRemoval()));
 
         return clientPoolWithLocation.getLocalHosts();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -188,8 +188,8 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
                 exceptionHandler,
                 blacklist,
                 new CassandraClientPoolMetrics(metricsManager),
-                new CassandraTopologyValidator(
-                        CassandraTopologyValidationMetrics.of(metricsManager.getTaggedRegistry())),
+                CassandraTopologyValidator.create(
+                        CassandraTopologyValidationMetrics.of(metricsManager.getTaggedRegistry()), runtimeConfig),
                 new CassandraAbsentHostTracker(config.consecutiveAbsencesBeforePoolRemoval()));
         cassandraClientPool.wrapper.initialize(initializeAsync);
         return cassandraClientPool.wrapper.isInitialized() ? cassandraClientPool : cassandraClientPool.wrapper;

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -155,11 +155,11 @@ import org.slf4j.LoggerFactory;
 /**
  * Each service can have one or many C* KVS.
  * For each C* KVS, it maintains a list of active nodes, and the client connections attached to each node:
- *
+ * <p>
  * n1->c1, c2, c3
  * n2->c5, c4, c9
  * n3->[N C* thrift client connections]
- *
+ * <p>
  * Where {n1, n2, n3} are the active nodes in the C* cluster. Also each
  * node contains the clients which are attached to the node.
  * if some nodes are down, and the change can be detected through active hosts,
@@ -261,8 +261,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                 new Blacklist(
                         config,
                         runtimeConfig.map(CassandraKeyValueServiceRuntimeConfig::unresponsiveHostBackoffTimeSeconds)),
-                new CassandraTopologyValidator(
-                        CassandraTopologyValidationMetrics.of(metricsManager.getTaggedRegistry())),
+                CassandraTopologyValidator.create(
+                        CassandraTopologyValidationMetrics.of(metricsManager.getTaggedRegistry()), runtimeConfig),
                 new CassandraAbsentHostTracker(config.consecutiveAbsencesBeforePoolRemoval()));
 
         return createOrShutdownClientPool(
@@ -605,15 +605,13 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * @param rows set containing the rows to retrieve values for.
      * @param selection specifies the set of columns to fetch.
      * @param startTs specifies the maximum timestamp (exclusive) at which to
-     *        retrieve each rows's value.
-     *
+     * retrieve each rows's value.
      * @return map of retrieved values. Values which do not exist (either
-     *         because they were deleted or never created in the first place)
-     *         are simply not returned.
-     *
+     * because they were deleted or never created in the first place)
+     * are simply not returned.
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable.
      * @throws IllegalArgumentException if any of the requests were invalid
-     *         (e.g., attempting to retrieve values from a non-existent table).
+     * (e.g., attempting to retrieve values from a non-existent table).
      */
     @Override
     public Map<Cell, Value> getRows(
@@ -788,15 +786,13 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableRef the name of the table to retrieve values from.
      * @param timestampByCell specifies, for each row, the maximum timestamp (exclusive) at which to
-     *        retrieve that rows's value.
-     *
+     * retrieve that rows's value.
      * @return map of retrieved values. Values which do not exist (either
-     *         because they were deleted or never created in the first place)
-     *         are simply not returned.
-     *
+     * because they were deleted or never created in the first place)
+     * are simply not returned.
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable.
      * @throws IllegalArgumentException if any of the requests were invalid
-     *         (e.g., attempting to retrieve values from a non-existent table).
+     * (e.g., attempting to retrieve values from a non-existent table).
      */
     @Override
     public Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell) {
@@ -853,13 +849,11 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableRef the name of the table to retrieve values from.
      * @param rows set containing the rows to retrieve values for. Behavior is undefined if {@code rows}
-     *        contains duplicates (as defined by {@link Arrays#equals(byte[], byte[])}).
+     * contains duplicates (as defined by {@link Arrays#equals(byte[], byte[])}).
      * @param batchColumnRangeSelection specifies the column range and the per-row batchSize to fetch.
      * @param timestamp specifies the maximum timestamp (exclusive) at which to retrieve each rows's value.
-     *
      * @return map of row names to {@link RowColumnRangeIterator}. Each {@link RowColumnRangeIterator} can iterate over
-     *         the values that are spanned by the {@code batchColumnRangeSelection} in increasing order by column name.
-     *
+     * the values that are spanned by the {@code batchColumnRangeSelection} in increasing order by column name.
      * @throws IllegalArgumentException if {@code rows} contains duplicates.
      */
     @Override
@@ -1119,7 +1113,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * @param tableRef the name of the table to put values into.
      * @param values map containing the key-value entries to put.
      * @param timestamp must be non-negative and not equal to {@link Long#MAX_VALUE}
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable.
      */
     @Override
@@ -1141,8 +1134,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableRef the name of the table to put values into.
      * @param values map containing the key-value entries to put with
-     *               non-negative timestamps less than {@link Long#MAX_VALUE}.
-     *
+     * non-negative timestamps less than {@link Long#MAX_VALUE}.
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable.
      */
     @Override
@@ -1170,7 +1162,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param valuesByTable map containing the key-value entries to put by table.
      * @param timestamp must be non-negative and not equal to {@link Long#MAX_VALUE}
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable.
      */
     @Override
@@ -1264,7 +1255,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * Requires all Cassandra nodes to be reachable.
      *
      * @param tableRef the name of the table to truncate.
-     *
      * @throws AtlasDbDependencyException if not all Cassandra nodes are reachable.
      * @throws RuntimeException if the table does not exist.
      */
@@ -1281,7 +1271,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * Requires all Cassandra nodes to be reachable.
      *
      * @param tablesToTruncate set od tables to truncate.
-     *
      * @throws AtlasDbDependencyException if not all Cassandra nodes are reachable.
      * @throws RuntimeException if the table does not exist.
      */
@@ -1297,7 +1286,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableRef the name of the table to delete values from.
      * @param keys map containing the keys to delete values for.
-     *
      * @throws PalantirRuntimeException if not all hosts respond successfully.
      */
     @Override
@@ -1327,15 +1315,15 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
 
     // TODO(unknown): after cassandra change: handle reverse ranges
     // TODO(unknown): after cassandra change: handle column filtering
+
     /**
      * For each row in the specified range, returns the most recent version strictly before timestamp. Requires a
      * quorum of Cassandra nodes to be reachable.
-     *
+     * <p>
      * Remember to close any {@link ClosableIterator}s you get in a finally block.
      *
      * @param rangeRequest the range to load.
      * @param timestamp specifies the maximum timestamp (exclusive) at which to retrieve each row's value.
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable.
      */
     @Override
@@ -1356,7 +1344,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * @param tableRef the name of the table to read from.
      * @param rangeRequest the range to load.
      * @param timestamp the maximum timestamp to load.
-     *
      * @throws InsufficientConsistencyException if not all hosts respond successfully.
      */
     @Override
@@ -1401,7 +1388,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     /**
      * Returns a sorted list of row keys in the specified range; see
      * {@link CassandraKeyValueService#getRowKeysInRange(TableReference, byte[], byte[], int)}.
-     *
+     * <p>
      * Implementation specific: this method specifically does not read any of the columns and can therefore be used
      * in the presence of wide rows. However, as a side-effect, it may return row where the row only contains Cassandra
      * tombstones.
@@ -1421,12 +1408,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * Drop the table, and also delete its table metadata. Requires a quorum of Cassandra nodes to be reachable.
      *
      * @param tableRef the name of the table to drop.
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable, or the cluster
      * cannot come to an agreement on schema versions. Note that this method is not atomic: if quorum is lost during
      * its execution or Cassandra nodes fail to settle on a schema version after the Cassandra schema is mutated, we
      * may drop the tables, but fail to to persist the changes to the _metadata table.
-     *
      * @throws UncheckedExecutionException if there are multiple schema mutation lock tables.
      */
     @Override
@@ -1438,13 +1423,12 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * Drop the tables, and also delete their table metadata. Requires a quorum of Cassandra nodes to be reachable.
      * <p>
      * Main gains here vs. dropTable:
-     *    - problems excepting, we will basically be serializing a rapid series of schema changes
-     *      through a single host checked out from the client pool, so reduced chance of schema disagreement issues
-     *    - client-side in-memory lock to prevent misbehaving callers from shooting themselves in the foot
-     *    - one less round trip
+     * - problems excepting, we will basically be serializing a rapid series of schema changes
+     * through a single host checked out from the client pool, so reduced chance of schema disagreement issues
+     * - client-side in-memory lock to prevent misbehaving callers from shooting themselves in the foot
+     * - one less round trip
      *
      * @param tablesToDrop the set of tables to drop.
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable, or the cluster
      * cannot come to an agreement on schema versions. Note that this method is not atomic: if quorum is lost during
      * its execution or Cassandra nodes fail to settle on a schema version after the Cassandra schema is mutated, we
@@ -1462,7 +1446,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableRef the name of the table to create.
      * @param metadata the metadata of the table to create.
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable, or the cluster
      * cannot come to an agreement on schema versions. Note that this method is not atomic: if quorum is lost during
      * its execution or Cassandra nodes fail to settle on a schema version after the Cassandra schema is mutated, we
@@ -1481,10 +1464,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * Requires a quorum of Cassandra nodes to be up and available.
      * <p>
      * Main gains here vs. createTable:
-     *    - problems excepting, we will basically be serializing a rapid series of schema changes
-     *      through a single host checked out from the client pool, so reduced chance of schema disagreement issues
-     *    - client-side in-memory lock to prevent misbehaving callers from shooting themselves in the foot
-     *    - one less round trip
+     * - problems excepting, we will basically be serializing a rapid series of schema changes
+     * through a single host checked out from the client pool, so reduced chance of schema disagreement issues
+     * - client-side in-memory lock to prevent misbehaving callers from shooting themselves in the foot
+     * - one less round trip
      * <p>
      * createTables(existingTable, newMetadata) can perform a metadata-only update. Additionally, it is possible
      * that this metadata-only update performs a schema mutation by altering the CFDef (e. g., user changes metadata
@@ -1492,7 +1475,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * does not alter the CfId
      *
      * @param tablesToMetadata a mapping of names of tables to create to their respective metadata.
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable, or the cluster
      * cannot come to an agreement on schema versions. Note that this method is not atomic: if quorum is lost during
      * its execution or Cassandra nodes fail to settle on a schema version after the Cassandra schema is mutated, we
@@ -1522,7 +1504,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * This will not contain the names of any hidden tables (e. g., the _metadata table).
      *
      * @return a set of TableReferences (table names) for all the visible tables
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable, or the cluster
      * cannot come to an agreement on schema versions.
      */
@@ -1539,10 +1520,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * positives. Requires a quorum of Cassandra nodes to be reachable.
      *
      * @param tableRef the name of the table to get metadata for.
-     *
      * @return a byte array representing the metadata for the table. Array is empty if no table
      * with the given name exists. Consider {@link TableMetadata#BYTES_HYDRATOR} for hydrating.
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable.
      */
     @Override
@@ -1577,7 +1556,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @return a mapping of table names to their respective metadata in form of a byte array.  Consider
      * {@link TableMetadata#BYTES_HYDRATOR} for hydrating.
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are available.
      */
     @Override
@@ -1590,7 +1568,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableRef the name of the table to record metadata for.
      * @param meta a byte array representing the metadata to record.
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable, or the cluster
      * cannot come to an agreement on schema versions. Note that this method is not atomic: if quorum is lost during
      * its execution or Cassandra nodes fail to settle on a schema version after the Cassandra schema is mutated, we
@@ -1606,7 +1583,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableRefToMetadata a mapping from each table's name to the respective byte array representing
      * the metadata to record.
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable, or the cluster
      * cannot come to an agreement on schema versions. Note that this method is not atomic: if quorum is lost during
      * its execution or Cassandra nodes fail to settle on a schema version after the Cassandra schema is mutated, we
@@ -1813,7 +1789,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableRef the name of the table to add the value to.
      * @param cells a set of cells to store the values in.
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable.
      */
     @Override
@@ -1841,7 +1816,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * @param cells set containg cells to retrieve timestamps for.
      * @param ts maximum timestamp to get (exclusive).
      * @return multimap of timestamps by cell
-     *
      * @throws AtlasDbDependencyException if not all Cassandra nodes are reachable.
      */
     @Override
@@ -1860,7 +1834,6 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableRef the name of the table to put values into.
      * @param values map containing the key-value entries to put.
-     *
      * @throws AtlasDbDependencyException if fewer than a quorum of Cassandra nodes are reachable.
      * @throws KeyAlreadyExistsException if you are putting a Cell with the same timestamp as one that already exists.
      */
@@ -1982,16 +1955,16 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      * Performs a check-and-set for multiple cells in a row into the key-value store.
      * Please see {@link MultiCheckAndSetRequest} for information about how to create this request,
      * and {@link KeyValueService} for more detailed documentation.
-     *
+     * <p>
      * If the call completes successfully, then you know that the old cells initially had the values you expected.
      * In this case, you can be sure that all your cells have been updated to their new values.
      * If the old cells initially did not have the values you expected, none of the cells will be updated and
      * {@link MultiCheckAndSetException} will be thrown.
      * Reads concurrent with this operation will not see a partial update.
-     *
+     * <p>
      * Another thing to note is that the check operation will **only be performed on values of cells that are declared
      * in the set of expected values** i.e. the check operation DOES NOT take updates into account.
-     *
+     * <p>
      * Does not require all Cassandra nodes to be up and available, works as long as quorum is achieved.
      *
      * @param request the request, including table, rowName, old values and new values.
@@ -2134,10 +2107,10 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
      *
      * @param tableRef the name of the table to retrieve values from.
      * @param timestampByCell specifies, for each row, the maximum timestamp (exclusive) at which to
-     *        retrieve that rows's value.
+     * retrieve that rows's value.
      * @return listenable future map of retrieved values. Values which do not exist (either
-     *         because they were deleted or never created in the first place)
-     *         are simply not returned.
+     * because they were deleted or never created in the first place)
+     * are simply not returned.
      */
     @Override
     public ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell) {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -26,6 +26,8 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.CassandraTopologyValidationMetrics;
+import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig;
+import com.palantir.atlasdb.cassandra.CassandraServersConfigs.ThriftHostsExtractingVisitor;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.common.streams.KeyedStream;
 import com.palantir.logsafe.Preconditions;
@@ -33,6 +35,8 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.refreshable.Refreshable;
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -41,6 +45,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import one.util.streamex.EntryStream;
 import org.apache.thrift.TApplicationException;
 import org.immutables.value.Value;
@@ -49,43 +54,57 @@ public final class CassandraTopologyValidator {
     private static final SafeLogger log = SafeLoggerFactory.get(CassandraTopologyValidator.class);
     private final CassandraTopologyValidationMetrics metrics;
     private final AtomicReference<ConsistentClusterTopology> pastConsistentTopology;
+    private final Supplier<Set<String>> configuredServers;
 
-    public CassandraTopologyValidator(CassandraTopologyValidationMetrics metrics) {
+    @VisibleForTesting
+    CassandraTopologyValidator(CassandraTopologyValidationMetrics metrics, Supplier<Set<String>> configuredServers) {
         this.metrics = metrics;
         this.pastConsistentTopology = new AtomicReference<>();
+        this.configuredServers = configuredServers;
+    }
+
+    public static CassandraTopologyValidator create(
+            CassandraTopologyValidationMetrics metrics,
+            Refreshable<CassandraKeyValueServiceRuntimeConfig> runtimeConfigRefreshable) {
+        return new CassandraTopologyValidator(
+                metrics,
+                runtimeConfigRefreshable.map(
+                        config -> config.servers().accept(ThriftHostsExtractingVisitor.INSTANCE).stream()
+                                .map(InetSocketAddress::getHostString)
+                                .collect(Collectors.toSet())));
     }
 
     /**
      * Checks a set of new Cassandra servers against the current Casssandra servers
      * to ensure their topologies are matching. This is done to prevent user-led split-brain,
      * which can occur if a user accidentally provided hostnames for two different Cassandra clusters.
-     *
+     * <p>
      * This is done by coming to a consensus on the topology of the pre-existing hosts,
      * and then subsequently returning any new hosts which do not match the present topology.
-     *
+     * <p>
      * Of course, there is the base case of all hosts will be new. In this case, we simply check that all
      * new hosts are in consensus.
-     *
+     * <p>
      * Servers that do not have support for the get_host_ids endpoint are always considered consistent,
      * even if we cannot come to a consensus on the hosts that do support the endpoint.
-     *
+     * <p>
      * Consensus may be demonstrated independently by a set of nodes. In this case, we require that:
      * (1) A quorum of nodes (excluding those without `get_host_ids` support) are reachable.
      * (2) All reachable nodes have the same set of hostIds.
      * (3) All Cassandra nodes without get_host_ids support are considered to be matching.
-     *
+     * <p>
      * The above should be sufficient to prevent user-led split-brain as:
      * (1) The initial list of servers validate that they've at least quorum for consensus of topology.
      * (2) All new hosts added then must match the set of pre-existing hosts topology.
-     *
+     * <p>
      * Consensus may also be demonstrated and new hosts added without a quorum of nodes being reachable, if:
      * (4) New hosts support get_host_ids, and have the same set of hostIds as the most recent previous consensus
      * satisfied through conditions (1) - (3).
-     *
+     * <p>
      * In this case, we know that a previous set of servers had quorum for a consensus, which we are also agreeing to.
      * Since we aren't agreeing on any new values, values that were agreed upon must have passed conditions (1) - (3)
      * at the time of their inception, and that required a quorum of nodes to agree.
-     *
+     * <p>
      * There does exist an edge case of, two sets of Cassandra clusters being added (3 and 6 respectively).
      * On initialization, the Cassandra cluster with 6 will be used as the base case if the other 3 nodes
      * are down, as this will satisfy quorum requirements. However, the cluster of 6 could be the wrong
@@ -159,8 +178,9 @@ public final class CassandraTopologyValidator {
         if (currentServersWithoutSoftFailures.isEmpty()) {
             ClusterTopologyResult topologyResultFromNewServers =
                     maybeGetConsistentClusterTopology(newServersWithoutSoftFailures);
+            Set<String> configuredServersSnapshot = configuredServers.get();
             Map<CassandraServer, HostIdResult> newServersFromConfig = EntryStream.of(newServersWithoutSoftFailures)
-                    .filterKeys(server -> newlyAddedHosts.get(server) == CassandraServerOrigin.CONFIG)
+                    .filterKeys(server -> configuredServersSnapshot.contains(server.cassandraHostName()))
                     .toMap();
             return getNewHostsWithInconsistentTopologiesFromTopologyResult(
                     topologyResultFromNewServers,
@@ -258,7 +278,7 @@ public final class CassandraTopologyValidator {
 
     /**
      * Obtains a consistent view of the cluster topology for the provided hosts.
-     *
+     * <p>
      * This is achieved by comparing the hostIds (list of UUIDs for each C* node) for all Cassandra nodes.
      * A quorum of C* nodes are required to be reachable and all reachable nodes must have the same
      * topology (hostIds) for this to return a valid result. Nodes that are reachable but do not have

--- a/changelog/@unreleased/pr-6755.v2.yml
+++ b/changelog/@unreleased/pr-6755.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    - Addresses an edge case in #6458 where in the event that a node providing the token ring was removed in the same client pool ring update, it is possible to encounter a situation where there are no live servers but also no nodes appearing to come from configuration.
+    - In the event no topology had previously been agreed, we allow a quorum in configuration to be the source of the first topology agreed upon by the cluster.
+    - Shift the acceptance criteria for adding new nodes to the cluster to be based on having at least one host ID in common with the past agreed topology - this allows for cluster expansions.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6755


### PR DESCRIPTION
## General
**Before this PR**:
Consider a state where a cluster has been connected to another datacenter. In this state, there are N nodes in config, N reachable, and 2N discoverable through the token ring. Separately, consider the decommission process for a two-DC cluster. This has a similar pattern to the above.

Currently, an inopportune IP refresh or pool eviction can mean that no new hosts can be admitted into the client pool, placing Atlas clients into a deadlocked state. Notice that if we aim to add 2N new servers, a quorum is N+1, but since we can never actually reach N+1 nodes, we will not get our quorum.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
- Shift the determination of whether a node originated from the config to the validator: this deals with an edge case in #6458 where in the event that a node providing the token ring was removed in the same client pool ring update, it is possible to encounter a situation where there are no live servers but also no nodes appearing to come from configuration.
- Implement #6723: in the event no topology had previously been agreed, we allow a quorum in configuration to be the source of the first topology agreed upon by the cluster.
- Shift the acceptance criteria for adding new nodes to the cluster to be based on having at least one host ID in common with the past agreed topology - this allows for cluster expansions. I believe this is safe because a false positive here implies UUID collision, which we don't generally protect against. There is a caveat which I've noted in the Concerns.
==COMMIT_MSG==

**Priority**: Dev P0

**Concerns / possible downsides (what feedback would you like?)**:
- I think this is safe, but have I done something wrong?
- It is possible for the topology to evolve, on the basis of only no-quorums, from [A, B] to [B, C] and then for us to _reject_ [C, D] because I do not update the topology or track the set of topologies which we've accepted. I think this is fine for our purposes, but it is an edge case worth calling out - should I track the superset of seen host IDs?

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: Not that I'm aware of

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes - each node has its own rules for discovering Cassandra.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: I don't think so.

**Does this PR need a schema migration?** No.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That we are not supporting more complex migration patterns.

**What was existing testing like? What have you done to improve it?**: I added a bunch of tests.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: I don't think we acquire shared resources?

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: We can run the cloud migrations with it!

**Has the safety of all log arguments been decided correctly?**: No new args (there are some safeargs that were previously safe that I refactored - I think the contents are the same but we should check)

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: Migration doesn't work, outage

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: I am the PoC.

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: Don't think so

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: **Yes** if we need to support more exotic node movements in migrations, though I don't know of any plans to do so

## Development Process
**Where should we start reviewing?**: CassandraTopologyValidator or its test

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
