### PR TITLE
Simplify Alter Table workflow

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
@@ -116,8 +116,6 @@ public final class OracleAlterTableIntegrationTest {
         CallableCheckedException<KeyValueService, TableMappingNotFoundException> workingKvsSupplier = () -> {
             String physicalTableName =
                     oracleTableNameGetter.getInternalShortTableName(connectionSupplier, TABLE_REFERENCE);
-            System.out.println("Lookout!!");
-            System.out.println(physicalTableName);
             return createKvs(getConfigWithAlterTableFromPhysicalTableName(physicalTableName));
         };
         whenConfiguredAlterTableToMatchMetadataAndOldDataIsStillReadable(workingKvsSupplier);

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleAlterTableIntegrationTest.java
@@ -26,9 +26,11 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.dbkvs.AlterTableMetadataReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.DbKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.ImmutableDbKeyValueServiceConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.ImmutableOracleDdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.ImmutableTableReferenceWrapper;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetterImpl;
@@ -36,6 +38,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionManagerAwareDbKvs;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.ConnectionSupplier;
 import com.palantir.atlasdb.keyvalue.dbkvs.impl.OverflowMigrationState;
 import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
+import com.palantir.atlasdb.logging.KvsProfilingLogger.CallableCheckedException;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.common.exception.TableMappingNotFoundException;
@@ -56,7 +59,7 @@ public final class OracleAlterTableIntegrationTest {
             .from(DbKvsOracleTestSuite.getKvsConfig())
             .ddl(ImmutableOracleDdlConfig.builder()
                     .overflowMigrationState(OverflowMigrationState.FINISHED)
-                    .addAlterTablesOrMetadataToMatch(TABLE_REFERENCE)
+                    .addAlterTablesOrMetadataToMatch(ImmutableTableReferenceWrapper.of(TABLE_REFERENCE))
                     .build())
             .build();
 
@@ -103,21 +106,21 @@ public final class OracleAlterTableIntegrationTest {
     }
 
     @Test
-    public void whenConfiguredAlterTableToMatchMetadataAndOldDataIsStillReadable() {
-        defaultKvs.createTable(TABLE_REFERENCE, EXPECTED_TABLE_METADATA.persistToBytes());
-        writeData(defaultKvs, ROW_1, TIMESTAMP_1);
-        assertThatDataCanBeRead(defaultKvs, DEFAULT_CELL_1, TIMESTAMP_1, DEFAULT_VALUE_1);
+    public void whenConfiguredWithTableReferenceAlterTableToMatchMetadataAndOldDataIsStillReadable() {
+        whenConfiguredAlterTableToMatchMetadataAndOldDataIsStillReadable(() -> createKvs(CONFIG_WITH_ALTER));
+    }
 
-        dropOverflowColumn();
-        defaultKvs.putMetadataForTable(TABLE_REFERENCE, OLD_TABLE_METADATA.persistToBytes());
-        assertThatThrownBy(() -> fetchData(defaultKvs, DEFAULT_CELL_1, TIMESTAMP_1));
-
-        KeyValueService workingKvs = createKvs(CONFIG_WITH_ALTER);
-        workingKvs.createTable(TABLE_REFERENCE, EXPECTED_TABLE_METADATA.persistToBytes());
-        assertThatDataCanBeRead(defaultKvs, DEFAULT_CELL_1, TIMESTAMP_1, DEFAULT_VALUE_1);
-        assertThatOverflowColumnExists();
-        assertThatCode(() -> writeData(defaultKvs, ROW_2, TIMESTAMP_2)).doesNotThrowAnyException();
-        assertThatDataCanBeRead(defaultKvs, DEFAULT_CELL_2, TIMESTAMP_2, DEFAULT_VALUE_2);
+    @Test
+    public void whenConfiguredWithPhysicalTableNameAlterTableToMatchMetadataAndOldDataIsStillReadable()
+            throws TableMappingNotFoundException {
+        CallableCheckedException<KeyValueService, TableMappingNotFoundException> workingKvsSupplier = () -> {
+            String physicalTableName =
+                    oracleTableNameGetter.getInternalShortTableName(connectionSupplier, TABLE_REFERENCE);
+            System.out.println("Lookout!!");
+            System.out.println(physicalTableName);
+            return createKvs(getConfigWithAlterTableFromPhysicalTableName(physicalTableName));
+        };
+        whenConfiguredAlterTableToMatchMetadataAndOldDataIsStillReadable(workingKvsSupplier);
     }
 
     @Test
@@ -129,6 +132,24 @@ public final class OracleAlterTableIntegrationTest {
 
         kvsWithAlter.createTable(TABLE_REFERENCE, EXPECTED_TABLE_METADATA.persistToBytes());
         writeData(defaultKvs, ROW_2, TIMESTAMP_2);
+        assertThatDataCanBeRead(defaultKvs, DEFAULT_CELL_2, TIMESTAMP_2, DEFAULT_VALUE_2);
+    }
+
+    private <E extends Exception> void whenConfiguredAlterTableToMatchMetadataAndOldDataIsStillReadable(
+            CallableCheckedException<KeyValueService, E> workingKvsSupplier) throws E {
+        defaultKvs.createTable(TABLE_REFERENCE, EXPECTED_TABLE_METADATA.persistToBytes());
+        writeData(defaultKvs, ROW_1, TIMESTAMP_1);
+        assertThatDataCanBeRead(defaultKvs, DEFAULT_CELL_1, TIMESTAMP_1, DEFAULT_VALUE_1);
+
+        dropOverflowColumn();
+        defaultKvs.putMetadataForTable(TABLE_REFERENCE, OLD_TABLE_METADATA.persistToBytes());
+        assertThatThrownBy(() -> fetchData(defaultKvs, DEFAULT_CELL_1, TIMESTAMP_1));
+
+        KeyValueService workingKvs = workingKvsSupplier.call();
+        workingKvs.createTable(TABLE_REFERENCE, EXPECTED_TABLE_METADATA.persistToBytes());
+        assertThatDataCanBeRead(defaultKvs, DEFAULT_CELL_1, TIMESTAMP_1, DEFAULT_VALUE_1);
+        assertThatOverflowColumnExists();
+        assertThatCode(() -> writeData(defaultKvs, ROW_2, TIMESTAMP_2)).doesNotThrowAnyException();
         assertThatDataCanBeRead(defaultKvs, DEFAULT_CELL_2, TIMESTAMP_2, DEFAULT_VALUE_2);
     }
 
@@ -180,5 +201,15 @@ public final class OracleAlterTableIntegrationTest {
 
     private static Cell createCell(String row, String columnValue) {
         return Cell.create(PtBytes.toBytes(row), PtBytes.toBytes(columnValue));
+    }
+
+    private static DbKeyValueServiceConfig getConfigWithAlterTableFromPhysicalTableName(String physicalTableName) {
+        return ImmutableDbKeyValueServiceConfig.builder()
+                .from(CONFIG_WITH_ALTER)
+                .ddl(ImmutableOracleDdlConfig.builder()
+                        .from(CONFIG_WITH_ALTER.ddl())
+                        .addAlterTablesOrMetadataToMatch(AlterTableMetadataReference.of(physicalTableName))
+                        .build())
+                .build();
     }
 }

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/AlterTableMetadataReference.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/AlterTableMetadataReference.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import org.immutables.value.Value;
+
+public interface AlterTableMetadataReference {
+    boolean doesTableReferenceOrPhysicalTableNameMatch(TableReference tableReference, String physicalTableName);
+
+    @JsonCreator
+    static AlterTableMetadataReference of(
+            @JsonProperty("namespace") Namespace namespace, @JsonProperty("tablename") String tableName) {
+        return ImmutableTableReferenceWrapper.of(TableReference.create(namespace, tableName));
+    }
+
+    @JsonCreator
+    static AlterTableMetadataReference of(@JsonProperty("physicalTableName") String physicalTableName) {
+        return ImmutablePhysicalTableNameWrapper.of(physicalTableName);
+    }
+
+    @Value.Immutable
+    interface TableReferenceWrapper extends AlterTableMetadataReference {
+        @Value.Parameter
+        TableReference tableReference();
+
+        @Override
+        default boolean doesTableReferenceOrPhysicalTableNameMatch(
+                TableReference tableReference, String _physicalTableName) {
+            return tableReference().equals(tableReference);
+        }
+    }
+
+    @Value.Immutable
+    interface PhysicalTableNameWrapper extends AlterTableMetadataReference {
+        @Value.Parameter
+        String physicalTableName();
+
+        @Override
+        default boolean doesTableReferenceOrPhysicalTableNameMatch(
+                TableReference _tableReference, String physicalTableName) {
+            return physicalTableName().equals(physicalTableName);
+        }
+    }
+}

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/OracleDdlConfig.java
@@ -130,7 +130,7 @@ public abstract class OracleDdlConfig extends DdlConfig {
      * still satisfies the status quo, thus it's on the configurator to determine if this change is safe to make.
      */
     @JsonProperty("alterTablesOrMetadataToMatchAndIKnowWhatIAmDoing")
-    public abstract List<TableReference> alterTablesOrMetadataToMatch();
+    public abstract List<AlterTableMetadataReference> alterTablesOrMetadataToMatch();
 
     @Override
     public final String type() {

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -155,8 +155,7 @@ public final class OracleDdlTable implements DbDdlTable {
             try {
                 log.info(
                         "Table name: {}, Overflow table migrated status: {}, overflow table existence status: {}, "
-                                + "overflow "
-                                + "column exists status: {}",
+                                + "overflow column exists status: {}",
                         LoggingArgs.tableRef(tableRef),
                         UnsafeArg.of("shortTableName", shortTableName),
                         SafeArg.of("overflowTableHasMigrated", overflowTableHasMigrated()),

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -142,16 +142,23 @@ public final class OracleDdlTable implements DbDdlTable {
                     e);
         }
 
-        log.info("Potentially altering table {} to have overflow column.", LoggingArgs.tableRef(tableRef));
+        log.info(
+                "Potentially altering table {} to have overflow column.",
+                LoggingArgs.tableRef(tableRef),
+                UnsafeArg.of("shortTableName", shortTableName));
         if (config.alterTablesOrMetadataToMatch().stream()
                 .anyMatch(ref -> ref.doesTableReferenceOrPhysicalTableNameMatch(tableRef, shortTableName))) {
-            log.info("Config contains table {}, checking if we can alter table.", LoggingArgs.tableRef(tableRef));
+            log.info(
+                    "Config contains table {}, checking if we can alter table.",
+                    LoggingArgs.tableRef(tableRef),
+                    UnsafeArg.of("shortTableName", shortTableName));
             try {
                 log.info(
                         "Table name: {}, Overflow table migrated status: {}, overflow table existence status: {}, "
                                 + "overflow "
                                 + "column exists status: {}",
                         LoggingArgs.tableRef(tableRef),
+                        UnsafeArg.of("shortTableName", shortTableName),
                         SafeArg.of("overflowTableHasMigrated", overflowTableHasMigrated()),
                         SafeArg.of("overflowTableExists", overflowTableExists()),
                         SafeArg.of("overflowColumnExists", overflowColumnExists(shortTableName)));

--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTable.java
@@ -143,19 +143,19 @@ public final class OracleDdlTable implements DbDdlTable {
         }
 
         log.info(
-                "Potentially altering table {} to have overflow column.",
+                "Potentially altering table {} (internal name: {}) to have overflow column.",
                 LoggingArgs.tableRef(tableRef),
                 UnsafeArg.of("shortTableName", shortTableName));
         if (config.alterTablesOrMetadataToMatch().stream()
                 .anyMatch(ref -> ref.doesTableReferenceOrPhysicalTableNameMatch(tableRef, shortTableName))) {
             log.info(
-                    "Config contains table {}, checking if we can alter table.",
+                    "Config contains table {} (internal name: {}), checking if we can alter table.",
                     LoggingArgs.tableRef(tableRef),
                     UnsafeArg.of("shortTableName", shortTableName));
             try {
                 log.info(
-                        "Table name: {}, Overflow table migrated status: {}, overflow table existence status: {}, "
-                                + "overflow column exists status: {}",
+                        "Table name: {} (internal name: {}), Overflow table migrated status: {},"
+                                + " overflow table existence status: {}, overflow column exists status: {}",
                         LoggingArgs.tableRef(tableRef),
                         UnsafeArg.of("shortTableName", shortTableName),
                         SafeArg.of("overflowTableHasMigrated", overflowTableHasMigrated()),

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/AlterTableMetadataReferenceTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/AlterTableMetadataReferenceTest.java
@@ -1,0 +1,97 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.atlasdb.config.AtlasDbConfigs;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class AlterTableMetadataReferenceTest {
+    private static final ObjectMapper OBJECT_MAPPER = AtlasDbConfigs.OBJECT_MAPPER;
+    public static final TableReference PRESENT_TABLE_REFERENCE = TableReference.create(Namespace.create("test"), "foo");
+    public static final String PRESENT_PHYSICAL_TABLE_NAME = "testfoo";
+    public static final String MISSING_PHYSICAL_TABLE_NAME = "asdasdasd";
+    public static final TableReference MISSING_TABLE_REFERENCE =
+            TableReference.create(Namespace.EMPTY_NAMESPACE, "foo");
+
+    @Test
+    public void canDeserialiseMixOfTableReferenceAndPhysicalTableName() throws JsonProcessingException {
+        String config = "- namespace:\n   name: test\n  tablename: foo\n- physicalTableName: testfoo";
+        List<AlterTableMetadataReference> references = OBJECT_MAPPER.readValue(config, new TypeReference<>() {});
+        assertThat(references)
+                .contains(
+                        ImmutableTableReferenceWrapper.of(PRESENT_TABLE_REFERENCE),
+                        ImmutablePhysicalTableNameWrapper.of(PRESENT_PHYSICAL_TABLE_NAME));
+    }
+
+    @Test
+    public void throwsIfFailToDeserialise() throws JsonProcessingException {
+        String config = "namespace: test\ntablename: foo";
+        assertThatThrownBy(() -> OBJECT_MAPPER.readValue(config, AlterTableMetadataReference.class))
+                .rootCause()
+                .isInstanceOf(SafeRuntimeException.class)
+                .satisfies(exc -> assertThatLoggableException((SafeRuntimeException) exc)
+                        .hasLogMessage(
+                                "The alterTablesOrMetadataToMatchAndIKnowWhatIAmDoing value is specified incorrectly."
+                                        + " Please either specify a physical table name via `physicalTableName:"
+                                        + " physicalTableName`, or as a table reference via \n"
+                                        + "`namespace:\n"
+                                        + "  name: namespace\n"
+                                        + "tablename: tableName")
+                        .hasExactlyArgs(SafeArg.of("node", Map.of("namespace", "test", "tablename", "foo"))));
+    }
+
+    @Test
+    public void doesTableReferenceOrPhysicalTableNameMatchReturnsTrueOnlyWhenMatchingTableRefForTableRefConfig() {
+        AlterTableMetadataReference alterTableReference = AlterTableMetadataReference.of(
+                PRESENT_TABLE_REFERENCE.getNamespace(), PRESENT_TABLE_REFERENCE.getTableName());
+
+        assertThat(alterTableReference.doesTableReferenceOrPhysicalTableNameMatch(
+                        PRESENT_TABLE_REFERENCE, MISSING_PHYSICAL_TABLE_NAME))
+                .isTrue();
+
+        assertThat(alterTableReference.doesTableReferenceOrPhysicalTableNameMatch(
+                        MISSING_TABLE_REFERENCE, MISSING_PHYSICAL_TABLE_NAME))
+                .isFalse();
+    }
+
+    @Test
+    public void
+            doesTableReferenceOrPhysicalTableNameMatchReturnsTrueOnlyWhenMatchingPhysicalTableNameForTableNameConfig() {
+        AlterTableMetadataReference alterTableReference = AlterTableMetadataReference.of(PRESENT_PHYSICAL_TABLE_NAME);
+
+        assertThat(alterTableReference.doesTableReferenceOrPhysicalTableNameMatch(
+                        MISSING_TABLE_REFERENCE, PRESENT_PHYSICAL_TABLE_NAME))
+                .isTrue();
+
+        assertThat(alterTableReference.doesTableReferenceOrPhysicalTableNameMatch(
+                        MISSING_TABLE_REFERENCE, MISSING_PHYSICAL_TABLE_NAME))
+                .isFalse();
+    }
+}

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTableTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleDdlTableTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.dbkvs.ImmutableOracleDdlConfig;
+import com.palantir.atlasdb.keyvalue.dbkvs.ImmutableTableReferenceWrapper;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleDdlConfig;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleErrorConstants;
 import com.palantir.atlasdb.keyvalue.dbkvs.OracleTableNameGetter;
@@ -74,7 +75,7 @@ public final class OracleDdlTableTest {
     private static final OracleDdlConfig TABLE_MAPPING_DEFAULT_CONFIG = ImmutableOracleDdlConfig.builder()
             .overflowMigrationState(OverflowMigrationState.FINISHED)
             .useTableMapping(true)
-            .alterTablesOrMetadataToMatch(Set.of(TEST_TABLE))
+            .addAlterTablesOrMetadataToMatch(ImmutableTableReferenceWrapper.of(TEST_TABLE))
             .build();
     private static final OracleDdlConfig NON_TABLE_MAPPING_DEFAULT_CONFIG = ImmutableOracleDdlConfig.builder()
             .overflowMigrationState(OverflowMigrationState.FINISHED)
@@ -324,7 +325,9 @@ public final class OracleDdlTableTest {
                 .thenThrow(new TableMappingNotFoundException("foo"));
         assertThatThrownBy(() -> tableMappingDdlTable.create(createMetadata(true)))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Unable to alter table to have overflow column due to a table mapping error");
+                .hasMessageContaining(
+                        "Unable to test whether table must be altered to have overflow column due to a table mapping"
+                                + " error.");
     }
 
     @Test


### PR DESCRIPTION
## General
**Before this PR**:
You had to find your namespace and table name. That's not simple to explain, but also doesn't help when things are dynamically generated. 
**After this PR**:
For simplifying docs, I added: Alter table workflows now support using the physical table name instead - since stacktraces have the table name present, this should simplify things!
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
Is preserving config back compat necessary for this specifically? The deserialisation logic is less pleasant. That's said, with highside config, it's hard to tell :/
**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
no
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
no
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
no
**Does this PR need a schema migration?**
no
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
none
**What was existing testing like? What have you done to improve it?**:
added tests
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
n/a
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
n/a
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
you can use physical table names for alter table workflows
**Has the safety of all log arguments been decided correctly?**:
yes, I think? Is there anyway we can have any short names safely logged?
**Will this change significantly affect our spending on metrics or logs?**:
no
**How would I tell that this PR does not work in production? (monitors, etc.)**:
nothing happens
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
just go back to using the namespace and tablename, ideally
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
n/a
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
no
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
no
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
no
## Development Process
**Where should we start reviewing?**:
AlterTableMetadataReference
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
n/a
**Please tag any other people who should be aware of this PR**:
@jeremyk-91

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
