### PR TITLE
[PDS-403847] [III] Part 1: Model Plausible Evolutions in CassandraTopologyValidator

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -288,3 +288,47 @@ acceptedBreaks:
         \ com.palantir.atlasdb.keyvalue.cassandra.CassandraClient, org.apache.thrift.TException>,\
         \ java.util.function.Supplier<java.util.Set<java.lang.String>>)"
       justification: "Only used internally"
+  "0.947.0":
+    com.palantir.atlasdb:atlasdb-cassandra:
+    - code: "java.class.removed"
+      old: "class com.palantir.atlasdb.keyvalue.cassandra.ImmutableConsistentClusterTopology"
+      justification: "Internal validator primitives"
+    - code: "java.class.removed"
+      old: "interface com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ConsistentClusterTopology"
+      justification: "Internal validator primitives"
+    - code: "java.method.addedToInterface"
+      new: "method java.util.Optional<com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ConsistentClusterTopologies>\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ClusterTopologyResult::agreedTopologies()"
+      justification: "Internal validator primitives"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ClusterTopologyResult\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ClusterTopologyResult::consensus(===com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ConsistentClusterTopology===)"
+      new: "parameter com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ClusterTopologyResult\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ClusterTopologyResult::consensus(===com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ConsistentClusterTopologies===)"
+      justification: "Internal validator primitives"
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.keyvalue.cassandra.ImmutableClusterTopologyResult\
+        \ com.palantir.atlasdb.keyvalue.cassandra.ImmutableClusterTopologyResult::withAgreedTopology(com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ConsistentClusterTopology)"
+      justification: "Internal validator primitives"
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.keyvalue.cassandra.ImmutableClusterTopologyResult\
+        \ com.palantir.atlasdb.keyvalue.cassandra.ImmutableClusterTopologyResult::withAgreedTopology(java.util.Optional<?\
+        \ extends com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ConsistentClusterTopology>)"
+      justification: "Internal validator primitives"
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.keyvalue.cassandra.ImmutableClusterTopologyResult.Builder\
+        \ com.palantir.atlasdb.keyvalue.cassandra.ImmutableClusterTopologyResult.Builder::agreedTopology(com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ConsistentClusterTopology)"
+      justification: "Internal validator primitives"
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.keyvalue.cassandra.ImmutableClusterTopologyResult.Builder\
+        \ com.palantir.atlasdb.keyvalue.cassandra.ImmutableClusterTopologyResult.Builder::agreedTopology(java.util.Optional<?\
+        \ extends com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ConsistentClusterTopology>)"
+      justification: "Internal validator primitives"
+    - code: "java.method.removed"
+      old: "method java.util.Optional<com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ConsistentClusterTopology>\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ClusterTopologyResult::agreedTopology()"
+      justification: "Internal validator primitives"
+    - code: "java.method.removed"
+      old: "method java.util.Optional<com.palantir.atlasdb.keyvalue.cassandra.CassandraTopologyValidator.ConsistentClusterTopology>\
+        \ com.palantir.atlasdb.keyvalue.cassandra.ImmutableClusterTopologyResult::agreedTopology()"
+      justification: "Internal validator primitives"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -243,7 +243,7 @@ public final class CassandraTopologyValidator {
                     return newServersWithoutSoftFailures.keySet();
                 }
                 Optional<ConsistentClusterTopologies> maybeTopologies = maybeGetConsistentClusterTopology(
-                        serversToConsiderWhenNoQuorumPresent)
+                                serversToConsiderWhenNoQuorumPresent)
                         .agreedTopologies();
                 if (maybeTopologies.isEmpty()) {
                     log.info(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidator.java
@@ -243,7 +243,7 @@ public final class CassandraTopologyValidator {
                     return newServersWithoutSoftFailures.keySet();
                 }
                 Optional<ConsistentClusterTopologies> maybeTopologies = maybeGetConsistentClusterTopology(
-                                serversToConsiderWhenNoQuorumPresent)
+                        serversToConsiderWhenNoQuorumPresent)
                         .agreedTopologies();
                 if (maybeTopologies.isEmpty()) {
                     log.info(
@@ -334,11 +334,8 @@ public final class CassandraTopologyValidator {
                                     .serversInConsensus(servers)
                                     .build()))
                     .build());
-        } else {
-            // There exists some set of host IDs that can't be connected to the starting node through plausible
-            // evolution.
-            return ClusterTopologyResult.dissent();
         }
+        return ClusterTopologyResult.dissent();
     }
 
     private Map<CassandraServer, HostIdResult> fetchHostIdsIgnoringSoftFailures(

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HostIdEvolution.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HostIdEvolution.java
@@ -30,7 +30,10 @@ public final class HostIdEvolution {
 
     /**
      * Returns true iff there exists a plausible sequence of cluster changes, measured through differences in snapshots
-     * of the host IDs of the cluster, that could have led to the given set of snapshots.
+     * of the host IDs of the cluster, that could have led to the given set of snapshots. Host IDs are generated as
+     * UUIDs: we thus consider that two snapshots of host IDs that contain at least one common element to be plausible
+     * evolutions of the same cluster, since we assume UUIDs will not collide. A consequence of this is that the
+     * empty set is not considered to be a plausible evolution of any other host ID set, including the empty set itself.
      * <p>
      * Notice that this method may give us false negatives as the cluster may go through more than one transition in
      * between the snapshots of host IDs we are able to read. However, in the absence of UUID collisions, this method

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HostIdEvolution.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HostIdEvolution.java
@@ -49,21 +49,19 @@ public final class HostIdEvolution {
         Set<Set<String>> remainingUnconnectedSets = new HashSet<>(sets);
 
         Iterator<Set<String>> iterator = remainingUnconnectedSets.iterator();
-        Set<String> newlyVisitedElements = new HashSet<>(iterator.next());
+        Set<String> visitedElements = new HashSet<>(iterator.next());
         iterator.remove();
-        boolean moreNodesToExplore = true;
+        boolean moreNodesToExplore = !remainingUnconnectedSets.isEmpty();
         while (moreNodesToExplore) {
+            // There may exist some performance optimisation here by only considering newly added elements on each
+            // iteration, but given the overall small data scale a simple DFS like this should suffice.
             Set<Set<String>> setsMatchingVisitedElements = remainingUnconnectedSets.stream()
                     .filter(hostIds ->
-                            !Sets.intersection(hostIds, newlyVisitedElements).isEmpty())
+                            !Sets.intersection(hostIds, visitedElements).isEmpty())
                     .collect(Collectors.toSet());
 
             remainingUnconnectedSets.removeAll(setsMatchingVisitedElements);
-            // It suffices to consider just the nodes visited on this iteration, since nodes that could have been
-            // reached from the nodes visited on previous iterations would have already have been visited and removed
-            // from remainingUnconnectedSets.
-            newlyVisitedElements.clear();
-            newlyVisitedElements.addAll(
+            visitedElements.addAll(
                     setsMatchingVisitedElements.stream().flatMap(Set::stream).collect(Collectors.toSet()));
             moreNodesToExplore = !setsMatchingVisitedElements.isEmpty();
         }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HostIdEvolution.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/HostIdEvolution.java
@@ -1,0 +1,72 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class HostIdEvolution {
+    private HostIdEvolution() {
+        // Utility class
+    }
+
+    /**
+     * Returns true iff there exists a plausible sequence of cluster changes, measured through differences in snapshots
+     * of the host IDs of the cluster, that could have led to the given set of snapshots.
+     * <p>
+     * Notice that this method may give us false negatives as the cluster may go through more than one transition in
+     * between the snapshots of host IDs we are able to read. However, in the absence of UUID collisions, this method
+     * will not give us false positives.
+     */
+    public static boolean existsPlausibleEvolutionOfHostIdSets(Set<Set<String>> sets) {
+        if (sets.isEmpty()) {
+            return true;
+        }
+        if (sets.contains(ImmutableSet.of())) {
+            // If present, this will not have a nonempty intersection with any other set, so *not* all sets would be
+            // connected by non-empty intersections.
+            return false;
+        }
+
+        Set<Set<String>> remainingUnconnectedSets = new HashSet<>(sets);
+
+        Iterator<Set<String>> iterator = remainingUnconnectedSets.iterator();
+        Set<String> newlyVisitedElements = new HashSet<>(iterator.next());
+        iterator.remove();
+        boolean moreNodesToExplore = true;
+        while (moreNodesToExplore) {
+            Set<Set<String>> setsMatchingVisitedElements = remainingUnconnectedSets.stream()
+                    .filter(hostIds ->
+                            !Sets.intersection(hostIds, newlyVisitedElements).isEmpty())
+                    .collect(Collectors.toSet());
+
+            remainingUnconnectedSets.removeAll(setsMatchingVisitedElements);
+            // It suffices to consider just the nodes visited on this iteration, since nodes that could have been
+            // reached from the nodes visited on previous iterations would have already have been visited and removed
+            // from remainingUnconnectedSets.
+            newlyVisitedElements.clear();
+            newlyVisitedElements.addAll(
+                    setsMatchingVisitedElements.stream().flatMap(Set::stream).collect(Collectors.toSet()));
+            moreNodesToExplore = !setsMatchingVisitedElements.isEmpty();
+        }
+        return remainingUnconnectedSets.isEmpty();
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
@@ -158,7 +158,7 @@ public final class CassandraTopologyValidatorTest {
     }
 
     @Test
-    public void returnsNewHostsWhenOnlyNewServersAndOneMismatch() {
+    public void returnsNewHostsWhenOnlyNewServersAndOneNodeDisagrees() {
         Map<CassandraServer, CassandraClientPoolingContainer> allHosts = initialiseHosts(NEW_HOSTS);
         setHostIds(
                 filterContainers(allHosts, server -> !server.equals(NEW_HOST_ONE)),
@@ -171,7 +171,7 @@ public final class CassandraTopologyValidatorTest {
     }
 
     @Test
-    public void returnsEmptyWhenOnlyNewServersAndOneMismatchWithPlausibleEvolution() {
+    public void returnsEmptyWhenOnlyNewServersAndOneNodeDisagreesWithPlausibleEvolution() {
         Map<CassandraServer, CassandraClientPoolingContainer> allHosts = initialiseHosts(NEW_HOSTS);
         setHostIds(
                 filterContainers(allHosts, server -> !server.equals(NEW_HOST_ONE)),
@@ -218,7 +218,7 @@ public final class CassandraTopologyValidatorTest {
         Predicate<String> badHostFilter = NEW_HOST_ONE::equals;
         Map<CassandraServer, CassandraClientPoolingContainer> allHosts = initialiseHosts(ALL_HOSTS);
         setHostIds(filterContainers(allHosts, badHostFilter.negate()), DEFAULT_RESULT);
-        setHostIds(filterContainers(allHosts, badHostFilter), HostIdResult.success(ImmutableSet.of("uuid4", "uuid5")));
+        setHostIds(filterContainers(allHosts, badHostFilter), HostIdResult.success(DIFFERENT_UUIDS));
         Set<CassandraServer> newServers = filterServers(allHosts, NEW_HOSTS::contains);
         Set<CassandraServer> badNewHosts = filterServers(allHosts, badHostFilter);
         assertThat(validator.getNewHostsWithInconsistentTopologies(mapToTokenRangeOrigin(newServers), allHosts))

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HostIdEvolutionTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HostIdEvolutionTest.java
@@ -1,0 +1,100 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+public class HostIdEvolutionTest {
+
+    @Test
+    public void zeroSetsAreAllConnectedByNonemptyIntersections() {
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(ImmutableSet.of()))
+                .isTrue();
+    }
+
+    @Test
+    public void singleNonemptySetConnectedToItselfByNonemptyIntersections() {
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(ImmutableSet.of(ImmutableSet.of("apple"))))
+                .isTrue();
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(
+                        ImmutableSet.of(ImmutableSet.of("broccoli", "carrot", "durian"))))
+                .isTrue();
+    }
+
+    @Test
+    public void singleEmptySetNotConnectedToItselfByNonemptyIntersections() {
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(ImmutableSet.of(ImmutableSet.of())))
+                .isFalse();
+    }
+
+    @Test
+    public void twoIntersectingSetsConnectedByNonemptyIntersections() {
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(ImmutableSet.of(
+                        ImmutableSet.of("eggplant", "fig", "grapefruit"),
+                        ImmutableSet.of("eggplant", "fig", "grapefruit", "honeydew"))))
+                .isTrue();
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(ImmutableSet.of(
+                        ImmutableSet.of("iceberg", "jicama", "kale"), ImmutableSet.of("kale", "leek", "mushroom"))))
+                .isTrue();
+    }
+
+    @Test
+    public void twoDisjointSetsNotConnectedByNonemptyIntersections() {
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(ImmutableSet.of(
+                        ImmutableSet.of("nectarine", "orange", "pear"), ImmutableSet.of("quince", "rhubarb"))))
+                .isFalse();
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(
+                        ImmutableSet.of(ImmutableSet.of("samphire", "taro", "ume"), ImmutableSet.of())))
+                .isFalse();
+    }
+
+    @Test
+    public void multipleSometimesPairwiseDisjointSetsConnectedByNonemptyIntersections() {
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(ImmutableSet.of(
+                        ImmutableSet.of("vanilla", "walnut"),
+                        ImmutableSet.of("walnut", "xocolatl"),
+                        ImmutableSet.of("xocolatl", "yam"),
+                        ImmutableSet.of("yam", "zucchini"),
+                        ImmutableSet.of("zucchini", "almond"))))
+                .isTrue();
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(ImmutableSet.of(
+                        ImmutableSet.of("beetroot", "currant"),
+                        ImmutableSet.of("broccoli", "currant"),
+                        ImmutableSet.of("currant", "durian"),
+                        ImmutableSet.of("durian", "eggplant"),
+                        ImmutableSet.of("durian", "edamame"))))
+                .isTrue();
+    }
+
+    @Test
+    public void multipleDisjointComponentsNotConnectedByNonemptyIntersections() {
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(ImmutableSet.of(
+                        ImmutableSet.of("apple", "banana"),
+                        ImmutableSet.of("banana", "carrot"),
+                        ImmutableSet.of("denim", "eggplant"),
+                        ImmutableSet.of("eggplant", "fig"))))
+                .isFalse();
+        assertThat(HostIdEvolution.existsPlausibleEvolutionOfHostIdSets(ImmutableSet.of(
+                        ImmutableSet.of("iceberg"),
+                        ImmutableSet.of("jerusalem artichoke", "kale"),
+                        ImmutableSet.of("kale", "leek"))))
+                .isFalse();
+    }
+}

--- a/changelog/@unreleased/pr-6766.v2.yml
+++ b/changelog/@unreleased/pr-6766.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: We keep track of past consistent _topologies_, and generally accept
+    quorums of nodes presenting topologies that are considered to be plausible evolutions
+    of one another.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6766

--- a/changelog/@unreleased/pr-6766.v2.yml
+++ b/changelog/@unreleased/pr-6766.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: We keep track of past consistent _topologies_, and generally accept
     quorums of nodes presenting topologies that are considered to be plausible evolutions
     of one another.

--- a/changelog/@unreleased/pr-6766.v2.yml
+++ b/changelog/@unreleased/pr-6766.v2.yml
@@ -1,7 +1,8 @@
 type: fix
 fix:
-  description: We keep track of past consistent _topologies_, and generally accept
-    quorums of nodes presenting topologies that are considered to be plausible evolutions
-    of one another.
+  description: We now handle Cassandra upscales and decommissions more smoothly. Previously
+    we only kept track of the last consistent topology and treated topologies that
+    are different in any way as distinct, so these cluster changes would be treated
+    as dissent/possible split brain, which is unnecessarily disruptive.
   links:
   - https://github.com/palantir/atlasdb/pull/6766


### PR DESCRIPTION
## General
**Before this PR**:
We only keep track of the past consistent _topology_, and treat topologies that are different in any way as distinct. This means we treat decommissions and upscales as dissent, which is unnecessarily disruptive.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
We keep track of past consistent _topologies_, and generally accept quorums of nodes presenting topologies that are considered to be plausible evolutions of one another.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: 
- `HostIdEvolution` feels VERY heavy-handed. It may be necessary (there are a bunch of tests for disjoint-pairs), but should I just have gone with "check no two pair of sets is disjoint"? That would still have satisfied the policy of sometimes reporting that we couldn't reconcile the topologies presented.
- There is a known issue with the topology validator (which frankly we should have fixed in stage II) around not updating the topology to be current when a NO_QUORUM based change is made. This may be significant in cases where we sleep for an entire DC connect/disconnect and then a bunch of nodes go offline. Testing this turns out to be quite nontrivial, so I'm not fixing this just yet.

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: Not that I'm aware of

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes - individual nodes can have different logic for deciding which Cassandras are good to talk to or not.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: Not right now.

**Does this PR need a schema migration?** No.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Some things around the ways host IDs work and that we can deal with false positives. I don't imagine these will change.

**What was existing testing like? What have you done to improve it?**: Added a bunch of tests for the topology check as well as in existing places where logic was changed from requiring equality to requiring plausible-evolution.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: Nothing much.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: No.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: We can check the args in the validation messages, especially for NO_QUORUM handling.

**Has the safety of all log arguments been decided correctly?**: No args.

**Will this change significantly affect our spending on metrics or logs?**: No.

**How would I tell that this PR does not work in production? (monitors, etc.)**: Client pool being empty.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: Not that I'm aware of.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Maybe, if we move to a different C* driver or something.

## Development Process
**Where should we start reviewing?**: Probably `HIE` first and then `CTV`.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
