### PR TITLE
Update targeted sweep docs to mention 16 shards

### DIFF
--- a/docs/source/cluster_management/sweep/targeted-sweep.rst
+++ b/docs/source/cluster_management/sweep/targeted-sweep.rst
@@ -41,7 +41,7 @@ In both cases, these configuration options are specified within a ``targetedSwee
    :widths: 80, 40, 200
 
    ``enabled``, "true", "Whether targeted sweep should be run by background threads. Note that enableSweepQueueWrites must be set to true before targeted sweep can be run."
-   ``shards``, "1", "Number of shards to use for persisting information to the sweep queue, enabling better parallelization of targeted sweep. The number of shards should be greater than or equal to the number of threads used for background targeted sweep. Note that this number must be monotonically increasing, and attempts to lower may be ignored. Maximum supported value is 256."
+   ``shards``, "16", "Number of shards to use for persisting information to the sweep queue, enabling better parallelization of targeted sweep. The number of shards should be greater than or equal to the number of threads used for background targeted sweep. Note that this number must be monotonically increasing, and attempts to lower may be ignored. Maximum supported value is 256."
 
 For example, to configure targeted sweep with three conservative threads, one thorough
 thread (which is the default) and 8 shards, one should add the following blocks to their configuration:


### PR DESCRIPTION
## General
**Before this PR**:
We used old default value for shards in our docs.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update targeted sweep docs - default shards value is 16
==COMMIT_MSG==

**Priority**: N/A

**Concerns / possible downsides (what feedback would you like?)**: N/A

**Is documentation needed?**: N/A

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: N/A

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: N/A

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: N/A

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: N/A

**Does this PR need a schema migration?** N/A

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: N/A

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: N/A

**Has the safety of all log arguments been decided correctly?**: N/A

**Will this change significantly affect our spending on metrics or logs?**: N/A

**How would I tell that this PR does not work in production? (monitors, etc.)**: N/A

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: N/A

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: N/A

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: N/A

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: N/A

## Development Process
**Where should we start reviewing?**: N/A

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**: N/A

