### PR TITLE
remove tests.gradle file

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -1,6 +1,5 @@
 
 apply from: "../gradle/shared.gradle"
-apply from: "../gradle/tests.gradle"
 
 versionsLock {
     testProject()
@@ -50,6 +49,10 @@ dependencies {
 
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'com.palantir.docker.compose:docker-compose-rule-core'
+
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 }
 
 task memorySensitiveTest(type: Test) {

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -1,5 +1,4 @@
 apply from: "../gradle/shared.gradle"
-apply from: "../gradle/tests.gradle"
 apply from: "../gradle/non-client-dist.gradle"
 
 apply plugin: 'com.palantir.sls-java-service-distribution'
@@ -74,6 +73,9 @@ dependencies {
         exclude group: 'commons-logging'
         exclude module: 'junit'
         exclude group: 'org.apache.httpcomponents'
+    }
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
     }
 
     runtimeOnly project(':atlasdb-dbkvs')

--- a/atlasdb-workload-server-distribution/build.gradle
+++ b/atlasdb-workload-server-distribution/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.palantir.sls-java-service-distribution'
 apply plugin: 'com.palantir.external-publish-dist'
 apply from: "../gradle/shared.gradle"
-apply from: "../gradle/tests.gradle"
 apply from: "../gradle/docker.gradle"
 apply from: "../gradle/non-client-dist.gradle"
 
@@ -29,6 +28,9 @@ dependencies {
     implementation project(':atlasdb-config')
 
     testImplementation 'io.dropwizard:dropwizard-testing'
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 
     compileOnly 'org.immutables:value::annotations'
     annotationProcessor 'org.immutables:value'

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -1,5 +1,0 @@
-dependencies {
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
-        because 'allows JUnit 3 and JUnit 4 tests to run'
-    }
-}

--- a/timelock-agent/build.gradle
+++ b/timelock-agent/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'org.unbroken-dome.test-sets'
 
 apply from: "../gradle/shared.gradle"
-apply from: "../gradle/tests.gradle"
 
 dependencies {
     implementation project(':lock-api-objects')
@@ -73,6 +72,9 @@ dependencies {
     testImplementation ('org.mockito:mockito-core') {
         // Mockito version doesn't agree with our JUnit version
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
+    }
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
     }
 
     testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'

--- a/timelock-impl/build.gradle
+++ b/timelock-impl/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'org.unbroken-dome.test-sets'
 apply plugin: 'com.palantir.metric-schema'
 
 apply from: "../gradle/shared.gradle"
-apply from: "../gradle/tests.gradle"
 
 dependencies {
     api project(':timelock-api')
@@ -84,6 +83,9 @@ dependencies {
     testImplementation project(':timelock-api:timelock-api-dialogue')
     testImplementation project(':timelock-api:timelock-api-objects')
     testImplementation project(':timestamp-api')
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 
     annotationProcessor 'com.palantir.conjure.java:conjure-undertow-processor'
     annotationProcessor project(":atlasdb-processors")

--- a/timelock-server-benchmark-client/build.gradle
+++ b/timelock-server-benchmark-client/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.palantir.sls-java-service-distribution'
 
 apply plugin: 'com.palantir.external-publish-dist'
 apply from: "../gradle/shared.gradle"
-apply from: "../gradle/tests.gradle"
 apply from: "../gradle/non-client-dist.gradle"
 
 schemas = ['com.palantir.atlasdb.timelock.benchmarks.schema.BenchmarksSchema']
@@ -41,6 +40,9 @@ dependencies {
     implementation project(':atlasdb-remoting-api')
     implementation project(':lock-api-objects')
     implementation project(':timestamp-api')
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 }
 
 distribution {

--- a/timelock-server-benchmark-cluster/build.gradle
+++ b/timelock-server-benchmark-cluster/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.palantir.sls-java-service-distribution'
 
 apply plugin: 'com.palantir.external-publish-dist'
 apply from: "../gradle/shared.gradle"
-apply from: "../gradle/tests.gradle"
 apply from: "../gradle/non-client-dist.gradle"
 
 versionsLock {
@@ -25,6 +24,9 @@ dependencies {
     implementation 'io.dropwizard.metrics:metrics-core'
     implementation project(':atlasdb-client')
     implementation project(':timelock-agent')
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 }
 
 distribution {

--- a/timelock-server-distribution/build.gradle
+++ b/timelock-server-distribution/build.gradle
@@ -2,11 +2,13 @@ apply plugin: 'com.palantir.sls-java-service-distribution'
 apply plugin: 'com.palantir.external-publish-dist'
 apply from: "../gradle/shared.gradle"
 apply from: "../gradle/docker.gradle"
-apply from: "../gradle/tests.gradle"
 apply from: "../gradle/non-client-dist.gradle"
 
 dependencies {
     runtimeOnly project(':timelock-server')
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 }
 
 distribution {

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'org.unbroken-dome.test-sets'
 
 apply from: "../gradle/shared.gradle"
-apply from: "../gradle/tests.gradle"
 
 testSets {
     libraries {


### PR DESCRIPTION
### Before this PR
1- We have two files to apply `testImplementations`: `shared.gradle` and `tests.gradle`.

### After this PR
1- `tests.gradle` is deleted. Its content is applied to package-specific gradle.builds

### Notes
- I checked that the number of tests have not changed so we are good to go.
- Gradle structure of the repo is really messed up. It can be cleaned but it is out of the JUnit5 migrations topic.

https://github.com/palantir/atlasdb/issues/6796