### PR TITLE
Throw QosException if autobatcher is shutdown

### DIFF
--- a/atlasdb-autobatch/build.gradle
+++ b/atlasdb-autobatch/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.guava:guava'
+    implementation 'com.palantir.conjure.java.api:errors'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.tracing:tracing'
     implementation 'io.dropwizard.metrics:metrics-core'


### PR DESCRIPTION
When stopping a service, our internal server library attempts to wait for requests to finish gracefully before closing managed resources. If requests do not complete within the shutdown timeout, then managed resources may be closed while there are still outstanding requests.

If a closed resource throws exceptions like `IllegalStateException`, then this will produce false positives in our internal errors metric.

Given that this exception is expected in normal operation and does not indicate a violated invariant, it is inappropriate to use `IllegalStateException` here.