### PR TITLE
lock junit5

### DIFF
--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.palantir.sls-recommended-dependencies'
-
 apply from: "../gradle/shared.gradle"
 
 libsDirName = file('build/artifacts')
+
 dependencies {
     api project(":timestamp-api")
     api project(":timestamp-client")
@@ -23,6 +23,7 @@ dependencies {
     testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
     testImplementation 'com.palantir.common:streams'
     testImplementation 'com.palantir.safe-logging:preconditions-assertj'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation project(':atlasdb-api')
     testAnnotationProcessor 'org.immutables:value'
     testCompileOnly 'org.immutables:value::annotations'
@@ -31,6 +32,11 @@ dependencies {
     compileOnly 'org.immutables:value::annotations'
     annotationProcessor project(":atlasdb-processors")
     compileOnly project(":atlasdb-processors")
+
+    testImplementation 'junit:junit'
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 }
 
 recommendedProductDependencies {

--- a/lock-api-objects/src/test/java/com/palantir/lock/watch/LockEventTest.java
+++ b/lock-api-objects/src/test/java/com/palantir/lock/watch/LockEventTest.java
@@ -45,7 +45,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.immutables.value.Value;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LockEventTest {
     private static final String BASE = "src/test/resources/lock-event-wire-format/";

--- a/lock-api-objects/src/test/java/com/palantir/util/IndexEncodingUtilsTest.java
+++ b/lock-api-objects/src/test/java/com/palantir/util/IndexEncodingUtilsTest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+/* TODO(boyoruk): Migrate to JUnit5. */
 @RunWith(Parameterized.class)
 public class IndexEncodingUtilsTest {
 

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -1,5 +1,4 @@
 apply from: "../gradle/shared.gradle"
-
 apply plugin: 'com.palantir.sls-recommended-dependencies'
 apply plugin: 'com.palantir.metric-schema'
 
@@ -9,6 +8,7 @@ license {
 }
 
 libsDirName = file('build/artifacts')
+
 dependencies {
     api project(':lock-conjure-api:lock-conjure-api-dialogue')
     api project(':lock-api-objects')
@@ -62,11 +62,12 @@ dependencies {
     testCompileOnly 'org.immutables:value::annotations'
 
     testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
-    testImplementation 'junit:junit'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.awaitility:awaitility'
     testImplementation('org.jmock:jmock') {
       exclude group: 'org.hamcrest'
     }
     testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
 }

--- a/lock-api/src/test/java/com/palantir/lock/AtlasLockDescriptorRangesTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/AtlasLockDescriptorRangesTest.java
@@ -19,7 +19,7 @@ package com.palantir.lock;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Range;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AtlasLockDescriptorRangesTest {
     private static final String TABLE = "test.table";

--- a/lock-api/src/test/java/com/palantir/lock/HeldLocksTokenTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/HeldLocksTokenTest.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import java.math.BigInteger;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class HeldLocksTokenTest {
 

--- a/lock-api/src/test/java/com/palantir/lock/LockClientTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/LockClientTest.java
@@ -18,7 +18,7 @@ package com.palantir.lock;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class LockClientTest {
     private final ObjectMapper mapper = new ObjectMapper();

--- a/lock-api/src/test/java/com/palantir/lock/LockDescriptorTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/LockDescriptorTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.common.base.Charsets;
 import com.google.common.io.BaseEncoding;
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LockDescriptorTest {
 

--- a/lock-api/src/test/java/com/palantir/lock/LockServerOptionsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/LockServerOptionsTest.java
@@ -25,7 +25,7 @@ import com.palantir.lock.v2.IdentifiedTimeLockRequest;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LockServerOptionsTest {
     private static final File LOCK_SERVER_OPTIONS_JSON = new File(IdentifiedTimeLockRequest.class

--- a/lock-api/src/test/java/com/palantir/lock/client/AsyncTimeLockUnlockerTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/AsyncTimeLockUnlockerTest.java
@@ -32,13 +32,15 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ThrowingRunnable;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class AsyncTimeLockUnlockerTest {
     private static final int ONE_THOUSAND = 1000;
@@ -49,13 +51,14 @@ public class AsyncTimeLockUnlockerTest {
     private TimelockService timelockService = mock(TimelockService.class);
     private AsyncTimeLockUnlocker unlocker = AsyncTimeLockUnlocker.create(timelockService);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         tokenList = createLockTokenList(ONE_THOUSAND);
         unlockedTokens = new ArrayList<>();
     }
 
-    @Test(timeout = 2_000)
+    @Test
+@Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS)
     public void enqueueDoesNotBlock() {
         doAnswer(invocation -> {
                     Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(30));

--- a/lock-api/src/test/java/com/palantir/lock/client/AsyncTimeLockUnlockerTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/AsyncTimeLockUnlockerTest.java
@@ -58,7 +58,7 @@ public class AsyncTimeLockUnlockerTest {
     }
 
     @Test
-@Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS)
+    @Timeout(value = 2000L, unit = TimeUnit.MILLISECONDS)
     public void enqueueDoesNotBlock() {
         doAnswer(invocation -> {
                     Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(30));

--- a/lock-api/src/test/java/com/palantir/lock/client/BatchingCommitTimestampGetterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/BatchingCommitTimestampGetterTest.java
@@ -45,7 +45,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 

--- a/lock-api/src/test/java/com/palantir/lock/client/BlockEnforcingLockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/BlockEnforcingLockServiceTest.java
@@ -37,7 +37,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.immutables.value.Value;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 @SuppressWarnings("unchecked") // Mocks with generic types

--- a/lock-api/src/test/java/com/palantir/lock/client/ConjureLockV1ResourceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ConjureLockV1ResourceTest.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.lock.ConjureLockRefreshToken;
 import com.palantir.lock.LockRefreshToken;
 import java.math.BigInteger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConjureLockV1ResourceTest {
     private static final BigInteger TOKEN_ID =

--- a/lock-api/src/test/java/com/palantir/lock/client/IdentifiedLockRequestTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/IdentifiedLockRequestTest.java
@@ -32,7 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IdentifiedLockRequestTest {
     private static final String BASE = "src/test/resources/identified-lock-request-wire-format/";

--- a/lock-api/src/test/java/com/palantir/lock/client/LeaderElectionReportingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LeaderElectionReportingTimelockServiceTest.java
@@ -49,8 +49,8 @@ import java.time.Instant;
 import java.util.UUID;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Parameter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.OngoingStubbing;
 
 public class LeaderElectionReportingTimelockServiceTest {
@@ -75,7 +75,7 @@ public class LeaderElectionReportingTimelockServiceTest {
 
     private LeaderElectionReportingTimelockService timelockService;
 
-    @Before
+    @BeforeEach
     public void before() {
         timelockService = new LeaderElectionReportingTimelockService(mockedDelegate, mockedRegistry, mockedClock);
         when(mockedDelegate.startTransactions(any())).thenReturn(startTransactionsResponse);

--- a/lock-api/src/test/java/com/palantir/lock/client/LeasedLockTokenTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LeasedLockTokenTest.java
@@ -26,7 +26,7 @@ import com.palantir.lock.v2.LeadershipId;
 import com.palantir.lock.v2.Lease;
 import java.time.Duration;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LeasedLockTokenTest {
     private static final ConjureLockToken LOCK_TOKEN = ConjureLockToken.of(UUID.randomUUID());

--- a/lock-api/src/test/java/com/palantir/lock/client/LockRefresherTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockRefresherTest.java
@@ -33,8 +33,8 @@ import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.jmock.lib.concurrent.DeterministicScheduler;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LockRefresherTest {
 
@@ -50,7 +50,7 @@ public class LockRefresherTest {
     private final LockRefresher<LockToken> refresher =
             new LockRefresher<>(executor, timelock, REFRESH_INTERVAL_MILLIS, clock);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(clock.instant()).thenReturn(Instant.EPOCH);
     }

--- a/lock-api/src/test/java/com/palantir/lock/client/LockTokenShareTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/LockTokenShareTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LockTokenShareTest {
     private static final LockToken LOCK_TOKEN = LockToken.of(UUID.randomUUID());

--- a/lock-api/src/test/java/com/palantir/lock/client/MultiClientCommitTimestampGetterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/MultiClientCommitTimestampGetterTest.java
@@ -54,7 +54,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import one.util.streamex.StreamEx;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MultiClientCommitTimestampGetterTest {
     private static final int COMMIT_TS_LIMIT_PER_REQUEST = 5;

--- a/lock-api/src/test/java/com/palantir/lock/client/MultiClientTimeLockUnlockerTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/MultiClientTimeLockUnlockerTest.java
@@ -35,7 +35,7 @@ import com.palantir.lock.client.MultiClientTimeLockUnlocker.UnlockConsumer;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MultiClientTimeLockUnlockerTest {
     private static final Namespace NAMESPACE_1 = Namespace.of("namespace");

--- a/lock-api/src/test/java/com/palantir/lock/client/MultiClientTransactionStarterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/MultiClientTransactionStarterTest.java
@@ -55,7 +55,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class MultiClientTransactionStarterTest {

--- a/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ProfilingTimelockServiceTest.java
@@ -39,7 +39,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class ProfilingTimelockServiceTest {

--- a/lock-api/src/test/java/com/palantir/lock/client/ReferenceTrackingWrapperTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/ReferenceTrackingWrapperTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReferenceTrackingWrapperTest {
     private final AutoCloseable closeableDelegate = mock(AutoCloseable.class);

--- a/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TimeLockClientTest.java
@@ -46,7 +46,7 @@ import com.palantir.timestamp.TimestampRange;
 import java.net.ConnectException;
 import java.net.UnknownHostException;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 

--- a/lock-api/src/test/java/com/palantir/lock/client/TimestampCorroboratingTimelockServiceTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TimestampCorroboratingTimelockServiceTest.java
@@ -53,15 +53,15 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class TimestampCorroboratingTimelockServiceTest {
     private static final String NAMESPACE_1 = "sonic";
     private static final String NAMESPACE_2 = "shadow";
@@ -81,7 +81,7 @@ public final class TimestampCorroboratingTimelockServiceTest {
 
     private TimestampCorroboratingTimelockService timelockService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         timelockService = new TimestampCorroboratingTimelockService(callback, rawTimelockService);
     }

--- a/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/TransactionStarterTest.java
@@ -42,14 +42,14 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TransactionStarterTest {
     @Mock
     private LockLeaseService lockLeaseService;
@@ -58,12 +58,12 @@ public class TransactionStarterTest {
     private final Optional<LockWatchVersion> version = Optional.empty();
     private TransactionStarter transactionStarter;
 
-    @Before
+    @BeforeEach
     public void before() {
         transactionStarter = TransactionStarter.create(lockLeaseService, RequestBatchersFactory.createForTests());
     }
 
-    @After
+    @AfterEach
     public void after() throws Exception {
         transactionStarter.close();
     }

--- a/lock-api/src/test/java/com/palantir/lock/client/UnreliableTimelockClientTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/UnreliableTimelockClientTest.java
@@ -36,13 +36,13 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class UnreliableTimelockClientTest {
 
     private static final LockToken LOCK_TOKEN = LockToken.of(UUID.fromString("00000000-0000-0000-0000-000000000000"));
@@ -56,7 +56,7 @@ public final class UnreliableTimelockClientTest {
 
     private UnreliableTimeLockService unreliableTimeLockService;
 
-    @Before
+    @BeforeEach
     public void before() {
         unreliableTimeLockService = new UnreliableTimeLockService(timeLockClient, NoOpBuggifyFactory.INSTANCE);
     }

--- a/lock-api/src/test/java/com/palantir/lock/v2/IdentifiedTimeLockRequestSerializationDeserializationTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/v2/IdentifiedTimeLockRequestSerializationDeserializationTest.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IdentifiedTimeLockRequestSerializationDeserializationTest {
     private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newServerObjectMapper();

--- a/lock-api/src/test/java/com/palantir/lock/v2/LeadershipIdTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/v2/LeadershipIdTest.java
@@ -19,7 +19,7 @@ package com.palantir.lock.v2;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LeadershipIdTest {
     private static final String SERIALIZED_LEADERSHIP_ID = "\"fc71247c-66a5-4f94-be24-3a2b00d29968\"";

--- a/lock-api/src/test/java/com/palantir/lock/v2/LeaseTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/v2/LeaseTest.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.palantir.common.time.NanoTime;
 import java.time.Duration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LeaseTest {
     private static final LeadershipId LEADERSHIP_ID_1 = LeadershipId.random();

--- a/lock-api/src/test/java/com/palantir/lock/v2/LockResponseV2Test.java
+++ b/lock-api/src/test/java/com/palantir/lock/v2/LockResponseV2Test.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.palantir.common.time.NanoTime;
 import java.time.Duration;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LockResponseV2Test {
     private static final LockToken LOCK_TOKEN = LockToken.of(UUID.randomUUID());

--- a/lock-api/src/test/java/com/palantir/lock/v2/PartitionedTimestampsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/v2/PartitionedTimestampsTest.java
@@ -18,7 +18,7 @@ package com.palantir.lock.v2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PartitionedTimestampsTest {
     private static final int NUM_PARTITIONS = 16;

--- a/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/ConjureLockRequestMetadataUtilsTest.java
@@ -43,8 +43,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class ConjureLockRequestMetadataUtilsTest {
     private static final LockDescriptor LOCK_1 = StringLockDescriptor.of("lock1");
@@ -82,7 +82,7 @@ public class ConjureLockRequestMetadataUtilsTest {
 
     // This is a good candidate for a static construction method, but we would rather avoid testing internals of
     // IndexEncodingUtils (checksum computation) within the tests for Conjure conversion.
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         KeyListChecksum checksum =
                 IndexEncodingUtils.computeChecksum(ConjureLockRequestMetadataUtils.DEFAULT_CHECKSUM_TYPE, LOCK_LIST);

--- a/lock-api/src/test/java/com/palantir/lock/watch/LockWatchCacheImplTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/LockWatchCacheImplTest.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.lock.watch.LockWatchStateUpdate.Success;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LockWatchCacheImplTest {
     private static final ImmutableSet<Long> TIMESTAMPS = ImmutableSet.of(1L, 2L);

--- a/lock-impl/build.gradle
+++ b/lock-impl/build.gradle
@@ -21,7 +21,6 @@ dependencies {
   implementation project(':lock-api-objects')
   implementation project(':timestamp-api')
 
-  testImplementation 'org.awaitility:awaitility'
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'
   testImplementation 'com.google.guava:guava'
   testImplementation 'com.palantir.safe-logging:preconditions'
@@ -29,6 +28,8 @@ dependencies {
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'uk.org.lidalia:lidalia-slf4j-ext'
   testImplementation 'uk.org.lidalia:slf4j-test'
+  testImplementation 'org.junit.jupiter:junit-jupiter'
+  testImplementation 'org.mockito:mockito-junit-jupiter'
   testImplementation project(":flake-rule")
   testImplementation project(':commons-executors')
   testImplementation project(':lock-api-objects')
@@ -40,4 +41,9 @@ dependencies {
   annotationProcessor 'org.immutables:value'
   compileOnly 'org.immutables:value::annotations'
   testCompileOnly 'org.immutables:value::annotations'
+
+  testImplementation 'junit:junit'
+  testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+    because 'allows JUnit 3 and JUnit 4 tests to run'
+  }
 }

--- a/lock-impl/src/test/java/com/palantir/lock/AllLockTests.java
+++ b/lock-impl/src/test/java/com/palantir/lock/AllLockTests.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+/* TODO(boyoruk): Migrate to JUnit5. */
 /**
  * Runs all lock server tests.
  *

--- a/lock-impl/src/test/java/com/palantir/lock/client/LockRefreshingLockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/client/LockRefreshingLockServiceTest.java
@@ -37,6 +37,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+/* TODO(boyoruk): Migrate to JUnit5 */
 public class LockRefreshingLockServiceTest {
     private LockRefreshingLockService server;
     private LockDescriptor lock1;

--- a/lock-impl/src/test/java/com/palantir/lock/impl/AdjustableBackgroundTaskTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/AdjustableBackgroundTaskTest.java
@@ -27,8 +27,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.jmock.lib.concurrent.DeterministicScheduler;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class AdjustableBackgroundTaskTest {
     private static final Duration DEFAULT_INTERVAL = Duration.ofSeconds(10);
@@ -50,7 +50,7 @@ public class AdjustableBackgroundTaskTest {
             field::incrementAndGet,
             scheduledExecutor);
 
-    @BeforeClass
+    @BeforeAll
     public static void testDelayShouldNotExceedMinimumDelay() {
         // We have to ensure that our default interval is higher than MINIMUM_INTERVAL_IF_NOT_RUNNING
         // so our tests are actually meaningful

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ClientAwareLockTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ClientAwareLockTest.java
@@ -39,6 +39,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
+/* TODO(boyoruk): Migrate to JUnit5 */
 /**
  * Tests for {@link ClientAwareReadWriteLockImpl}.
  *

--- a/lock-impl/src/test/java/com/palantir/lock/impl/LegacyTimelockServiceTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/LegacyTimelockServiceTest.java
@@ -46,8 +46,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
@@ -71,7 +71,7 @@ public class LegacyTimelockServiceTest {
     private final LegacyTimelockService timelock =
             new LegacyTimelockService(timestampService, lockService, LOCK_CLIENT);
 
-    @Before
+    @BeforeEach
     public void before() {
         when(timestampService.getFreshTimestamp()).thenReturn(FRESH_TIMESTAMP);
     }

--- a/lock-impl/src/test/java/com/palantir/lock/impl/LockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/LockServiceImplTest.java
@@ -42,10 +42,10 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.org.lidalia.slf4jext.Level;
 import uk.org.lidalia.slf4jtest.LoggingEvent;
 import uk.org.lidalia.slf4jtest.TestLogger;
@@ -63,13 +63,13 @@ public final class LockServiceImplTest {
     private TestLogger testSlowLogger;
     private TestLogger testLockServiceImplLogger;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupLockService() {
         lockServiceWithSlowLogEnabled = createLockServiceWithSlowLogEnabled(true);
         lockServiceWithSlowLogDisabled = createLockServiceWithSlowLogEnabled(false);
     }
 
-    @Before
+    @BeforeEach
     public void setUpLoggers() {
         testSlowLogger = TestLoggerFactory.getTestLogger(SlowLockLogger.class);
         testLockServiceImplLogger = TestLoggerFactory.getTestLogger(LockServiceImpl.class);
@@ -77,7 +77,7 @@ public final class LockServiceImplTest {
         testLockServiceImplLogger.setEnabledLevelsForAllThreads(Level.DEBUG);
     }
 
-    @After
+    @AfterEach
     public void clearLoggers() {
         TestLoggerFactory.clearAll();
     }

--- a/lock-impl/src/test/java/com/palantir/lock/impl/LockTokenConverterTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/LockTokenConverterTest.java
@@ -22,7 +22,7 @@ import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.v2.LockToken;
 import java.math.BigInteger;
 import java.util.Random;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LockTokenConverterTest {
 

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadInfoLockServiceImplTest.java
@@ -42,8 +42,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class ThreadInfoLockServiceImplTest {
     private static final LockDescriptor TEST_LOCK_1 = StringLockDescriptor.of("lock-1");
@@ -310,7 +310,7 @@ public class ThreadInfoLockServiceImplTest {
         lockServiceWithRecordingEnabled.close();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         lockService.close();
     }

--- a/lock-impl/src/test/java/com/palantir/lock/impl/ThreadPooledWrapperTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/impl/ThreadPooledWrapperTest.java
@@ -29,8 +29,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ThreadPooledWrapperTest {
     private static final Waiter WAITER = new Waiter();
@@ -44,7 +44,7 @@ public class ThreadPooledWrapperTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void resetLatch() {
         countDownLatch = new CountDownLatch(1);
     }

--- a/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceSerDeTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceSerDeTest.java
@@ -34,7 +34,7 @@ import com.palantir.lock.StringLockDescriptor;
 import java.math.BigInteger;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LockServiceSerDeTest {
 

--- a/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
+++ b/lock-impl/src/test/java/com/palantir/lock/logger/LockServiceStateLoggerTest.java
@@ -49,8 +49,8 @@ import java.util.stream.Collectors;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/* TODO(boyoruk): Migrate to JUnit5 */
 public class LockServiceStateLoggerTest {
-
     private static final ConcurrentMap<HeldLocksToken, LockServiceImpl.HeldLocks<HeldLocksToken>> heldLocksTokenMap =
             new MapMaker().makeMap();
 


### PR DESCRIPTION
Migrate these packages to JUnit5:
- lock-api
- lock-api-objects
- lock-conjure-api
- lock-impl

https://github.com/palantir/atlasdb/issues/6796