### PR TITLE
add metrics for debugging getMessages#p999 problem

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1449,7 +1449,8 @@ public class SnapshotTransaction extends AbstractTransaction
                 endTime = clock.instant();
                 if (endTime.isAfter(startTime.plus(1, ChronoUnit.SECONDS))) {
                     warnTakesTooMuchTime(
-                            "validatePreCommitRequirementsOnNonExhaustiveReadIfNecessary(tableRef, getStartTimestamp()) took a lot of time",
+                            "validatePreCommitRequirementsOnNonExhaustiveReadIfNecessary(tableRef,"
+                                    + " getStartTimestamp()) took a lot of time",
                             Duration.between(startTime, endTime),
                             tableRef);
                 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1471,8 +1471,7 @@ public class SnapshotTransaction extends AbstractTransaction
                     "warnTakesTooMuchTime",
                     SafeArg.of("message", message),
                     SafeArg.of("duration", duration),
-                    SafeArg.of("tableName", tableRef.getTableName()),
-                    SafeArg.of("namespace", tableRef.getNamespace()));
+                    LoggingArgs.tableRef(tableRef));
         } catch (Exception e) {
             log.warn("Failed to log warning", e);
         }


### PR DESCRIPTION
During the rollout of the faster topic ordering project mentioned [here](https://github.palantir.build/foundry/alta/pull/7509), we observed occurrences where the `getMessages` endpoint on Alta exceeded the p999 limits. Prior to merging the PR, we aim to monitor the underlying processes and identify where the time is being spent. Upon reviewing the Alta repository, it is evident that the only external call made is to the AEQ library, which in turn invokes the `getRange` endpoint within the AtlasDB repository. In this PR, I have made an effort to identify and log the areas where this endpoint performs time-consuming operations.

### Notes for the reader:
- I have added a try/catch block around the logging code to prevent any potential issues caused by debugging lines.
- It would be great if you could review the functionality of the `postFilterRows` function. When called, it should execute the `getCommitTimestamps` function. There are multiple futures, async operations, and function references involved, and based on my understanding, it synchronously call the `getCommitTimestamps` function to allow us for the time measurement.
- **This library release should be only used by the Alta.**