### PR TITLE
Boy/subdirectory creater

### DIFF
--- a/atlasdb-tests-shared/src/main/java/com/palantir/test/utils/SubdirectoryCreator.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/test/utils/SubdirectoryCreator.java
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
-package com.palantir;
+package com.palantir.test.utils;
 
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.File;
 
-public class SubdirectoryCreator {
+public final class SubdirectoryCreator {
+
+    private SubdirectoryCreator() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
     public static File getAndCreateSubdirectory(File base, String subdirectoryName) {
         File file = base.toPath().resolve(subdirectoryName).toFile();
         if (file.mkdirs()) {
             return file;
         }
-        throw new RuntimeException("Unexpected error when creating a subdirectory");
+        throw new SafeRuntimeException("Unexpected error when creating a subdirectory");
     }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/test/utils/SubdirectoryCreator.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/test/utils/SubdirectoryCreator.java
@@ -21,9 +21,7 @@ import java.io.File;
 
 public final class SubdirectoryCreator {
 
-    private SubdirectoryCreator() {
-        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
-    }
+    private SubdirectoryCreator() {}
 
     public static File getAndCreateSubdirectory(File base, String subdirectoryName) {
         File file = base.toPath().resolve(subdirectoryName).toFile();

--- a/leader-election-impl/build.gradle
+++ b/leader-election-impl/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   testImplementation 'io.dropwizard.metrics:metrics-core'
   testImplementation project(':commons-executors')
   testImplementation project(':leader-election-api-protobufs')
+  testImplementation project(':atlasdb-tests-shared')
 
   annotationProcessor 'org.immutables:value'
   compileOnly 'org.immutables:value::annotations'

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -22,6 +22,7 @@ import static com.palantir.paxos.PaxosStateLogTestUtils.readRoundUnchecked;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.test.utils.SubdirectoryCreator;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -45,10 +46,11 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
 
     @BeforeEach
     public void setup() throws IOException {
-        source = new PaxosStateLogImpl<>(
-                getAndCreateSubdirectory(tempFolder, "source").getPath());
+        source = new PaxosStateLogImpl<>(SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "source")
+                .getPath());
         DataSource targetSource = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                getAndCreateSubdirectory(tempFolder, "target").toPath());
+                SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "target")
+                        .toPath());
         target = SqlitePaxosStateLog.create(NAMESPACE, targetSource);
         migrationState = SqlitePaxosStateLogMigrationState.create(NAMESPACE, targetSource);
     }
@@ -128,13 +130,5 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
                 .mapKeys(value -> value.seq)
                 .map(value -> readRoundUnchecked(target, value.seq))
                 .collectToMap();
-    }
-
-    private static File getAndCreateSubdirectory(File base, String subdirectoryName) {
-        File file = base.toPath().resolve(subdirectoryName).toFile();
-        if (file.mkdirs()) {
-            return file;
-        }
-        throw new RuntimeException("Unexpected error when creating a subdirectory");
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.palantir.common.streams.KeyedStream;
+import com.palantir.test.utils.SubdirectoryCreator;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -64,9 +65,11 @@ public class PaxosStateLogMigratorTest {
     @BeforeEach
     public void setup() throws IOException {
         DataSource sourceConn = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                getAndCreateSubdirectory(tempFolder, "source").toPath());
+                SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "source")
+                        .toPath());
         DataSource targetConn = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                getAndCreateSubdirectory(tempFolder, "target").toPath());
+                SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "target")
+                        .toPath());
         source = SqlitePaxosStateLog.create(NAMESPACE, sourceConn);
         target = spy(SqlitePaxosStateLog.create(NAMESPACE, targetConn));
         migrationState = SqlitePaxosStateLogMigrationState.create(NAMESPACE, targetConn);
@@ -539,13 +542,5 @@ public class PaxosStateLogMigratorTest {
                 .collect(Collectors.toList());
         valuesWritten.forEach(value -> targetLog.writeRound(value.seq, value));
         return valuesWritten;
-    }
-
-    private static File getAndCreateSubdirectory(File base, String subdirectoryName) {
-        File file = base.toPath().resolve(subdirectoryName).toFile();
-        if (file.mkdirs()) {
-            return file;
-        }
-        throw new RuntimeException("Unexpected error when creating a subdirectory");
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SplittingPaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SplittingPaxosStateLogTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.test.utils.SubdirectoryCreator;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -47,9 +48,11 @@ public class SplittingPaxosStateLogTest {
     @BeforeEach
     public void setup() throws IOException {
         DataSource legacy = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                getAndCreateSubdirectory(tempFolder, "legacy").toPath());
+                SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "legacy")
+                        .toPath());
         DataSource current = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                getAndCreateSubdirectory(tempFolder, "current").toPath());
+                SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "current")
+                        .toPath());
         legacyLog = spy(SqlitePaxosStateLog.create(NAMESPACE, legacy));
         currentLog = spy(SqlitePaxosStateLog.create(NAMESPACE, current));
     }
@@ -158,13 +161,5 @@ public class SplittingPaxosStateLogTest {
                         .build())
                 .cutoffInclusive(cutoff)
                 .build();
-    }
-
-    private static File getAndCreateSubdirectory(File base, String subdirectoryName) {
-        File file = base.toPath().resolve(subdirectoryName).toFile();
-        if (file.mkdirs()) {
-            return file;
-        }
-        throw new RuntimeException("Unexpected error when creating a subdirectory");
     }
 }

--- a/timelock-agent/build.gradle
+++ b/timelock-agent/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     api project(':timelock-corruption-detection:timelock-corruption-detection-jersey')
     api project(':timelock-corruption-detection:timelock-corruption-detection-undertow')
 
+    testImplementation project(':atlasdb-tests-shared')
     testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-guava'
     testImplementation 'org.awaitility:awaitility'

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationIntegrationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationIntegrationTest.java
@@ -19,7 +19,7 @@ package com.palantir.timelock.config;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.palantir.SubdirectoryCreator;
+import com.palantir.test.utils.SubdirectoryCreator;
 import java.io.File;
 import java.time.Clock;
 import org.junit.jupiter.api.BeforeEach;

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
@@ -18,7 +18,7 @@ package com.palantir.timelock.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.palantir.SubdirectoryCreator;
+import com.palantir.test.utils.SubdirectoryCreator;
 import com.palantir.timelock.config.PaxosInstallConfiguration.PaxosLeaderMode;
 import java.io.File;
 import java.nio.file.Paths;

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
@@ -23,11 +23,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.palantir.SubdirectoryCreator;
 import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 import com.palantir.conjure.java.api.config.service.PartialServiceConfiguration;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.test.utils.SubdirectoryCreator;
 import com.palantir.timelock.config.ClusterConfiguration;
 import com.palantir.timelock.config.DefaultClusterConfiguration;
 import com.palantir.timelock.config.ImmutableClusterInstallConfiguration;

--- a/timelock-impl/build.gradle
+++ b/timelock-impl/build.gradle
@@ -83,6 +83,7 @@ dependencies {
     testImplementation project(':timelock-api:timelock-api-dialogue')
     testImplementation project(':timelock-api:timelock-api-objects')
     testImplementation project(':timestamp-api')
+    testImplementation project(':atlasdb-tests-shared')
 
     annotationProcessor 'com.palantir.conjure.java:conjure-undertow-processor'
     annotationProcessor project(":atlasdb-processors")

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -29,6 +29,7 @@ import com.palantir.paxos.PaxosProposalId;
 import com.palantir.paxos.PaxosValue;
 import com.palantir.paxos.SqliteConnections;
 import com.palantir.sls.versions.OrderableSlsVersion;
+import com.palantir.test.utils.SubdirectoryCreator;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -61,9 +62,11 @@ public class LocalPaxosComponentsTest {
 
     @BeforeEach
     public void setUp() throws IOException {
-        legacyDirectory = getAndCreateSubdirectory(TEMPORARY_FOLDER, "legacy").toPath();
+        legacyDirectory = SubdirectoryCreator.getAndCreateSubdirectory(TEMPORARY_FOLDER, "legacy")
+                .toPath();
         sqlite = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                getAndCreateSubdirectory(TEMPORARY_FOLDER, "sqlite").toPath());
+                SubdirectoryCreator.getAndCreateSubdirectory(TEMPORARY_FOLDER, "sqlite")
+                        .toPath());
         paxosComponents = createPaxosComponents(true);
     }
 
@@ -146,13 +149,5 @@ public class LocalPaxosComponentsTest {
                 canCreateNewClients,
                 timeLockVersion,
                 false);
-    }
-
-    private static File getAndCreateSubdirectory(File base, String subdirectoryName) {
-        File file = base.toPath().resolve(subdirectoryName).toFile();
-        if (file.mkdirs()) {
-            return file;
-        }
-        throw new RuntimeException("Unexpected error when creating a subdirectory");
     }
 }


### PR DESCRIPTION
With the migration to JUnit5, we no longer utilize the `TempFolder` class. Previously, this class provided the functionality to create subdirectories using the `createFolder` function. Now, in order to replicate this behavior, we need to implement our own custom method. To achieve this, let's create a class called `SubdirectoryCreator` and place it in a common package that is accessible by other packages.

https://github.com/palantir/atlasdb/issues/6796