### PR TITLE
commons junit5

### DIFF
--- a/commons-db/build.gradle
+++ b/commons-db/build.gradle
@@ -27,7 +27,7 @@ dependencies {
   testImplementation 'org.slf4j:slf4j-api'
   testImplementation project(':atlasdb-commons')
 
-  testImplementation 'junit:junit'
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/ThreadConfinedProxyTest.java
@@ -33,7 +33,7 @@ import java.util.ListIterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ThreadConfinedProxyTest {
 

--- a/commons-db/src/test/java/com/palantir/nexus/db/sql/BasicSQLTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/sql/BasicSQLTest.java
@@ -31,7 +31,7 @@ import java.sql.SQLException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked") // mocked executors
 public class BasicSQLTest {

--- a/commons-db/src/test/java/com/palantir/nexus/db/sql/SQLStringTest.java
+++ b/commons-db/src/test/java/com/palantir/nexus/db/sql/SQLStringTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.palantir.nexus.db.DBType;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SQLStringTest {
     @Test

--- a/commons-executors/build.gradle
+++ b/commons-executors/build.gradle
@@ -1,6 +1,7 @@
 apply from: "../gradle/shared.gradle"
 
 libsDirName = file('build/artifacts')
+
 dependencies {
     api project(":commons-executors-api")
 
@@ -14,7 +15,8 @@ dependencies {
 
     testImplementation 'com.palantir.tritium:tritium-registry'
     testImplementation 'io.dropwizard.metrics:metrics-core'
-
     testImplementation 'com.google.guava:guava'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+
     testCompileOnly 'org.immutables:value::annotations'
 }

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocalTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/ExecutorInheritableThreadLocalTest.java
@@ -28,8 +28,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class ExecutorInheritableThreadLocalTest {
     private static final String orig = "Yo";
@@ -106,7 +106,7 @@ public class ExecutorInheritableThreadLocalTest {
                 }
             };
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         exec.shutdownNow();
         local.remove();

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/InitializeableScheduledExecutorServiceSupplierTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/InitializeableScheduledExecutorServiceSupplierTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InitializeableScheduledExecutorServiceSupplierTest {
     private final InitializeableScheduledExecutorServiceSupplier supplier =

--- a/commons-executors/src/test/java/com/palantir/common/concurrent/PTExecutorsTest.java
+++ b/commons-executors/src/test/java/com/palantir/common/concurrent/PTExecutorsTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName") // Name matches the class we're testing
 public class PTExecutorsTest {


### PR DESCRIPTION
Migrate these packages to JUnit5:

- cassandra-patitioner
- commons-annotations
- commons-api
- commons-db
- commons-executors
- commons-executors-api
- commons-proxy

https://github.com/palantir/atlasdb/issues/6796

