### PR TITLE
cassandra and cli junit5

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -1,4 +1,3 @@
-
 apply from: "../gradle/shared.gradle"
 
 versionsLock {
@@ -50,9 +49,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'com.palantir.docker.compose:docker-compose-rule-core'
 
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
-        because 'allows JUnit 3 and JUnit 4 tests to run'
-    }
+    /* TODO(boyoruk): Upgrade all package to JUnit5. */
+    testImplementation 'junit:junit'
 }
 
 task memorySensitiveTest(type: Test) {

--- a/atlasdb-cassandra-multinode-tests/build.gradle
+++ b/atlasdb-cassandra-multinode-tests/build.gradle
@@ -1,4 +1,3 @@
-
 apply from: "../gradle/shared.gradle"
 
 versionsLock {
@@ -22,7 +21,6 @@ dependencies {
 
     testImplementation ('com.palantir.cassandra:cassandra-thrift') {
        exclude module: 'junit'
-
        exclude group: 'org.apache.httpcomponents'
     }
     testImplementation 'com.datastax.cassandra:cassandra-driver-core'
@@ -34,4 +32,7 @@ dependencies {
         include '**/CassandraSchemaLockTest.class'
         include '**/OneNodeDownTestSuite.class'
     }
+
+    /* TODO(boyoruk): Upgrade all package to JUnit5. */
+    testImplementation 'junit:junit'
 }

--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -80,6 +80,8 @@ dependencies {
   testImplementation 'org.awaitility:awaitility'
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'uk.org.lidalia:slf4j-test'
+  testImplementation 'org.junit.jupiter:junit-jupiter'
+  testImplementation 'org.mockito:mockito-junit-jupiter'
   testImplementation project(":atlasdb-config")
   testImplementation project(path: ":atlasdb-client", configuration: "testArtifacts")
   testImplementation project(':atlasdb-client-protobufs')
@@ -102,6 +104,11 @@ dependencies {
   compileOnly 'org.immutables:value::annotations'
   compileOnly project(":atlasdb-processors")
   testCompileOnly 'org.immutables:value::annotations'
+
+  testImplementation 'junit:junit'
+  testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+    because 'allows JUnit 3 and JUnit 4 tests to run'
+  }
 }
 
 shadowJar {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/ThriftObjectSizeUtilsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/ThriftObjectSizeUtilsTest.java
@@ -35,7 +35,7 @@ import org.apache.cassandra.thrift.KeySlice;
 import org.apache.cassandra.thrift.Mutation;
 import org.apache.cassandra.thrift.SlicePredicate;
 import org.apache.cassandra.thrift.SuperColumn;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ThriftObjectSizeUtilsTest {
     private static final String TEST_NAME = "foo";

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfigTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraCellLoadingConfigTest.java
@@ -19,7 +19,7 @@ package com.palantir.atlasdb.cassandra;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("ResultOfMethodCallIgnored") // We are concerned that there are no exceptions
 public class CassandraCellLoadingConfigTest {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfigsTest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraKeyValueServiceConfigsTest {
     private static final String KEYSPACE = "ks";

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraMutationTimestampProvidersTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraMutationTimestampProvidersTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongUnaryOperator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraMutationTimestampProvidersTest {
     private static final CassandraMutationTimestampProvider LEGACY_PROVIDER =

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraReloadableKeyValueServiceRuntimeConfigTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraReloadableKeyValueServiceRuntimeConfigTest.java
@@ -26,7 +26,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.refreshable.Refreshable;
 import java.net.InetSocketAddress;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraReloadableKeyValueServiceRuntimeConfigTest {
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraServersConfigsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/CassandraServersConfigsTest.java
@@ -27,7 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URL;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraServersConfigsTest {
     private static final InetSocketAddress THRIFT_SERVER_1 =

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/HostIdResultTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/HostIdResultTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class HostIdResultTest {
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/QosCassandraClientTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/QosCassandraClientTest.java
@@ -51,8 +51,8 @@ import org.apache.cassandra.thrift.KeySlice;
 import org.apache.cassandra.thrift.Mutation;
 import org.apache.cassandra.thrift.SlicePredicate;
 import org.apache.thrift.TException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class QosCassandraClientTest {
     private final CassandraClient mockClient = mock(CassandraClient.class);
@@ -78,7 +78,7 @@ public class QosCassandraClientTest {
 
     private CassandraClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         client = new QosCassandraClient(mockClient, mockMetrics, ticker);
         when(ticker.read()).thenReturn(NANOS_START).thenReturn(NANOS_END);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialValueTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/RefreshableWithInitialValueTest.java
@@ -24,12 +24,12 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.refreshable.SettableRefreshable;
 import java.util.function.Function;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RefreshableWithInitialValueTest {
 
     @Mock

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/ReloadingCloseableContainerImplTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/ReloadingCloseableContainerImplTest.java
@@ -26,13 +26,13 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.refreshable.SettableRefreshable;
 import java.util.function.Function;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ReloadingCloseableContainerImplTest {
     private static final int INITIAL_VALUE = 0;
     private static final int UPDATED_VALUE = 1;
@@ -50,7 +50,7 @@ public class ReloadingCloseableContainerImplTest {
 
     private ReloadingCloseableContainerImpl<AutoCloseable> reloadingCloseableContainer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(resourceFactory.apply(INITIAL_VALUE)).thenReturn(initialResource);
         when(resourceFactory.apply(UPDATED_VALUE)).thenReturn(refreshedResource);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/ReloadingCloseableContainerImplTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/ReloadingCloseableContainerImplTest.java
@@ -53,7 +53,6 @@ public class ReloadingCloseableContainerImplTest {
     @BeforeEach
     public void setUp() {
         when(resourceFactory.apply(INITIAL_VALUE)).thenReturn(initialResource);
-        when(resourceFactory.apply(UPDATED_VALUE)).thenReturn(refreshedResource);
         refreshableFactoryArg = Refreshable.create(INITIAL_VALUE);
         reloadingCloseableContainer = ReloadingCloseableContainerImpl.of(refreshableFactoryArg, resourceFactory);
     }
@@ -67,6 +66,7 @@ public class ReloadingCloseableContainerImplTest {
 
     @Test
     public void previousResourceIsClosedAfterRefresh() throws Exception {
+        when(resourceFactory.apply(UPDATED_VALUE)).thenReturn(refreshedResource);
         AutoCloseable resource = reloadingCloseableContainer.get();
         refreshableFactoryArg.update(UPDATED_VALUE);
         verify(resource).close();
@@ -74,6 +74,7 @@ public class ReloadingCloseableContainerImplTest {
 
     @Test
     public void newResourceCreatedWithUpdatedRefreshableValueAfterRefresh() throws Exception {
+        when(resourceFactory.apply(UPDATED_VALUE)).thenReturn(refreshedResource);
         AutoCloseable resource = reloadingCloseableContainer.get();
 
         refreshableFactoryArg.update(UPDATED_VALUE);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/CqlMetadataTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/CqlMetadataTest.java
@@ -36,15 +36,15 @@ import java.nio.ByteBuffer;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CqlMetadataTest {
     private static final String TOKEN_1 = "1df388e2a10c81a4339ab9304497385b";
     private static final String TOKEN_2 = "974ef05bdfaf14b88cbe12bce50e5023";
@@ -61,7 +61,7 @@ public class CqlMetadataTest {
 
     private CqlMetadata cqlMetadata;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(metadata.getTokenRanges()).thenReturn(ImmutableSet.of(FIRST_RANGE, SECOND_RANGE, WRAPAROUND_RANGE));
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/CqlMetadataTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/CqlMetadataTest.java
@@ -63,17 +63,6 @@ public class CqlMetadataTest {
 
     @BeforeEach
     public void setUp() {
-        when(metadata.getTokenRanges()).thenReturn(ImmutableSet.of(FIRST_RANGE, SECOND_RANGE, WRAPAROUND_RANGE));
-
-        ArgumentCaptor<ByteBuffer> componentCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
-        when(metadata.newToken(componentCaptor.capture()))
-                .thenAnswer(invocation -> CassandraTokenRanges.getToken(invocation.getArgument(0, ByteBuffer.class)));
-
-        ArgumentCaptor<Token> startTokenCaptor = ArgumentCaptor.forClass(Token.class);
-        ArgumentCaptor<Token> endTokenCaptor = ArgumentCaptor.forClass(Token.class);
-        when(metadata.newTokenRange(startTokenCaptor.capture(), endTokenCaptor.capture()))
-                .thenAnswer(this::createFromArgs);
-
         cqlMetadata = new CqlMetadata(metadata);
     }
 
@@ -84,6 +73,8 @@ public class CqlMetadataTest {
 
     @Test
     public void testGetTokenRanges() {
+        when(metadata.getTokenRanges()).thenReturn(ImmutableSet.of(FIRST_RANGE, SECOND_RANGE, WRAPAROUND_RANGE));
+        prepareMetadataForNewTokenInvocation();
         Set<Range<LightweightOppToken>> tokenRanges = cqlMetadata.getTokenRanges();
         assertThat(tokenRanges)
                 .containsExactlyInAnyOrder(
@@ -103,6 +94,7 @@ public class CqlMetadataTest {
 
     @Test
     public void testMinTokenGivesFullRange() {
+        prepareMetadataForNewTokenInvocation();
         Token minToken = CassandraTokenRanges.minToken();
         TokenRange tokenRange = CassandraTokenRanges.create(minToken, minToken);
 
@@ -113,6 +105,7 @@ public class CqlMetadataTest {
 
     @Test
     public void testSameTokenGivesEmptyRange() {
+        prepareMetadataForNewTokenInvocation();
         TokenRange tokenRange = CassandraTokenRanges.create(FIRST_TOKEN, FIRST_TOKEN);
 
         Range<LightweightOppToken> emptyRange =
@@ -122,6 +115,8 @@ public class CqlMetadataTest {
 
     @Test
     public void canGetTokenRangesByEnd() {
+        when(metadata.getTokenRanges()).thenReturn(ImmutableSet.of(FIRST_RANGE, SECOND_RANGE, WRAPAROUND_RANGE));
+        prepareMetadataForNewTokenInvocation();
         Set<Range<LightweightOppToken>> tokenRanges = cqlMetadata.getTokenRanges();
 
         TreeMap<LightweightOppToken, Range<LightweightOppToken>> tokenRangesByEnd = KeyedStream.of(tokenRanges)
@@ -133,6 +128,8 @@ public class CqlMetadataTest {
 
     @Test
     public void testReverseConversionNoLowerBound() {
+        prepareMetadataForNewTokenInvocation();
+        prepareMetadataNewTokenRangeInvocation();
         Range<LightweightOppToken> lowerUnbounded = Range.atMost(LightweightOppToken.serialize(FIRST_TOKEN));
         TokenRange lowerTokenRange = cqlMetadata.toTokenRange(lowerUnbounded);
         assertThat(lowerTokenRange.getStart()).isEqualTo(CassandraTokenRanges.minToken());
@@ -141,6 +138,8 @@ public class CqlMetadataTest {
 
     @Test
     public void testReverseConversionNoUpperBound() {
+        prepareMetadataForNewTokenInvocation();
+        prepareMetadataNewTokenRangeInvocation();
         Range<LightweightOppToken> upperUnbounded = Range.greaterThan(LightweightOppToken.serialize(FIRST_TOKEN));
         TokenRange lowerTokenRange = cqlMetadata.toTokenRange(upperUnbounded);
         assertThat(lowerTokenRange.getStart()).isEqualTo(FIRST_TOKEN);
@@ -156,5 +155,18 @@ public class CqlMetadataTest {
         assertThatThrownBy(() -> cqlMetadata.toTokenRange(closedOpen))
                 .isExactlyInstanceOf(SafeIllegalArgumentException.class)
                 .hasMessageContaining("Token range lower bound should be open");
+    }
+
+    private void prepareMetadataNewTokenRangeInvocation() {
+        ArgumentCaptor<Token> startTokenCaptor = ArgumentCaptor.forClass(Token.class);
+        ArgumentCaptor<Token> endTokenCaptor = ArgumentCaptor.forClass(Token.class);
+        when(metadata.newTokenRange(startTokenCaptor.capture(), endTokenCaptor.capture()))
+                .thenAnswer(this::createFromArgs);
+    }
+
+    private void prepareMetadataForNewTokenInvocation() {
+        ArgumentCaptor<ByteBuffer> componentCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+        when(metadata.newToken(componentCaptor.capture()))
+                .thenAnswer(invocation -> CassandraTokenRanges.getToken(invocation.getArgument(0, ByteBuffer.class)));
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions1TableInteractionTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions1TableInteractionTest.java
@@ -37,7 +37,7 @@ import com.palantir.atlasdb.transaction.service.TransactionStatus;
 import com.palantir.timestamp.FullyBoundedTimestampRange;
 import java.nio.ByteBuffer;
 import org.apache.commons.codec.binary.Hex;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Transactions1TableInteractionTest {
     private static final FullyBoundedTimestampRange TXN1_RANGE = FullyBoundedTimestampRange.of(Range.closed(5L, 500L));

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions2TableInteractionTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions2TableInteractionTest.java
@@ -40,8 +40,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import org.apache.commons.codec.binary.Hex;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Transactions2TableInteractionTest {
     private static final FullyBoundedTimestampRange RANGE = FullyBoundedTimestampRange.of(Range.closed(5L, 500L));
@@ -51,7 +51,7 @@ public class Transactions2TableInteractionTest {
     private final TransactionsTableInteraction interaction = new Transactions2TableInteraction(RANGE, mockPolicy);
     private final TableMetadata tableMetadata = mock(TableMetadata.class, RETURNS_DEEP_STUBS);
 
-    @Before
+    @BeforeEach
     public void setupMock() {
         when(tableMetadata.getKeyspace().getName()).thenReturn(KEYSPACE);
         when(tableMetadata.getName()).thenReturn(TransactionConstants.TRANSACTIONS2_TABLE.getTableName());

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteractionTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/transaction/Transactions3TableInteractionTest.java
@@ -43,8 +43,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import org.apache.commons.codec.binary.Hex;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Transactions3TableInteractionTest {
     private static final FullyBoundedTimestampRange RANGE = FullyBoundedTimestampRange.of(Range.closed(5L, 500L));
@@ -55,7 +55,7 @@ public class Transactions3TableInteractionTest {
     private final TransactionsTableInteraction interaction = new Transactions3TableInteraction(RANGE);
     private final TableMetadata tableMetadata = mock(TableMetadata.class, RETURNS_DEEP_STUBS);
 
-    @Before
+    @BeforeEach
     public void setupMock() {
         when(tableMetadata.getKeyspace().getName()).thenReturn(KEYSPACE);
         when(tableMetadata.getName()).thenReturn(TransactionConstants.TRANSACTIONS2_TABLE.getTableName());

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/transaction/TransactionsTableInteractionTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/cassandra/backup/transaction/TransactionsTableInteractionTest.java
@@ -27,7 +27,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.timestamp.FullyBoundedTimestampRange;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransactionsTableInteractionTest {
     private static final DefaultRetryPolicy POLICY = DefaultRetryPolicy.INSTANCE;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/BlacklistTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/BlacklistTest.java
@@ -32,8 +32,8 @@ import java.net.InetSocketAddress;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BlacklistTest {
     private static final InetSocketAddress ADDRESS_1 = InetSocketAddress.createUnresolved("NW16XE", 123);
@@ -64,7 +64,7 @@ public class BlacklistTest {
 
     private final Blacklist blacklist = new Blacklist(CONFIG, UNRESPONSIVE_HOST_BACKOFF_TIME, clock);
 
-    @Before
+    @BeforeEach
     @SuppressWarnings("unchecked") // Mock type is correct
     public void setUp() {
         when(clock.millis()).thenAnswer(invocation -> time.addAndGet(ONE_SECOND.toMillis() + 1));

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraAbsentHostTrackerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraAbsentHostTrackerTest.java
@@ -26,7 +26,7 @@ import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import java.net.InetSocketAddress;
 import java.util.Set;
 import java.util.stream.IntStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraAbsentHostTrackerTest {
     private static final InetSocketAddress ADDRESS_1 = InetSocketAddress.createUnresolved("1", 1);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraApiVersionTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraApiVersionTest.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraApiVersionTest {
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
@@ -46,7 +46,7 @@ import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.transport.TMemoryInputTransport;
 import org.apache.thrift.transport.TTransportException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraClientFactoryTest {
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -71,8 +71,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.cassandra.thrift.InvalidRequestException;
 import org.jmock.lib.concurrent.DeterministicScheduler;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.OngoingStubbing;
@@ -111,7 +111,7 @@ public final class CassandraClientPoolTest {
 
     private Blacklist blacklist;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(CassandraKeyValueServiceConfig.class);
         runtimeConfig = mock(CassandraKeyValueServiceRuntimeConfig.class);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceConfigTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceConfigTest.java
@@ -23,7 +23,7 @@ import com.palantir.atlasdb.cassandra.ImmutableCassandraKeyValueServiceConfig;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import java.net.InetSocketAddress;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraKeyValueServiceConfigTest {
     private static final InetSocketAddress SERVER_ADDRESS = InetSocketAddress.createUnresolved("localhost", 9160);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicePueTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicePueTest.java
@@ -25,7 +25,7 @@ import com.google.protobuf.ByteString;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraKeyValueServicePueTest {
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesSchemaConsensusTest.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.util.io.AvailabilityRequirement;
 import org.apache.thrift.TException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraKeyValueServicesSchemaConsensusTest {
     private static final int NO_WAITING_SCHEMA_MUTATION_TIMEOUT_MILLIS = 0;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServicesTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Value;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraKeyValueServicesTest {
     private static final byte[] DATA = PtBytes.toBytes("data");

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsWrapperTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsWrapperTest.java
@@ -27,7 +27,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.exception.NotInitializedException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraKvsWrapperTest {
     private static final CassandraKeyValueServiceImpl kvs = mock(CassandraKeyValueServiceImpl.class);

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelperTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelperTest.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.cassandra.thrift.TokenRange;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraLogHelperTest {
     private static final String TOKEN_1 = "i-am-a-token";

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraNamespaceDeleterTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraNamespaceDeleterTest.java
@@ -36,13 +36,13 @@ import org.apache.cassandra.thrift.KsDef;
 import org.apache.cassandra.thrift.NotFoundException;
 import org.apache.cassandra.thrift.TimedOutException;
 import org.apache.thrift.TException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class CassandraNamespaceDeleterTest {
     private static final String KEYSPACE = "nonreservedkeyspace";
     private static final ImmutableCqlQuery DROP_KEYSPACE_QUERY = CqlQuery.builder()
@@ -56,7 +56,7 @@ public final class CassandraNamespaceDeleterTest {
 
     private NamespaceDeleter namespaceDeleter;
 
-    @Before
+    @BeforeEach
     public void before() {
         namespaceDeleter = new CassandraNamespaceDeleter(getConfig(), () -> cassandraClient);
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraRequestExceptionHandlerTest.java
@@ -31,8 +31,8 @@ import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.TimedOutException;
 import org.apache.cassandra.thrift.UnavailableException;
 import org.apache.thrift.transport.TTransportException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CassandraRequestExceptionHandlerTest {
     private static final String MESSAGE = "a exception";
@@ -70,7 +70,7 @@ public class CassandraRequestExceptionHandlerTest {
     private CassandraRequestExceptionHandler handlerLegacy;
     private CassandraRequestExceptionHandler handlerConservative;
 
-    @Before
+    @BeforeEach
     public void setup() {
         handlerLegacy = new CassandraRequestExceptionHandler(
                 () -> MAX_RETRIES_PER_HOST,

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraServerOriginTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraServerOriginTest.java
@@ -23,7 +23,7 @@ import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class CassandraServerOriginTest {
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableOptionsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTableOptionsTest.java
@@ -19,7 +19,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.atlasdb.table.description.TableMetadata;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraTableOptionsTest {
     private static final TableMetadata DENSELY_ACCESSED_WIDE_ROWS_METADATA =

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampStoreInvalidatorTest.java
@@ -23,8 +23,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CassandraTimestampStoreInvalidatorTest {
     private static final long BACKUP_TIMESTAMP = 42;
@@ -32,7 +32,7 @@ public class CassandraTimestampStoreInvalidatorTest {
     private final CassandraTimestampBackupRunner backupRunner = mock(CassandraTimestampBackupRunner.class);
     private final CassandraTimestampStoreInvalidator invalidator = new CassandraTimestampStoreInvalidator(backupRunner);
 
-    @Before
+    @BeforeEach
     public void before() {
         when(backupRunner.backupExistingTimestamp()).thenReturn(BACKUP_TIMESTAMP);
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampUtilsTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.CqlRow;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraTimestampUtilsTest {
     private static final byte[] KEY_1 = {120};

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 import one.util.streamex.EntryStream;
 import one.util.streamex.StreamEx;
 import org.apache.thrift.TApplicationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class CassandraTopologyValidatorTest {
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -64,7 +64,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void unsetTopologyAndHighRfThrows() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         defaultTopology(HOST_1), defaultTopology(HOST_2))
                 .build();
         assertThatThrownBy(() -> CassandraVerifier.sanityCheckDatacenters(client, verifierConfig))
@@ -73,7 +73,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void unsetTopologyAndRfOneSucceeds() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         defaultTopology(HOST_1), defaultTopology(HOST_2))
                 .replicationFactor(1)
                 .build();
@@ -83,7 +83,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void nonDefaultDcAndHighRfSucceeds() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         createDetails(DC_1, RACK_1, HOST_1))
                 .build();
         assertThat(CassandraVerifier.sanityCheckDatacenters(client, verifierConfig))
@@ -92,7 +92,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void oneDcOneRackAndMoreHostsThanRfThrows() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         createDetails(DC_1, RACK_1, HOST_1),
                         createDetails(DC_1, RACK_1, HOST_2),
                         createDetails(DC_1, RACK_1, HOST_3),
@@ -104,13 +104,14 @@ public class CassandraVerifierTest {
 
     @Test
     public void moreDcsPresentThanInStrategyOptionsSucceeds() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         createDetails(DC_1, RACK_1, HOST_1))
                 .build();
         KsDef ksDef = CassandraVerifier.createKsDefForFresh(client, verifierConfig);
         CassandraVerifier.sanityCheckedDatacenters.invalidateAll();
         CassandraVerifier.sanityCheckedDatacenters.cleanUp();
-        setTopologyAndGetServersConfig(createDetails(DC_1, RACK_1, HOST_1), createDetails(DC_2, RACK_2, HOST_2));
+        setTopologyAndGetServersConfigWithClientDescribeRingInvocation(
+                createDetails(DC_1, RACK_1, HOST_1), createDetails(DC_2, RACK_2, HOST_2));
 
         assertThatCode(() -> CassandraVerifier.checkAndSetReplicationFactor(client, ksDef, verifierConfig))
                 .as("strategy options should only contain info for DC_1 but should not throw despite detecting two DCs")
@@ -119,7 +120,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void oneDcFewerRacksThanRfAndMoreHostsThanRfThrows() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         defaultDcDetails(RACK_1, HOST_1),
                         defaultDcDetails(RACK_2, HOST_2),
                         defaultDcDetails(RACK_1, HOST_3),
@@ -131,7 +132,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void oneDcMoreRacksThanRfAndMoreHostsThanRfSucceeds() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         defaultDcDetails(RACK_1, HOST_1),
                         defaultDcDetails(RACK_2, HOST_2),
                         defaultDcDetails(RACK_1, HOST_3),
@@ -145,7 +146,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void oneDcFewerRacksThanRfAndFewerHostsThanRfSucceeds() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         defaultDcDetails(RACK_1, HOST_1),
                         defaultDcDetails(RACK_2, HOST_2),
                         defaultDcDetails(RACK_1, HOST_2),
@@ -157,7 +158,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void multipleDcSuceeds() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         createDetails(DC_1, RACK_1, HOST_1),
                         createDetails(DC_1, RACK_1, HOST_2),
                         createDetails(DC_1, RACK_1, HOST_3),
@@ -169,7 +170,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void freshInstanceSetsStrategyOptions() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         createDetails(DC_1, RACK_1, HOST_1),
                         createDetails(DC_1, RACK_1, HOST_2),
                         createDetails(DC_1, RACK_1, HOST_3),
@@ -182,7 +183,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void simpleStrategyOneDcOneRfSucceedsAndUpdatesKsDef() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         createDetails(DC_1, RACK_1, HOST_1))
                 .replicationFactor(1)
                 .build();
@@ -198,7 +199,7 @@ public class CassandraVerifierTest {
     }
 
     @Test
-    public void simpleStrategyOneDcHighRfThrows() throws TException {
+    public void simpleStrategyOneDcHighRfThrows() {
         CassandraVerifierConfig verifierConfig =
                 getVerifierConfigBuilderWithDefaults().build();
         KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
@@ -210,7 +211,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void simpleStrategyMultipleDcsThrows() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         createDetails(DC_1, RACK_1, HOST_1),
                         createDetails(DC_1, RACK_1, HOST_2),
                         createDetails(DC_1, RACK_1, HOST_3),
@@ -227,7 +228,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void returnSameKsDefIfNodeTopologyChecksIgnored() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         createDetails(DC_1, RACK_1, HOST_1))
                 .replicationFactor(7)
                 .ignoreNodeTopologyChecks(true)
@@ -245,7 +246,7 @@ public class CassandraVerifierTest {
 
     @Test
     public void networkStrategyMultipleDcsSucceeds() throws TException {
-        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults(
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(
                         createDetails(DC_1, RACK_1, HOST_1),
                         createDetails(DC_1, RACK_1, HOST_2),
                         createDetails(DC_1, RACK_1, HOST_3),
@@ -262,7 +263,7 @@ public class CassandraVerifierTest {
     }
 
     @Test
-    public void differentRfThanConfigThrows() throws TException {
+    public void differentRfThanConfigThrows() {
         CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults()
                 .replicationFactor(1)
                 .ignoreDatacenterConfigurationChecks(false)
@@ -277,7 +278,7 @@ public class CassandraVerifierTest {
     @Test
     public void keyspaceAlreadyExistsOnlyChecksForAnyAvailableNodes() throws TException {
         CassandraVerifierConfig verifierConfig =
-                getVerifierConfigBuilderWithDefaults(defaultTopology(HOST_1)).build();
+                getVerifierConfigBuilderWithDefaults().build();
         when(client.describe_schema_versions())
                 .thenReturn(ImmutableMap.of(
                         "A",
@@ -306,11 +307,9 @@ public class CassandraVerifierTest {
         return details.setRack(rack);
     }
 
-    private ImmutableCassandraVerifierConfig.Builder getVerifierConfigBuilderWithDefaults(EndpointDetails... details)
-            throws TException {
+    private ImmutableCassandraVerifierConfig.Builder getBaseVerifierConfigBuilderWithDefaults() {
         return CassandraVerifierConfig.builder()
                 .clientConfig(clientConfig)
-                .servers(setTopologyAndGetServersConfig(details))
                 .keyspace("test")
                 .replicationFactor(3)
                 .ignoreNodeTopologyChecks(false)
@@ -318,11 +317,27 @@ public class CassandraVerifierTest {
                 .schemaMutationTimeoutMillis(0);
     }
 
-    private CassandraServersConfig setTopologyAndGetServersConfig(EndpointDetails... details) throws TException {
-        when(client.describe_ring(CassandraConstants.SIMPLE_RF_TEST_KEYSPACE))
-                .thenReturn(ImmutableList.of(mockRangeWithDetails(details)));
+    private ImmutableCassandraVerifierConfig.Builder getVerifierConfigBuilderWithDefaults() {
+        return getBaseVerifierConfigBuilderWithDefaults().servers(setTopologyAndGetServersConfig());
+    }
+
+    private ImmutableCassandraVerifierConfig.Builder
+            getVerifierConfigBuilderWithDefaultsAndClientDescribeRingInvocation(EndpointDetails... details)
+                    throws TException {
+        return getBaseVerifierConfigBuilderWithDefaults()
+                .servers(setTopologyAndGetServersConfigWithClientDescribeRingInvocation(details));
+    }
+
+    private CassandraServersConfig setTopologyAndGetServersConfig() {
         return ImmutableDefaultConfig.builder()
                 .addThriftHosts(InetSocketAddress.createUnresolved(HOST_1, 8080))
                 .build();
+    }
+
+    private CassandraServersConfig setTopologyAndGetServersConfigWithClientDescribeRingInvocation(
+            EndpointDetails... details) throws TException {
+        when(client.describe_ring(CassandraConstants.SIMPLE_RF_TEST_KEYSPACE))
+                .thenReturn(ImmutableList.of(mockRangeWithDetails(details)));
+        return setTopologyAndGetServersConfig();
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -33,13 +33,13 @@ import org.apache.cassandra.thrift.EndpointDetails;
 import org.apache.cassandra.thrift.KsDef;
 import org.apache.cassandra.thrift.TokenRange;
 import org.apache.thrift.TException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CassandraVerifierTest {
     private static final String DC_1 = "dc1";
     private static final String DC_2 = "dc2";
@@ -57,7 +57,7 @@ public class CassandraVerifierTest {
     @Mock
     CassandraClientConfig clientConfig;
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         CassandraVerifier.sanityCheckedDatacenters.invalidateAll();
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoaderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoaderTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CellLoaderTest {
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CellLoadingBatcherTest.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked") // AssertJ assertions
 public class CellLoadingBatcherTest {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitionsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ColumnFamilyDefinitionsTest.java
@@ -23,7 +23,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.table.description.TableMetadata;
 import org.apache.cassandra.thrift.CfDef;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ColumnFamilyDefinitionsTest {
     private static final int FOUR_DAYS_IN_SECONDS = 4 * 24 * 60 * 60;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CqlExecutorTest.java
@@ -33,8 +33,8 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import org.apache.cassandra.thrift.CqlPreparedResult;
 import org.apache.cassandra.thrift.CqlResult;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 
 public class CqlExecutorTest {
@@ -51,7 +51,7 @@ public class CqlExecutorTest {
     private static final long TIMESTAMP = 123L;
     private static final int LIMIT = 100;
 
-    @Before
+    @BeforeEach
     public void before() {
         CqlResult result = new CqlResult();
         result.setRows(ImmutableList.of());

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ExpiringMemoizedRunnableTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ExpiringMemoizedRunnableTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.time.Duration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExpiringMemoizedRunnableTest {
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTablesTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HiddenTablesTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HiddenTablesTest {
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HostIdEvolutionTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/HostIdEvolutionTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableSet;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HostIdEvolutionTest {
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/LightweightOppTokenTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/LightweightOppTokenTest.java
@@ -30,6 +30,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+/* TODO(boyoruk): Migrate to JUnit5 */
 @RunWith(Parameterized.class)
 public class LightweightOppTokenTest {
     @Parameter()

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/NonSoftFailureHostIdResultTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/NonSoftFailureHostIdResultTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NonSoftFailureHostIdResultTest {
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClientTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ProfilingCassandraClientTest.java
@@ -38,8 +38,8 @@ import org.apache.cassandra.thrift.CqlRow;
 import org.apache.cassandra.thrift.SlicePredicate;
 import org.apache.cassandra.thrift.SliceRange;
 import org.apache.thrift.TException;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class ProfilingCassandraClientTest {
     private static final CqlQuery CQL_QUERY = CqlQuery.builder()
@@ -49,7 +49,7 @@ public class ProfilingCassandraClientTest {
     private final CassandraClient delegate = mock(CassandraClient.class);
     private final CassandraClient profilingClient = new ProfilingCassandraClient(delegate);
 
-    @After
+    @AfterEach
     public void noMoreInteractions() {
         verifyNoMoreInteractions(delegate);
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.cassandra.thrift.ConsistencyLevel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReadConsistencyProviderTest {
     private static final TableReference TABLE_1 = TableReference.createFromFullyQualifiedName("bobby.tables");

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/RetryableCassandraRequestTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/RetryableCassandraRequestTest.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.common.base.FunctionCheckedException;
 import java.net.InetSocketAddress;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RetryableCassandraRequestTest {
     private static final int DEFAULT_PORT = 5000;
@@ -35,7 +35,7 @@ public class RetryableCassandraRequestTest {
 
     private RetryableCassandraRequest<Void, RuntimeException> request;
 
-    @Before
+    @BeforeEach
     public void setup() {
         request = new RetryableCassandraRequest<>(SERVER_1, noOp());
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TokensTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TokensTest.java
@@ -24,7 +24,7 @@ import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class TokensTest {
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CachingStatementPreparerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CachingStatementPreparerTest.java
@@ -30,8 +30,8 @@ import com.palantir.atlasdb.keyvalue.cassandra.async.statement.preparing.Caching
 import com.palantir.atlasdb.keyvalue.cassandra.async.statement.preparing.StatementPreparer;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CachingStatementPreparerTest {
 
@@ -43,7 +43,7 @@ public class CachingStatementPreparerTest {
 
     private CachingStatementPreparer cache;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         cache = CachingStatementPreparer.create(STATEMENT_PREPARER, METRICS_MANAGER.getTaggedRegistry(), 100);
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceTests.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceTests.java
@@ -71,7 +71,6 @@ public class CassandraAsyncKeyValueServiceTests {
     public void setUp() {
         asyncKeyValueService = CassandraAsyncKeyValueService.create(
                 KEYSPACE, cqlClientContainer, AtlasFutures.futuresCombiner(MoreExecutors.newDirectExecutorService()));
-        when(cqlClientContainer.get()).thenReturn(cqlClient);
     }
 
     @AfterEach
@@ -81,6 +80,7 @@ public class CassandraAsyncKeyValueServiceTests {
 
     @Test
     public void testNoDataVisible() throws Exception {
+        prepareCqlClientContainerInvocation();
         setUpNonVisibleCells(NON_VISIBLE_CELL);
 
         Map<Cell, Long> request = ImmutableMap.of(NON_VISIBLE_CELL, TIMESTAMP);
@@ -91,6 +91,7 @@ public class CassandraAsyncKeyValueServiceTests {
 
     @Test
     public void testFilteringNonVisible() throws Exception {
+        prepareCqlClientContainerInvocation();
         setUpVisibleCells(VISIBLE_CELL_1);
         setUpNonVisibleCells(NON_VISIBLE_CELL);
 
@@ -104,6 +105,7 @@ public class CassandraAsyncKeyValueServiceTests {
 
     @Test
     public void testAllVisible() throws Exception {
+        prepareCqlClientContainerInvocation();
         setUpVisibleCells(VISIBLE_CELL_1, VISIBLE_CELL_2);
 
         Map<Cell, Long> request = ImmutableMap.of(
@@ -122,6 +124,7 @@ public class CassandraAsyncKeyValueServiceTests {
 
     @Test
     public void testIsValidFalseWhenClientIsInvalid() {
+        prepareCqlClientContainerInvocation();
         when(cqlClientContainer.isClosed()).thenReturn(false);
         when(cqlClient.isValid()).thenReturn(false);
         assertThat(asyncKeyValueService.isValid()).isFalse();
@@ -129,6 +132,7 @@ public class CassandraAsyncKeyValueServiceTests {
 
     @Test
     public void testIsValidTrueWhenContainerOpenAndClientValid() {
+        prepareCqlClientContainerInvocation();
         when(cqlClient.isValid()).thenReturn(true);
         assertThat(asyncKeyValueService.isValid()).isTrue();
     }
@@ -158,5 +162,9 @@ public class CassandraAsyncKeyValueServiceTests {
                 .cell(cell)
                 .humanReadableTimestamp(TIMESTAMP)
                 .build();
+    }
+
+    private void prepareCqlClientContainerInvocation() {
+        when(cqlClientContainer.get()).thenReturn(cqlClient);
     }
 }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceTests.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CassandraAsyncKeyValueServiceTests.java
@@ -38,14 +38,14 @@ import com.palantir.common.random.RandomBytes;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CassandraAsyncKeyValueServiceTests {
     private static final String KEYSPACE = "test";
     private static final TableReference TABLE = TableReference.create(Namespace.DEFAULT_NAMESPACE, "foo");
@@ -67,14 +67,14 @@ public class CassandraAsyncKeyValueServiceTests {
     @Mock
     private ReloadingCloseableContainerImpl<CqlClient> cqlClientContainer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         asyncKeyValueService = CassandraAsyncKeyValueService.create(
                 KEYSPACE, cqlClientContainer, AtlasFutures.futuresCombiner(MoreExecutors.newDirectExecutorService()));
         when(cqlClientContainer.get()).thenReturn(cqlClient);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         asyncKeyValueService.close();
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImplTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/CqlClientImplTest.java
@@ -24,13 +24,13 @@ import com.datastax.driver.core.Session;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.CqlCapableConfigTuning;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CqlClientImplTest {
     private static final boolean INITIALIZE_ASYNC = false;
     private static final TaggedMetricRegistry REGISTRY = new DefaultTaggedMetricRegistry();
@@ -44,7 +44,7 @@ public class CqlClientImplTest {
     @Mock
     private CqlCapableConfigTuning cqlCapableConfigTuning;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(cluster.connect()).thenReturn(session);
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClientTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/async/ThrowingCqlClientTest.java
@@ -21,12 +21,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.atlasdb.keyvalue.cassandra.async.queries.CqlQuerySpec;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ThrowingCqlClientTest {
 
     @Mock

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/cas/CheckAndSetQueriesTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/cas/CheckAndSetQueriesTest.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CheckAndSetQueriesTest {
     private static final TableReference TABLE_REFERENCE = TableReference.createFromFullyQualifiedName("ns.table");

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/AsyncSupplierTests.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/AsyncSupplierTests.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class AsyncSupplierTests {
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolMetricsTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraClientPoolMetricsTest.java
@@ -27,7 +27,7 @@ import com.palantir.refreshable.Refreshable;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.MetricName;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraClientPoolMetricsTest {
     private final MetricsManager metricsManager =

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -38,7 +38,7 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CassandraServiceTest {
     private static final int DEFAULT_PORT = 5000;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/DistributionOutlierControllerTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/DistributionOutlierControllerTest.java
@@ -29,7 +29,7 @@ import com.palantir.common.streams.KeyedStream;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DistributionOutlierControllerTest {
     private static final double MIN_THRESHOLD = 0.1;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/ExceptionHandlingSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/ExceptionHandlingSupplierTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class ExceptionHandlingSupplierTest {
     private static final String VALUE = "value";

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostLocationSupplierTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class HostLocationSupplierTest {
     private static final Supplier<Optional<String>> EC2_SNITCH_SUPPLIER =

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
@@ -93,17 +93,7 @@ public class HostnamesByIpSupplierTest {
             Thread.sleep(1);
             throw new NotFoundException();
         });
-        setupKeyspaceAndTable(secondaryClient);
-        CqlResult cqlResult = createMockCqlResult(ImmutableList.of(
-                ImmutableList.of(
-                        createColumn("ip", PtBytes.toBytes("10.0.0.0")),
-                        createColumn("hostname", PtBytes.toBytes("cassandra-1"))),
-                ImmutableList.of(
-                        createColumn("ip", PtBytes.toBytes("10.0.0.1")),
-                        createColumn("hostname", PtBytes.toBytes("cassandra-2")))));
-        Mockito.lenient()
-                .when(secondaryClient.execute_cql3_query(any(), any(), any()))
-                .thenReturn(cqlResult);
+        verify(secondaryClient, Mockito.never()).execute_cql3_query(any(), any(), any());
         assertThat(supplier.get()).isEmpty();
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/HostnamesByIpSupplierTest.java
@@ -42,13 +42,13 @@ import org.apache.cassandra.thrift.KsDef;
 import org.apache.cassandra.thrift.NotFoundException;
 import org.apache.cassandra.thrift.TimedOutException;
 import org.apache.thrift.TException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HostnamesByIpSupplierTest {
     @Mock
     CassandraClient client;

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/WeightedServersTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/WeightedServersTest.java
@@ -23,7 +23,7 @@ import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class WeightedServersTest {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/ThriftQueryWeighersTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/thrift/ThriftQueryWeighersTest.java
@@ -28,7 +28,7 @@ import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.KeyRange;
 import org.apache.cassandra.thrift.KeySlice;
 import org.apache.cassandra.thrift.Mutation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ThriftQueryWeighersTest {
 

--- a/atlasdb-cli-distribution/build.gradle
+++ b/atlasdb-cli-distribution/build.gradle
@@ -1,12 +1,10 @@
 apply plugin: 'com.palantir.sls-java-service-distribution'
-
 apply plugin: 'com.palantir.external-publish-dist'
 apply from: "../gradle/shared.gradle"
 apply from: "../gradle/non-client-dist.gradle"
 
 dependencies {
   runtimeOnly project(':atlasdb-cli')
-
   runtimeOnly project(':atlasdb-cassandra')
   runtimeOnly project(':atlasdb-dbkvs')
 }

--- a/atlasdb-cli/build.gradle
+++ b/atlasdb-cli/build.gradle
@@ -1,6 +1,5 @@
 apply from: '../gradle/shared.gradle'
 
-
 dependencies {
     api project(':atlasdb-cassandra')
     api project(path: ':atlasdb-dagger', configuration: 'shadow')
@@ -50,4 +49,10 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    testImplementation 'junit:junit'
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 }

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
@@ -63,6 +63,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+/* TODO(boyoruk): Migrate to JUnit5 */
 public class KeyValueServiceMigratorsTest {
     private static final long FUTURE_TIMESTAMP = 3141592653589L;
     private static final TableReference TEST_TABLE = TableReference.createFromFullyQualifiedName("test.table");

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestFastForwardTimestampCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestFastForwardTimestampCommand.java
@@ -37,6 +37,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+/* TODO(boyoruk): Migrate to JUnit5 */
 public class TestFastForwardTimestampCommand {
     private static final String TIMESTAMP_GROUP = "timestamp";
     private static final String FETCH_COMMAND =

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestKvsMigrationCommand.java
@@ -38,9 +38,9 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestKvsMigrationCommand {
     private static final String[] EMPTY_ARGS = new String[] {};
@@ -59,14 +59,14 @@ public class TestKvsMigrationCommand {
     private AtlasDbServices fromServices;
     private AtlasDbServices toServices;
 
-    @Before
+    @BeforeEach
     public void setupServices() throws Exception {
         KvsMigrationCommand cmd = getCommand(EMPTY_ARGS, EMPTY_ARGS);
         fromServices = cmd.connectFromServices();
         toServices = cmd.connectToServices();
     }
 
-    @After
+    @AfterEach
     public void close() {
         fromServices.close();
         toServices.close();

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestScrubQueueMigrationCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestScrubQueueMigrationCommand.java
@@ -39,21 +39,21 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.SortedMap;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestScrubQueueMigrationCommand {
     private KeyValueService kvs;
     private ScrubberStore scrubStore;
 
-    @Before
+    @BeforeEach
     public void before() {
         kvs = new InMemoryKeyValueService(false, MoreExecutors.newDirectExecutorService());
         scrubStore = KeyValueServiceScrubberStore.create(kvs);
     }
 
-    @After
+    @AfterEach
     public void after() {
         kvs.close();
     }

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestSingleBackendCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestSingleBackendCommand.java
@@ -30,8 +30,8 @@ import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestSingleBackendCommand {
 
@@ -81,7 +81,7 @@ public class TestSingleBackendCommand {
         }
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws URISyntaxException {
         simpleConfigFile = AbstractTestRunner.getResourcePath(InMemoryTestRunner.CONFIG_LOCATION);
         nestedConfigFile = Paths.get(TestSingleBackendCommand.class

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestSweepCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestSweepCommand.java
@@ -54,6 +54,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+/* TODO(boyoruk): Migrate to JUnit5 */
 @RunWith(Parameterized.class)
 public class TestSweepCommand {
 

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestTimestampCommand.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/TestTimestampCommand.java
@@ -67,6 +67,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+/* TODO(boyoruk): Migrate to JUnit5 */
 @RunWith(Parameterized.class)
 public class TestTimestampCommand {
 

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/output/OutputPrinterTest.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/output/OutputPrinterTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.palantir.atlasdb.cli.runner.StandardStreamUtilities;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 public class OutputPrinterTest {


### PR DESCRIPTION
Migrate these packages to JUnit5:

- atlasdb-cassandra
- atlasdb-cassandra-integration-tests
- atlasdb-cassandra-multinode-tests
- atlasdb-cli
- atlasdb-cli-distribution

https://github.com/palantir/atlasdb/issues/6796

