### PR TITLE
junit5 config and conjure

### DIFF
--- a/atlasdb-config/build.gradle
+++ b/atlasdb-config/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testImplementation 'com.palantir.sls.versions:sls-versions'
 
     api 'com.palantir.dialogue:dialogue-clients'
+    testImplementation project(path: ':atlasdb-tests-shared')
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'
@@ -80,4 +81,11 @@ dependencies {
     testImplementation 'com.github.stefanbirkner:system-rules'
     // Needed for Jersey Response-based tests
     testImplementation 'org.glassfish.jersey.core:jersey-common'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
+
+    testImplementation 'junit:junit'
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigDeserializationTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigDeserializationTest.java
@@ -22,7 +22,7 @@ import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AtlasDbConfigDeserializationTest {
     private static final File TEST_CONFIG_FILE = new File(AtlasDbConfigDeserializationTest.class

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigTest.java
@@ -26,8 +26,8 @@ import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import java.util.Optional;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("CheckReturnValue")
 public class AtlasDbConfigTest {
@@ -66,7 +66,7 @@ public class AtlasDbConfigTest {
     private static final String CLIENT_NAMESPACE = "client";
     private static final String CASSANDRA = "cassandra";
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         when(KVS_CONFIG_WITHOUT_NAMESPACE.namespace()).thenReturn(Optional.empty());
         when(KVS_CONFIG_WITH_OTHER_NAMESPACE.namespace()).thenReturn(Optional.of(OTHER_CLIENT));

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbConfigsTest.java
@@ -28,14 +28,14 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class AtlasDbConfigsTest {
     private static String previousKeyPathProperty;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws URISyntaxException {
         previousKeyPathProperty = System.getProperty(KeyFileUtils.KEY_PATH_PROPERTY);
         System.setProperty(
@@ -44,7 +44,7 @@ public class AtlasDbConfigsTest {
                         .toString());
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() {
         if (previousKeyPathProperty != null) {
             System.setProperty(KeyFileUtils.KEY_PATH_PROPERTY, previousKeyPathProperty);

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigDeserializationTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigDeserializationTest.java
@@ -21,7 +21,7 @@ import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AtlasDbRuntimeConfigDeserializationTest {
     private static final File TEST_RUNTIME_CONFIG_FILE = new File(AtlasDbRuntimeConfigDeserializationTest.class

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfigTest.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.atlasdb.stream.StreamStorePersistenceConfigurations;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AtlasDbRuntimeConfigTest {
     @Test

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/ServerListConfigsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/ServerListConfigsTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.refreshable.Refreshable;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ServerListConfigsTest {
     private static final String CLIENT = "client";

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/TimeLockClientConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/TimeLockClientConfigTest.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TimeLockClientConfigTest {
     private static final String CLIENT = "testClient";

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/TimeLockClientConfigsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/TimeLockClientConfigsTest.java
@@ -17,7 +17,7 @@ package com.palantir.atlasdb.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TimeLockClientConfigsTest {
     private static final String CLIENT_1 = "bar";

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/config/TransactionManagersAsyncInitializationTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/config/TransactionManagersAsyncInitializationTest.java
@@ -36,7 +36,7 @@ import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.time.Duration;
 import java.util.Map;
 import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransactionManagersAsyncInitializationTest {
     private static final String USER_AGENT_NAME = "user-agent";

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProviderTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProviderTest.java
@@ -61,6 +61,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+/* TODO(boyoruk): Migrate to JUnit5 */
 public class AtlasDbDialogueServiceProviderTest {
     private static final SslConfiguration SSL_CONFIGURATION =
             SslConfiguration.of(Paths.get("var/security/trustStore.jks"));

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscoveryTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscoveryTest.java
@@ -26,7 +26,7 @@ import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.refreshable.Refreshable;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class AtlasDbServiceDiscoveryTest {
     private static final KeyValueServiceConfig INVALID_KVS_CONFIG = new TestKeyValueServiceConfig(true, "fakeconfig");

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/PersistentStoragePathSanitizerTests.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/PersistentStoragePathSanitizerTests.java
@@ -20,22 +20,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.test.utils.SubdirectoryCreator;
 import java.io.File;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public final class PersistentStoragePathSanitizerTests {
-    @Rule
-    public TemporaryFolder testFolder = new TemporaryFolder();
+    @TempDir
+    public File testFolder;
 
     private String testFolderPath;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        testFolderPath = testFolder.getRoot().getAbsolutePath();
+        testFolderPath = testFolder.getAbsolutePath();
     }
 
     @Test
@@ -45,8 +45,7 @@ public final class PersistentStoragePathSanitizerTests {
 
     @Test
     public void sanitizingFile() throws IOException {
-        File file = testFolder.newFile();
-
+        File file = SubdirectoryCreator.createAndGetFile(testFolder, "temp");
         assertThatThrownBy(() -> PersistentStoragePathSanitizer.sanitizeStoragePath(file.getAbsolutePath()))
                 .isInstanceOf(SafeIllegalArgumentException.class)
                 .hasMessageContaining("has to point to a directory");
@@ -57,10 +56,10 @@ public final class PersistentStoragePathSanitizerTests {
         PersistentStoragePathSanitizer.sanitizeStoragePath(testFolderPath)
                 .toFile()
                 .mkdir();
-        assertThat(testFolder.getRoot().listFiles()).hasSize(1);
+        assertThat(testFolder.listFiles()).hasSize(1);
 
         PersistentStoragePathSanitizer.sanitizeStoragePath(testFolderPath);
-        assertThat(testFolder.getRoot().listFiles())
+        assertThat(testFolder.listFiles())
                 .as("Sanitization should remove the special subfolder.")
                 .isEmpty();
     }

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/ServiceDiscoveringAtlasSupplierTest.java
@@ -29,7 +29,7 @@ import com.palantir.refreshable.Refreshable;
 import com.palantir.timestamp.ManagedTimestampService;
 import java.io.IOException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ServiceDiscoveringAtlasSupplierTest {
     private final KeyValueServiceConfigHelper kvsConfig = () -> AutoServiceAnnotatedAtlasDbFactory.TYPE;

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/startup/ConsistencyCheckRunnerTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/startup/ConsistencyCheckRunnerTest.java
@@ -25,7 +25,7 @@ import com.palantir.atlasdb.factory.TransactionManagerConsistencyResults;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.impl.consistency.TransactionManagerConsistencyCheck;
 import com.palantir.exception.NotInitializedException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConsistencyCheckRunnerTest {
     private static final RuntimeException EXCEPTION_1 = new RuntimeException("bad");

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/ShortAndLongTimeoutServicesTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/ShortAndLongTimeoutServicesTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.math.IntMath;
 import com.palantir.atlasdb.factory.ServiceCreator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ShortAndLongTimeoutServicesTest {
     @Test

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimeoutSensitiveLockRpcClientTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timelock/TimeoutSensitiveLockRpcClientTest.java
@@ -26,7 +26,7 @@ import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockRpcClient;
 import com.palantir.lock.StringLockDescriptor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TimeoutSensitiveLockRpcClientTest {
     private static final String NAMESPACE = "namespace";

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timestamp/FreshTimestampSupplierAdapterTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/factory/timestamp/FreshTimestampSupplierAdapterTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.palantir.exception.NotInitializedException;
 import com.palantir.timestamp.TimestampService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FreshTimestampSupplierAdapterTest {
     private final FreshTimestampSupplierAdapter adapter = new FreshTimestampSupplierAdapter();

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpClientsTest.java
@@ -66,6 +66,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+/* TODO(boyoruk): Migrate to JUnit5 */
 public class AtlasDbHttpClientsTest {
 
     private static final String LOCALHOST = "localhost";

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpProtocolVersionTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/AtlasDbHttpProtocolVersionTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 import java.util.stream.Stream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AtlasDbHttpProtocolVersionTest {
     @Test

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/ProtocolAwarenessTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/ProtocolAwarenessTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.api.config.service.UserAgents;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProtocolAwarenessTest {
     private static final UserAgent USER_AGENT_1 = createBaseUserAgent("Bond", "0.0.7");

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/http/RedirectRetryTargeterTest.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RedirectRetryTargeterTest {
     private static final URL URL_1 = createUrlUnchecked("https", "hostage", 42, "/request/hourai-branch");

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/keyvalue/impl/AsyncInitializeableInMemoryKvsTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/keyvalue/impl/AsyncInitializeableInMemoryKvsTest.java
@@ -23,7 +23,7 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.exception.NotInitializedException;
 import java.time.Duration;
 import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AsyncInitializeableInMemoryKvsTest {
 

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactoryTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAsyncAtlasDbFactoryTest.java
@@ -27,7 +27,7 @@ import com.palantir.timestamp.TimestampService;
 import java.time.Duration;
 import java.util.Optional;
 import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InMemoryAsyncAtlasDbFactoryTest {
     private final AtlasDbFactory factory = new InMemoryAsyncAtlasDbFactory();

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfigTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbConfigTest.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.memory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.atlasdb.spi.KeyValueServiceConfigHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InMemoryAtlasDbConfigTest {
     private static final InMemoryAtlasDbConfig CONFIG_1 = new InMemoryAtlasDbConfig();

--- a/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactoryTest.java
+++ b/atlasdb-config/src/test/java/com/palantir/atlasdb/memory/InMemoryAtlasDbFactoryTest.java
@@ -23,7 +23,7 @@ import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.timestamp.TimestampService;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InMemoryAtlasDbFactoryTest {
     private final AtlasDbFactory factory = new InMemoryAtlasDbFactory();

--- a/atlasdb-conjure/build.gradle
+++ b/atlasdb-conjure/build.gradle
@@ -33,7 +33,8 @@ dependencies {
   annotationProcessor 'org.immutables:value'
   compileOnly 'org.immutables:value::annotations'
 
-  testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.junit.jupiter:junit-jupiter'
+  testImplementation 'org.mockito:mockito-junit-jupiter'
 }

--- a/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/ClientOptionsTest.java
+++ b/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/ClientOptionsTest.java
@@ -22,7 +22,7 @@ import com.palantir.atlasdb.config.AuxiliaryRemotingParameters;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.client.config.ClientConfiguration;
 import java.time.Duration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ClientOptionsTest {
     private static final UserAgent USER_AGENT = UserAgent.of(UserAgent.Agent.of("tom", "1.2.3"));

--- a/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/DialogueClientOptionsTest.java
+++ b/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/DialogueClientOptionsTest.java
@@ -28,7 +28,7 @@ import com.palantir.conjure.java.api.config.service.ServicesConfigBlock;
 import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DialogueClientOptionsTest {
     private static final String SERVICE_NAME = "service";

--- a/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/FastFailoverProxyTest.java
+++ b/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/FastFailoverProxyTest.java
@@ -36,8 +36,8 @@ import java.time.Instant;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BinaryOperator;
 import java.util.function.LongConsumer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked") // Mock usage
 public class FastFailoverProxyTest {
@@ -47,7 +47,7 @@ public class FastFailoverProxyTest {
 
     private BinaryOperator<Integer> proxy;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         setUpClock();
         createProxy();

--- a/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/RetryOnSocketTimeoutExceptionProxyTest.java
+++ b/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/RetryOnSocketTimeoutExceptionProxyTest.java
@@ -23,13 +23,13 @@ import static org.mockito.Mockito.when;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.function.BinaryOperator;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RetryOnSocketTimeoutExceptionProxyTest {
 
     @Mock
@@ -40,7 +40,7 @@ public class RetryOnSocketTimeoutExceptionProxyTest {
 
     private BinaryOperator<Integer> proxy;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         createProxy();
     }

--- a/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/UnknownRemoteDebuggingProxyTest.java
+++ b/atlasdb-conjure/src/test/java/com/palantir/atlasdb/http/v2/UnknownRemoteDebuggingProxyTest.java
@@ -29,8 +29,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BinaryOperator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class UnknownRemoteDebuggingProxyTest {
     private final BinaryOperator<Integer> binaryOperator = mock(BinaryOperator.class);
@@ -38,7 +38,7 @@ public class UnknownRemoteDebuggingProxyTest {
     private final AtomicLong time = new AtomicLong();
     private BinaryOperator<Integer> debuggingProxy;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         setUpClock();
         createProxy();

--- a/atlasdb-console-distribution/build.gradle
+++ b/atlasdb-console-distribution/build.gradle
@@ -1,12 +1,10 @@
 apply plugin: 'com.palantir.sls-java-service-distribution'
-
 apply plugin: 'com.palantir.external-publish-dist'
 apply from: "../gradle/shared.gradle"
 apply from: "../gradle/non-client-dist.gradle"
 
 dependencies {
   runtimeOnly project(':atlasdb-console')
-
   runtimeOnly project(':atlasdb-cassandra')
   runtimeOnly project(':atlasdb-dbkvs')
 }

--- a/atlasdb-console/build.gradle
+++ b/atlasdb-console/build.gradle
@@ -36,6 +36,9 @@ dependencies {
       exclude group: 'org.hamcrest'
     }
     testImplementation 'org.gmock:gmock'
+
+    /* TODO(boyoruk): Migrate package to JUnit5 */
+    testImplementation 'junit:junit'
 }
 
 tasks.checkImplicitDependenciesMain.enabled = false

--- a/atlasdb-container-test-utils/build.gradle
+++ b/atlasdb-container-test-utils/build.gradle
@@ -1,4 +1,3 @@
-
 apply from: "${rootProject.projectDir}/gradle/shared.gradle"
 
 versionsLock {
@@ -33,4 +32,7 @@ dependencies {
     testImplementation 'com.github.stefanbirkner:system-rules'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.mockito:mockito-core'
+
+    /* TODO(boyoruk): Migrate to JUnit5 */
+    testImplementation 'junit:junit'
 }

--- a/atlasdb-coordination-impl/build.gradle
+++ b/atlasdb-coordination-impl/build.gradle
@@ -1,4 +1,3 @@
-
 apply from: "../gradle/shared.gradle"
 
 dependencies {
@@ -26,4 +25,5 @@ dependencies {
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
+  testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/CoordinationServiceImplTest.java
+++ b/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/CoordinationServiceImplTest.java
@@ -36,15 +36,13 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CoordinationServiceImplTest {
     private static final String STRING = "string";
     private static final ValueAndBound<String> STRING_AND_ONE_HUNDRED = ValueAndBound.of(Optional.of(STRING), 100);
     private static final ValueAndBound<String> OTHER_STRING_AND_ONE_THOUSAND =
             ValueAndBound.of(Optional.of("otherstring"), 1000);
-    private static final ValueAndBound<String> ANOTHER_STRING_AND_ONE_HUNDRED =
-            ValueAndBound.of(Optional.of("anotherstring"), 100);
 
     @SuppressWarnings("unchecked") // Known to be safe in context of this test.
     private final CoordinationStore<String> coordinationStore = mock(CoordinationStore.class);

--- a/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStoreTest.java
+++ b/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/KeyValueServiceCoordinationStoreTest.java
@@ -49,7 +49,7 @@ import com.palantir.conjure.java.serialization.ObjectMappers;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class KeyValueServiceCoordinationStoreTest {
     private static final byte[] COORDINATION_ROW = PtBytes.toBytes("aaaaa");

--- a/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/TransformingCoordinationServiceTest.java
+++ b/atlasdb-coordination-impl/src/test/java/com/palantir/atlasdb/coordination/keyvalue/TransformingCoordinationServiceTest.java
@@ -30,8 +30,8 @@ import com.palantir.atlasdb.coordination.ValueAndBound;
 import com.palantir.atlasdb.keyvalue.impl.CheckAndSetResult;
 import java.util.Optional;
 import java.util.function.Function;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked") // This test uses mocks liberally
 public class TransformingCoordinationServiceTest {
@@ -42,13 +42,13 @@ public class TransformingCoordinationServiceTest {
         throw new IllegalStateException("I'm not supposed to be called directly, use mocks");
     };
 
-    private CoordinationService<Integer> delegate = mock(CoordinationService.class);
-    private Function<String, Integer> stringToIntTransform = mock(Function.class);
-    private Function<Integer, String> intToStringTransform = mock(Function.class);
-    private CoordinationService<String> coordinationService =
+    private final CoordinationService<Integer> delegate = mock(CoordinationService.class);
+    private final Function<String, Integer> stringToIntTransform = mock(Function.class);
+    private final Function<Integer, String> intToStringTransform = mock(Function.class);
+    private final CoordinationService<String> coordinationService =
             new TransformingCoordinationService<>(delegate, intToStringTransform, stringToIntTransform);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(stringToIntTransform.apply(STRING_1)).thenReturn(INTEGER_1);
         when(intToStringTransform.apply(INTEGER_1)).thenReturn(STRING_1);

--- a/atlasdb-dagger/build.gradle
+++ b/atlasdb-dagger/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.github.johnrengelman.shadow'
-
 apply from: '../gradle/shared.gradle'
 
 dependencies {
@@ -30,6 +29,8 @@ dependencies {
 
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.junit.jupiter:junit-jupiter'
+  testImplementation 'org.mockito:mockito-junit-jupiter'
 
   shadow project(':atlasdb-service')
 }

--- a/atlasdb-dagger/src/test/java/com/palantir/atlasdb/services/AtlasDbServicesTest.java
+++ b/atlasdb-dagger/src/test/java/com/palantir/atlasdb/services/AtlasDbServicesTest.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AtlasDbServicesTest {
 

--- a/atlasdb-dagger/src/test/java/com/palantir/atlasdb/services/RawKeyValueServiceModuleTest.java
+++ b/atlasdb-dagger/src/test/java/com/palantir/atlasdb/services/RawKeyValueServiceModuleTest.java
@@ -22,12 +22,12 @@ import static org.mockito.Mockito.when;
 
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RawKeyValueServiceModuleTest {
 
     @Mock

--- a/atlasdb-tests-shared/src/main/java/com/palantir/test/utils/SubdirectoryCreator.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/test/utils/SubdirectoryCreator.java
@@ -18,16 +18,25 @@ package com.palantir.test.utils;
 
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.File;
+import java.io.IOException;
 
 public final class SubdirectoryCreator {
 
     private SubdirectoryCreator() {}
 
-    public static File getAndCreateSubdirectory(File base, String subdirectoryName) {
-        File file = base.toPath().resolve(subdirectoryName).toFile();
-        if (file.mkdirs()) {
-            return file;
+    public static File createAndGetSubdirectory(File parentDirectory, String subdirectoryName) {
+        File subdirectory = parentDirectory.toPath().resolve(subdirectoryName).toFile();
+        if (subdirectory.mkdirs()) {
+            return subdirectory;
         }
         throw new SafeRuntimeException("Unexpected error when creating a subdirectory");
+    }
+
+    public static File createAndGetFile(File directory, String fileName) throws IOException {
+        File file = directory.toPath().resolve(fileName).toFile();
+        if (file.createNewFile()) {
+            return file;
+        }
+        throw new SafeRuntimeException("Unexpected error when creating a file");
     }
 }

--- a/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/FileToSqlitePaxosStateLogIntegrationTest.java
@@ -46,10 +46,10 @@ public class FileToSqlitePaxosStateLogIntegrationTest {
 
     @BeforeEach
     public void setup() throws IOException {
-        source = new PaxosStateLogImpl<>(SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "source")
+        source = new PaxosStateLogImpl<>(SubdirectoryCreator.createAndGetSubdirectory(tempFolder, "source")
                 .getPath());
         DataSource targetSource = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "target")
+                SubdirectoryCreator.createAndGetSubdirectory(tempFolder, "target")
                         .toPath());
         target = SqlitePaxosStateLog.create(NAMESPACE, targetSource);
         migrationState = SqlitePaxosStateLogMigrationState.create(NAMESPACE, targetSource);

--- a/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/PaxosStateLogMigratorTest.java
@@ -65,10 +65,10 @@ public class PaxosStateLogMigratorTest {
     @BeforeEach
     public void setup() throws IOException {
         DataSource sourceConn = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "source")
+                SubdirectoryCreator.createAndGetSubdirectory(tempFolder, "source")
                         .toPath());
         DataSource targetConn = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "target")
+                SubdirectoryCreator.createAndGetSubdirectory(tempFolder, "target")
                         .toPath());
         source = SqlitePaxosStateLog.create(NAMESPACE, sourceConn);
         target = spy(SqlitePaxosStateLog.create(NAMESPACE, targetConn));

--- a/leader-election-impl/src/test/java/com/palantir/paxos/SplittingPaxosStateLogTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/paxos/SplittingPaxosStateLogTest.java
@@ -48,10 +48,10 @@ public class SplittingPaxosStateLogTest {
     @BeforeEach
     public void setup() throws IOException {
         DataSource legacy = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "legacy")
+                SubdirectoryCreator.createAndGetSubdirectory(tempFolder, "legacy")
                         .toPath());
         DataSource current = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                SubdirectoryCreator.getAndCreateSubdirectory(tempFolder, "current")
+                SubdirectoryCreator.createAndGetSubdirectory(tempFolder, "current")
                         .toPath());
         legacyLog = spy(SqlitePaxosStateLog.create(NAMESPACE, legacy));
         currentLog = spy(SqlitePaxosStateLog.create(NAMESPACE, current));

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationIntegrationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/PaxosInstallConfigurationIntegrationTest.java
@@ -70,8 +70,8 @@ public class PaxosInstallConfigurationIntegrationTest {
     @Test
     public void canCreateConfigurationWithDirectoriesHavingPrefixesInName() {
         assertThatCode(() -> createPartialConfiguration(
-                                SubdirectoryCreator.getAndCreateSubdirectory(temporaryFolder, "tom"),
-                                SubdirectoryCreator.getAndCreateSubdirectory(temporaryFolder, "tomato"))
+                                SubdirectoryCreator.createAndGetSubdirectory(temporaryFolder, "tom"),
+                                SubdirectoryCreator.createAndGetSubdirectory(temporaryFolder, "tomato"))
                         .isNewService(false)
                         .build())
                 .doesNotThrowAnyException();
@@ -79,7 +79,7 @@ public class PaxosInstallConfigurationIntegrationTest {
 
     @Test
     public void cannotCreateConfigurationWithIdenticalDirectories() {
-        File directory = SubdirectoryCreator.getAndCreateSubdirectory(temporaryFolder, "tomato");
+        File directory = SubdirectoryCreator.createAndGetSubdirectory(temporaryFolder, "tomato");
         assertThatThrownBy(() -> createPartialConfiguration(directory, directory)
                         .isNewService(false)
                         .build())
@@ -89,8 +89,8 @@ public class PaxosInstallConfigurationIntegrationTest {
 
     @Test
     public void sqliteDirectoryCannotBeSubdirectoryOfFileBasedDirectory() {
-        File parent = SubdirectoryCreator.getAndCreateSubdirectory(temporaryFolder, "tomato");
-        File child = SubdirectoryCreator.getAndCreateSubdirectory(parent, "tomatina");
+        File parent = SubdirectoryCreator.createAndGetSubdirectory(temporaryFolder, "tomato");
+        File child = SubdirectoryCreator.createAndGetSubdirectory(parent, "tomatina");
         assertThatThrownBy(() -> createPartialConfiguration(parent, child)
                         .isNewService(false)
                         .build())
@@ -100,8 +100,8 @@ public class PaxosInstallConfigurationIntegrationTest {
 
     @Test
     public void fileBasedDirectoryCannotBeSubdirectoryOfSqliteDirectory() {
-        File parent = SubdirectoryCreator.getAndCreateSubdirectory(temporaryFolder, "tomato");
-        File child = SubdirectoryCreator.getAndCreateSubdirectory(parent, "tomatina");
+        File parent = SubdirectoryCreator.createAndGetSubdirectory(temporaryFolder, "tomato");
+        File child = SubdirectoryCreator.createAndGetSubdirectory(parent, "tomatina");
         assertThatThrownBy(() -> createPartialConfiguration(child, parent)
                         .isNewService(false)
                         .build())
@@ -110,7 +110,7 @@ public class PaxosInstallConfigurationIntegrationTest {
     }
 
     private File getAndCreateRandomSubdirectory() {
-        return SubdirectoryCreator.getAndCreateSubdirectory(
+        return SubdirectoryCreator.createAndGetSubdirectory(
                 temporaryFolder, Clock.systemUTC().instant().toString());
     }
 

--- a/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/config/TimeLockInstallConfigurationTest.java
@@ -42,8 +42,8 @@ public class TimeLockInstallConfigurationTest {
         newSqliteLogDirectory =
                 Paths.get(temporaryFolder.toString(), "sqlite-is-cool").toFile();
 
-        extantPaxosLogDirectory = SubdirectoryCreator.getAndCreateSubdirectory(temporaryFolder, "lets-do-some-voting");
-        extantSqliteLogDirectory = SubdirectoryCreator.getAndCreateSubdirectory(temporaryFolder, "whats-a-right-join");
+        extantPaxosLogDirectory = SubdirectoryCreator.createAndGetSubdirectory(temporaryFolder, "lets-do-some-voting");
+        extantSqliteLogDirectory = SubdirectoryCreator.createAndGetSubdirectory(temporaryFolder, "whats-a-right-join");
     }
 
     @Test

--- a/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
+++ b/timelock-agent/src/test/java/com/palantir/timelock/paxos/TimeLockAgentTest.java
@@ -72,8 +72,8 @@ public class TimeLockAgentTest {
         newPaxosLogDirectory =
                 Paths.get(temporaryFolder.toString(), "part-time-parliament").toFile();
 
-        extantPaxosLogDirectory = SubdirectoryCreator.getAndCreateSubdirectory(temporaryFolder, "lets-do-some-voting");
-        extantSqliteLogDirectory = SubdirectoryCreator.getAndCreateSubdirectory(temporaryFolder, "whats-a-right-join");
+        extantPaxosLogDirectory = SubdirectoryCreator.createAndGetSubdirectory(temporaryFolder, "lets-do-some-voting");
+        extantSqliteLogDirectory = SubdirectoryCreator.createAndGetSubdirectory(temporaryFolder, "whats-a-right-join");
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponentsTest.java
@@ -62,10 +62,10 @@ public class LocalPaxosComponentsTest {
 
     @BeforeEach
     public void setUp() throws IOException {
-        legacyDirectory = SubdirectoryCreator.getAndCreateSubdirectory(TEMPORARY_FOLDER, "legacy")
+        legacyDirectory = SubdirectoryCreator.createAndGetSubdirectory(TEMPORARY_FOLDER, "legacy")
                 .toPath();
         sqlite = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                SubdirectoryCreator.getAndCreateSubdirectory(TEMPORARY_FOLDER, "sqlite")
+                SubdirectoryCreator.createAndGetSubdirectory(TEMPORARY_FOLDER, "sqlite")
                         .toPath());
         paxosComponents = createPaxosComponents(true);
     }


### PR DESCRIPTION
Migrate these packages to JUnit5:

- atlasdb-config
- atlasdb-conjure
- atlasdb-console
- atlasdb-console-distribution
- atlasdb-container-test-utils
- atlasdb-coordination-impl
- atlasdb-dagger

https://github.com/palantir/atlasdb/issues/6796