### PR TITLE
junit5 jepsen

### DIFF
--- a/atlasdb-jepsen-tests/build.gradle
+++ b/atlasdb-jepsen-tests/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 
 shadowJar {

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/JepsenLockClientTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/JepsenLockClientTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
 public class JepsenLockClientTest {

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/SynchronousLockClientTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/http/SynchronousLockClientTest.java
@@ -29,7 +29,7 @@ import com.palantir.lock.LockRequest;
 import com.palantir.lock.LockService;
 import java.math.BigInteger;
 import java.util.Collections;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SynchronousLockClientTest {
     private static final LockService LOCK_SERVICE = mock(LockService.class);

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckerIntegrationTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckerIntegrationTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JepsenHistoryCheckerIntegrationTest {
     @Test

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckerTest.java
@@ -29,7 +29,7 @@ import com.palantir.atlasdb.jepsen.events.Event;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JepsenHistoryCheckerTest {
     private static final ImmutableMap<Keyword, ?> INFO_EVENT = ImmutableMap.of(

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckersTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/JepsenHistoryCheckersTest.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.jepsen.events.Checker;
 import java.util.List;
 import java.util.function.Supplier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JepsenHistoryCheckersTest {
     @Test

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/NemesisResilienceCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/NemesisResilienceCheckerTest.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.utils.CheckerTestUtils;
 import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NemesisResilienceCheckerTest {
     private static final long ZERO_TIME = 0L;

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelperTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/PartitionByInvokeNameCheckerHelperTest.java
@@ -30,7 +30,7 @@ import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class PartitionByInvokeNameCheckerHelperTest {

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/events/EventTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/events/EventTest.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.jepsen.JepsenConstants;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EventTest {
     public static final String SOME_LONG_AS_STRING = "136";

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/IsolatedProcessCorrectnessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/IsolatedProcessCorrectnessCheckerTest.java
@@ -25,7 +25,7 @@ import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.utils.CheckerTestUtils;
 import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IsolatedProcessCorrectnessCheckerTest {
     private static final int PROCESS_1 = 1;

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockAcquisitionLivenessCheckerTest.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.jepsen.CheckerResult;
 import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LockAcquisitionLivenessCheckerTest {
     private static final long TIME = 3000L;

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockCorrectnessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/LockCorrectnessCheckerTest.java
@@ -25,7 +25,7 @@ import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.utils.CheckerTestUtils;
 import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LockCorrectnessCheckerTest {
     private static final int PROCESS_1 = 1;

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/RefreshCorrectnessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/lock/RefreshCorrectnessCheckerTest.java
@@ -25,7 +25,7 @@ import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.utils.CheckerTestUtils;
 import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RefreshCorrectnessCheckerTest {
     private static final int PROCESS_1 = 1;

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/MonotonicCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/MonotonicCheckerTest.java
@@ -23,7 +23,7 @@ import com.palantir.atlasdb.jepsen.CheckerResult;
 import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.utils.CheckerTestUtils;
 import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MonotonicCheckerTest {
     private static final Long ZERO_TIME = 0L;

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/NonOverlappingReadsMonotonicCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/NonOverlappingReadsMonotonicCheckerTest.java
@@ -23,7 +23,7 @@ import com.palantir.atlasdb.jepsen.CheckerResult;
 import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.utils.CheckerTestUtils;
 import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NonOverlappingReadsMonotonicCheckerTest {
     private static final int PROCESS_0 = 0;

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/TimestampLivenessCheckerTest.java
@@ -24,7 +24,7 @@ import com.palantir.atlasdb.jepsen.CheckerResult;
 import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.events.RequestType;
 import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TimestampLivenessCheckerTest {
     private static final long TIME = 1984L;

--- a/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/UniquenessCheckerTest.java
+++ b/atlasdb-jepsen-tests/src/test/java/com/palantir/atlasdb/jepsen/timestamp/UniquenessCheckerTest.java
@@ -22,7 +22,7 @@ import com.palantir.atlasdb.jepsen.CheckerResult;
 import com.palantir.atlasdb.jepsen.events.Event;
 import com.palantir.atlasdb.jepsen.utils.CheckerTestUtils;
 import com.palantir.atlasdb.jepsen.utils.TestEventUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UniquenessCheckerTest {
     private static final long ZERO_TIME = 0L;

--- a/atlasdb-perf/build.gradle
+++ b/atlasdb-perf/build.gradle
@@ -1,7 +1,6 @@
-
 apply from: '../gradle/shared.gradle'
-
 apply plugin: 'application'
+
 mainClassName = 'com.palantir.atlasdb.performance.cli.AtlasDbPerfCli'
 applicationName = 'atlasdb-perf'
 
@@ -62,6 +61,9 @@ dependencies {
     annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
     compileOnly 'org.immutables:value::annotations'
     compileOnly 'org.openjdk.jmh:jmh-generator-annprocess'
+
+    /* TODO(boyoruk): Migrate to JUnit5 */
+    testImplementation 'junit:junit'
 }
 
 distZip {

--- a/atlasdb-processors-tests/build.gradle
+++ b/atlasdb-processors-tests/build.gradle
@@ -11,4 +11,5 @@ dependencies {
     testImplementation 'com.google.guava:guava'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateGenericTests.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateGenericTests.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.Sets;
 import java.util.Set;
 import org.assertj.core.api.Condition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AutoDelegateGenericTests {
     @Test

--- a/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateInterfaceTests.java
+++ b/atlasdb-processors-tests/src/test/java/com/palantir/processors/AutoDelegateInterfaceTests.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.verify;
 import com.google.common.collect.Sets;
 import java.lang.reflect.Modifier;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AutoDelegateInterfaceTests {
 

--- a/atlasdb-processors/build.gradle
+++ b/atlasdb-processors/build.gradle
@@ -1,5 +1,4 @@
 apply from: "../gradle/shared.gradle"
-
 apply plugin: 'java-library'
 
 dependencies {

--- a/atlasdb-remoting-api/build.gradle
+++ b/atlasdb-remoting-api/build.gradle
@@ -16,11 +16,4 @@ dependencies {
 
   annotationProcessor 'org.immutables:value'
   compileOnly 'org.immutables:value::annotations'
-
-  testImplementation 'junit:junit'
-  testImplementation 'org.assertj:assertj-core'
-  testImplementation('org.jmock:jmock') {
-    exclude group: 'org.hamcrest'
-  }
-  testImplementation 'org.mockito:mockito-core'
 }

--- a/atlasdb-service/build.gradle
+++ b/atlasdb-service/build.gradle
@@ -3,8 +3,6 @@ apply from: "../gradle/shared.gradle"
 dependencies {
     implementation 'javax.inject:javax.inject'
 
-    testImplementation 'org.mockito:mockito-core'
-
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
@@ -24,6 +22,8 @@ dependencies {
 
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation 'com.google.guava:guava'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation project(':atlasdb-api')
     testImplementation project(':atlasdb-client')
 

--- a/atlasdb-service/src/test/java/com/palantir/atlasdb/impl/AtlasDbServiceImplTest.java
+++ b/atlasdb-service/src/test/java/com/palantir/atlasdb/impl/AtlasDbServiceImplTest.java
@@ -22,14 +22,14 @@ import static org.mockito.Mockito.verify;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AtlasDbServiceImplTest {
     private KeyValueService kvs;
     private AtlasDbServiceImpl atlasDbService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         kvs = mock(KeyValueService.class);
         TransactionManager txManager = mock(TransactionManager.class);

--- a/atlasdb-service/src/test/java/com/palantir/atlasdb/jackson/AtlasDeserializersTest.java
+++ b/atlasdb-service/src/test/java/com/palantir/atlasdb/jackson/AtlasDeserializersTest.java
@@ -24,7 +24,7 @@ import com.google.common.primitives.Bytes;
 import com.palantir.atlasdb.table.description.NameComponentDescription;
 import com.palantir.atlasdb.table.description.NameMetadataDescription;
 import com.palantir.atlasdb.table.description.ValueType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AtlasDeserializersTest {
     private static final NameMetadataDescription NAME_METADATA_DESCRIPTION =

--- a/atlasdb-service/src/test/java/com/palantir/atlasdb/jackson/TableMetadataDeserializerTest.java
+++ b/atlasdb-service/src/test/java/com/palantir/atlasdb/jackson/TableMetadataDeserializerTest.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.atlasdb.persist.api.Persister;
 import com.palantir.atlasdb.persister.JacksonPersister;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TableMetadataDeserializerTest {
     private final TableMetadataDeserializer deserializer = new TableMetadataDeserializer();

--- a/atlasdb-workload-server-api/build.gradle
+++ b/atlasdb-workload-server-api/build.gradle
@@ -14,4 +14,5 @@ dependencies {
 
     testImplementation 'com.palantir.safe-logging:preconditions-assertj'
     testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/invariant/CrossCellInconsistencyTest.java
+++ b/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/invariant/CrossCellInconsistencyTest.java
@@ -23,7 +23,7 @@ import com.palantir.atlasdb.workload.store.ImmutableWorkloadCell;
 import com.palantir.atlasdb.workload.store.TableAndWorkloadCell;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CrossCellInconsistencyTest {
     // The constants in WorkloadTestHelper are not accessible from this package.

--- a/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/invariant/MismatchedValueTest.java
+++ b/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/invariant/MismatchedValueTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.palantir.logsafe.SafeArg;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class MismatchedValueTest {
 

--- a/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/store/IndexTableTest.java
+++ b/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/store/IndexTableTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.palantir.logsafe.SafeArg;
 import java.util.Locale;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class IndexTableTest {
 

--- a/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/ColumnRangeSelectionTest.java
+++ b/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/ColumnRangeSelectionTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ColumnRangeSelectionTest {
     @Test

--- a/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/MaybeWitnessedTransactionTest.java
+++ b/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/MaybeWitnessedTransactionTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.mock;
 
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MaybeWitnessedTransactionTest {
 

--- a/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedRowColumnRangeReadTransactionActionTest.java
+++ b/atlasdb-workload-server-api/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedRowColumnRangeReadTransactionActionTest.java
@@ -27,7 +27,7 @@ import com.palantir.atlasdb.workload.transaction.RowColumnRangeReadTransactionAc
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WitnessedRowColumnRangeReadTransactionActionTest {
     @Test

--- a/atlasdb-workload-server-distribution/build.gradle
+++ b/atlasdb-workload-server-distribution/build.gradle
@@ -27,13 +27,14 @@ dependencies {
     implementation project(':atlasdb-workload-server-api')
     implementation project(':atlasdb-config')
 
-    testImplementation 'io.dropwizard:dropwizard-testing'
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
-        because 'allows JUnit 3 and JUnit 4 tests to run'
-    }
-
     compileOnly 'org.immutables:value::annotations'
     annotationProcessor 'org.immutables:value'
+
+    testImplementation 'io.dropwizard:dropwizard-testing'
+    testImplementation 'junit:junit'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine', {
+        because 'allows JUnit 3 and JUnit 4 tests to run'
+    }
 }
 
 

--- a/atlasdb-workload-server-distribution/src/test/java/com/palantir/atlasdb/workload/WorkloadServerLauncherTest.java
+++ b/atlasdb-workload-server-distribution/src/test/java/com/palantir/atlasdb/workload/WorkloadServerLauncherTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+/* TODO(boyoruk): Migrate to JUnit5 */
 public class WorkloadServerLauncherTest {
     @ClassRule
     public static final DropwizardAppRule<WorkloadServerConfiguration> RULE = new DropwizardAppRule<>(

--- a/atlasdb-workload-server/build.gradle
+++ b/atlasdb-workload-server/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
     testImplementation 'com.palantir.safe-logging:preconditions-assertj'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation('org.jmock:jmock') {
         exclude group: 'org.hamcrest'
     }

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/background/BackgroundCassandraJobTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/background/BackgroundCassandraJobTest.java
@@ -22,12 +22,12 @@ import static org.mockito.Mockito.verify;
 import com.palantir.atlasdb.buggify.AlwaysBuggifyFactory;
 import com.palantir.atlasdb.workload.resource.CassandraSidecarResource;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class BackgroundCassandraJobTest {
 
     private static final String HOST_ONE = "cassandra1";

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/DurableWritesInvariantMetricReporterTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/DurableWritesInvariantMetricReporterTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class DurableWritesInvariantMetricReporterTest {
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/DurableWritesInvariantTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/DurableWritesInvariantTest.java
@@ -41,14 +41,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public final class DurableWritesInvariantTest {
 
     private AtlasDbTransactionStore store;
 
-    @Before
+    @BeforeEach
     public void before() {
         store = AtlasDbTransactionStore.create(
                 TransactionManagers.createInMemory(Set.of()),

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/SerializableInvariantLogReporterTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/SerializableInvariantLogReporterTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import com.palantir.atlasdb.workload.transaction.witnessed.FullyWitnessedTransaction;
 import com.palantir.atlasdb.workload.transaction.witnessed.InvalidWitnessedTransaction;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SerializableInvariantLogReporterTest {
     @Test

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/SerializableInvariantTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/SerializableInvariantTest.java
@@ -36,12 +36,12 @@ import com.palantir.atlasdb.workload.workflow.WorkflowHistory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class SerializableInvariantTest {
 
     @Mock

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/SnapshotInvariantTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/SnapshotInvariantTest.java
@@ -37,12 +37,12 @@ import com.palantir.atlasdb.workload.workflow.WorkflowHistory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class SnapshotInvariantTest {
     @Mock
     private ReadableTransactionStore readableTransactionStore;

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/VersionedTableViewTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/VersionedTableViewTest.java
@@ -24,7 +24,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.Map;
 import java.util.TreeMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class VersionedTableViewTest {
     @Test

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunnerTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunnerTest.java
@@ -39,13 +39,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AntithesisWorkflowValidatorRunnerTest {
 
     private static final ListeningExecutorService EXECUTOR_SERVICE =
@@ -67,7 +67,7 @@ public class AntithesisWorkflowValidatorRunnerTest {
 
     private WorkflowAndInvariants<Workflow> workflowAndInvariants;
 
-    @Before
+    @BeforeEach
     public void before() {
         when(workflow.run()).thenReturn(workflowHistory);
         workflowAndInvariants = WorkflowAndInvariants.of(workflow, invariantReporterOne, invariantReporterTwo);

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/DefaultWorkflowRunnerTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/DefaultWorkflowRunnerTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import one.util.streamex.EntryStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DefaultWorkflowRunnerTest {
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbInteractiveTransactionTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbInteractiveTransactionTest.java
@@ -43,14 +43,14 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public final class AtlasDbInteractiveTransactionTest {
 
     private TransactionManager manager;
 
-    @Before
+    @BeforeEach
     public void before() {
         manager = TransactionManagers.createInMemory(Set.of());
         manager.getKeyValueService().createTables(TABLES_TO_ATLAS_METADATA);

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreFactoryTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreFactoryTest.java
@@ -29,7 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class AtlasDbTransactionStoreFactoryTest {
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreTest.java
@@ -63,8 +63,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public final class AtlasDbTransactionStoreTest {
 
@@ -75,7 +75,7 @@ public final class AtlasDbTransactionStoreTest {
 
     private AtlasDbTransactionStore store;
 
-    @Before
+    @BeforeEach
     public void before() {
         manager = TransactionManagers.createInMemory(Set.of());
         store = AtlasDbTransactionStore.create(manager, TABLES_TO_ATLAS_METADATA);

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/InMemoryTransactionReplayerTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/InMemoryTransactionReplayerTest.java
@@ -31,7 +31,7 @@ import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedDeleteTransa
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransactionAction;
 import io.vavr.Tuple2;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class InMemoryTransactionReplayerTest {
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/InMemoryValidationStoreTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/InMemoryValidationStoreTest.java
@@ -33,7 +33,7 @@ import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransac
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class InMemoryValidationStoreTest {
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/SimpleRangeQueryReaderTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/SimpleRangeQueryReaderTest.java
@@ -25,7 +25,7 @@ import com.palantir.atlasdb.workload.store.TableAndWorkloadCell;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.Map;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SimpleRangeQueryReaderTest {
     private final StructureHolder<Map<TableAndWorkloadCell, Optional<Integer>>> valueMap =

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/WitnessToActionVisitorTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/WitnessToActionVisitorTest.java
@@ -24,7 +24,7 @@ import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedDeleteTransa
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedSingleCellReadTransactionAction;
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransactionAction;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class WitnessToActionVisitorTest {
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/OnlyCommittedWitnessedTransactionVisitorTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/OnlyCommittedWitnessedTransactionVisitorTest.java
@@ -22,12 +22,12 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.palantir.atlasdb.workload.store.ReadOnlyTransactionStore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class OnlyCommittedWitnessedTransactionVisitorTest {
 
     private static final FullyWitnessedTransaction READ_ONLY_WITNESSED_TRANSACTION =

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionsTest.java
@@ -23,12 +23,12 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.workload.store.ReadOnlyTransactionStore;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class WitnessedTransactionsTest {
     @Mock
     private ReadOnlyTransactionStore readOnlyTransactionStore;

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/util/AtlasDbUtilsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/util/AtlasDbUtilsTest.java
@@ -22,7 +22,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.workload.store.IsolationLevel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AtlasDbUtilsTest {
     @Test

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/ConcurrentTransactionRunnerTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/ConcurrentTransactionRunnerTest.java
@@ -43,8 +43,8 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.jmock.lib.concurrent.DeterministicScheduler;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ConcurrentTransactionRunnerTest {
     private static final int DEFAULT_TASK_MULTIPLICITY = 100;
@@ -56,7 +56,7 @@ public class ConcurrentTransactionRunnerTest {
     private final ConcurrentTransactionRunner<TransactionStore> runner =
             new ConcurrentTransactionRunner<>(store, executorService);
 
-    @Before
+    @BeforeEach
     public void setupTask() {
         when(task.apply(any(), anyInt()))
                 .thenAnswer(invocation ->

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/DefaultWorkflowTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/DefaultWorkflowTest.java
@@ -27,7 +27,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.workload.store.TransactionStore;
 import com.palantir.common.concurrent.PTExecutors;
 import java.util.concurrent.ScheduledExecutorService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DefaultWorkflowTest {
     private final TransactionStore store = mock(TransactionStore.class);

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/RandomWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/RandomWorkflowsTest.java
@@ -41,13 +41,13 @@ import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RandomWorkflowsTest {
     private static final String TABLE_NAME = "random.random";
     private static final RandomWorkflowConfiguration CONFIGURATION = ImmutableRandomWorkflowConfiguration.builder()
@@ -69,7 +69,7 @@ public class RandomWorkflowsTest {
 
     private Workflow workflow;
 
-    @Before
+    @BeforeEach
     public void before() {
         this.workflow = RandomWorkflows.create(
                 memoryStore,

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellReadNoTouchWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellReadNoTouchWorkflowsTest.java
@@ -40,7 +40,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SingleBusyCellReadNoTouchWorkflowsTest {
     private static final String TABLE_NAME = "busy.readnotouch.cell";

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleBusyCellWorkflowsTest.java
@@ -38,7 +38,7 @@ import com.palantir.common.concurrent.PTExecutors;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SingleBusyCellWorkflowsTest {
     private static final String TABLE_NAME = "busy.cell";

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleRowTwoCellsWorkflowConfigurationTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleRowTwoCellsWorkflowConfigurationTest.java
@@ -24,7 +24,7 @@ import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.atlasdb.workload.store.IsolationLevel;
 import com.palantir.atlasdb.workload.transaction.WorkloadTestHelpers;
 import com.palantir.conjure.java.serialization.ObjectMappers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SingleRowTwoCellsWorkflowConfigurationTest {
     private static final TableConfiguration TABLE_CONFIGURATION = ImmutableTableConfiguration.builder()

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleRowTwoCellsWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/SingleRowTwoCellsWorkflowsTest.java
@@ -37,7 +37,7 @@ import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransac
 import com.palantir.atlasdb.workload.util.AtlasDbUtils;
 import com.palantir.common.concurrent.PTExecutors;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SingleRowTwoCellsWorkflowsTest {
     private static final String TABLE_NAME = "my.coffee";

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflowsTest.java
@@ -49,7 +49,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransientRowsWorkflowsTest {
     private static final int ITERATION_COUNT = 5;

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/WriteOnceDeleteOnceWorkflowTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/WriteOnceDeleteOnceWorkflowTest.java
@@ -43,7 +43,7 @@ import com.palantir.atlasdb.workload.util.AtlasDbUtils;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.IntFunction;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WriteOnceDeleteOnceWorkflowTest {
     private static final String TABLE_NAME = "my.latte";

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/bank/BankBalanceUtilsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/bank/BankBalanceUtilsTest.java
@@ -24,12 +24,12 @@ import java.security.SecureRandom;
 import java.util.Map;
 import java.util.Optional;
 import one.util.streamex.EntryStream;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public final class BankBalanceUtilsTest {
 
     private static final Map<Integer, Optional<Integer>> VALID_BALANCES = Map.of(0, Optional.of(1), 1, Optional.of(1));

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/bank/BankBalanceWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/bank/BankBalanceWorkflowsTest.java
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import one.util.streamex.EntryStream;
 import one.util.streamex.IntStreamEx;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class BankBalanceWorkflowsTest {
     private static final String TABLE_NAME = "bank.bank";

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/ring/RingGraphTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/ring/RingGraphTest.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.palantir.logsafe.SafeArg;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class RingGraphTest {
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/ring/RingWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/ring/RingWorkflowsTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RingWorkflowsTest {
 


### PR DESCRIPTION
Migrate these packages to JUnit5:

- atlasdb-jepsen-tests
- atlasdb-perf
- atlasdb-processors
- atlasdb-processors-tests
- atlasdb-remoting-api
- atlasdb-service
- atlasdb-workload-server
- atlasdb-workload-server-antihesis
- atlasdb-workload-server-api
- atlasdb-workload-server-distribution

https://github.com/palantir/atlasdb/issues/6796