### PR TITLE
Boy/first iteration wrap up

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     testImplementation 'com.palantir.safe-logging:safe-logging'
     testImplementation 'org.apache.commons:commons-lang3'
     testImplementation 'org.apache.thrift:libthrift'
+    testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.awaitility:awaitility'
     testImplementation 'org.slf4j:slf4j-api'
     testImplementation 'org.apache.commons:commons-pool2'

--- a/atlasdb-dbkvs-hikari/build.gradle
+++ b/atlasdb-dbkvs-hikari/build.gradle
@@ -19,6 +19,7 @@ dependencies {
   runtimeOnly 'com.oracle.database.jdbc:ojdbc11'
   runtimeOnly 'org.postgresql:postgresql'
 
+  testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'com.google.guava:guava'
   testImplementation 'com.palantir.safe-logging:preconditions'

--- a/atlasdb-service/build.gradle
+++ b/atlasdb-service/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation 'com.google.guava:guava'
+    testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation project(':atlasdb-api')

--- a/atlasdb-workload-server-distribution/build.gradle
+++ b/atlasdb-workload-server-distribution/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     compileOnly 'org.immutables:value::annotations'
     annotationProcessor 'org.immutables:value'
 
+    testImplementation 'org.assertj:assertj-core'
     testImplementation 'io.dropwizard:dropwizard-testing'
     testImplementation 'junit:junit'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine', {

--- a/commons-executors/build.gradle
+++ b/commons-executors/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     testImplementation 'com.palantir.tritium:tritium-registry'
     testImplementation 'io.dropwizard.metrics:metrics-core'
     testImplementation 'com.google.guava:guava'
+    testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
     testCompileOnly 'org.immutables:value::annotations'

--- a/examples/profile-client/build.gradle
+++ b/examples/profile-client/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   testImplementation 'com.google.guava:guava'
   testImplementation 'com.palantir.tritium:tritium-registry'
   testImplementation 'io.dropwizard.metrics:metrics-core'
+  testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testImplementation project(':atlasdb-api')
   testImplementation project(':atlasdb-commons')

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -5,7 +5,6 @@ apply plugin: 'checkstyle'
 apply plugin: 'com.github.hierynomus.license'
 apply plugin: 'com.palantir.external-publish-jar'
 
-
 version = rootProject.version
 group = rootProject.group
 
@@ -30,9 +29,6 @@ dependencies {
     implementation 'com.google.code.findbugs:findbugs-annotations'
     implementation 'com.palantir.safe-logging:logger'
     implementation 'com.palantir.safe-logging:safe-logging'
-
-    testImplementation 'junit:junit'
-    testImplementation 'org.assertj:assertj-core'
 }
 
 checkUnusedDependencies {

--- a/timestamp-impl/build.gradle
+++ b/timestamp-impl/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   testImplementation('org.jmock:jmock') {
     exclude group: 'org.hamcrest'
   }
+  testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'
 }


### PR DESCRIPTION
All packages have been completed for the first iteration. Before starting the second iteration, let's remove all `testImplementations` from `shared.gradle` and place them into the packages they are actually being used.

See the [issue](https://github.com/palantir/atlasdb/issues/6796) for more context.