### PR TITLE
Boy/parametrized junit5

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -104,11 +104,6 @@ dependencies {
   compileOnly 'org.immutables:value::annotations'
   compileOnly project(":atlasdb-processors")
   testCompileOnly 'org.immutables:value::annotations'
-
-  testImplementation 'junit:junit'
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
-    because 'allows JUnit 3 and JUnit 4 tests to run'
-  }
 }
 
 shadowJar {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/LightweightOppTokenTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/LightweightOppTokenTest.java
@@ -28,15 +28,16 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class LightweightOppTokenTest {
+    private static final String PARAMETERIZED_TEST_NAME = "{index}: input=\"{0}\"";
 
-    public static List<String> getParameters() {
+    public static List<String> inputs() {
         return TokensTest.generateTokens()
                 .flatMap(input -> Stream.of(input, input.toLowerCase(Locale.ROOT), input.toUpperCase(Locale.ROOT)))
                 .collect(Collectors.toList());
     }
 
-    @ParameterizedTest(name = "{index}: input=\"{0}\"")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("inputs")
     public void inputsAreValidBase16Strings(String input) {
         assertThat(input).matches("^[0-9a-fA-F]*$");
         assertThat(input.length() % 2)
@@ -45,8 +46,8 @@ public class LightweightOppTokenTest {
         assertThat(CassandraHex.hexToBytes(input)).hasSize(input.length() / 2);
     }
 
-    @ParameterizedTest(name = "{index}: input=\"{0}\"")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("inputs")
     public void createFromHexEncodedStringRegardlessOfCase(String input) {
         LightweightOppToken token = LightweightOppToken.fromHex(input);
         LightweightOppToken tokenFromLowerCase = LightweightOppToken.fromHex(input.toLowerCase(Locale.ROOT));
@@ -68,8 +69,8 @@ public class LightweightOppTokenTest {
                 .isEqualByComparingTo(tokenFromBytes);
     }
 
-    @ParameterizedTest(name = "{index}: input=\"{0}\"")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("inputs")
     public void fromHexCorrectlyDeserializesStrings(String input) throws Exception {
         LightweightOppToken token = LightweightOppToken.fromHex(input);
         Bytes expectedBytes = Bytes.from(org.apache.commons.codec.binary.Hex.decodeHex(input));
@@ -81,8 +82,8 @@ public class LightweightOppTokenTest {
         assertThat(token.toString()).isEqualToIgnoringCase(input);
     }
 
-    @ParameterizedTest(name = "{index}: input=\"{0}\"")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("inputs")
     public void tokenMatchesCassandraImplementation(String input) throws Exception {
         // Test compatibility with Cassandra hex conversions from:
         // https://github.com/palantir/cassandra/blob/palantir-cassandra-2.2.18/src/java/org/apache/cassandra/dht/ByteOrderedPartitioner.java#L74

--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -97,11 +97,6 @@ dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testImplementation 'org.mockito:mockito-junit-jupiter'
 
-  testImplementation 'junit:junit'
-  testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
-    because 'allows JUnit 3 and JUnit 4 tests to run'
-  }
-
   integrationInputImplementation project(':atlasdb-client')
   integrationInputImplementation 'com.fasterxml.jackson.core:jackson-annotations'
   integrationInputImplementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/IterablePartitionerTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/IterablePartitionerTest.java
@@ -27,19 +27,20 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 
 public class IterablePartitionerTest {
+    private static final String PARAMETERIZED_TEST_NAME = "tableName={0}";
 
     // approx put size is intentionally larger than the max (this triggers logging)
     private static final long LARGE_PUT_SIZE = 20L;
     private static final long MAXIMUM_PUT_SIZE = 10L;
     private static final long SMALL_PUT_SIZE = 6L;
 
-    public static List<String> getParameters() {
+    public static List<String> tableNames() {
         return List.of("test", "foo.bar", "[intentionally.invalid.table.name, foo.bar.baz]");
     }
 
     @SuppressWarnings("Slf4jConstantLogMessage")
-    @ParameterizedTest(name = "tableName={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("tableNames")
     public void testWithLogging(String tableName) {
         Logger mockLogger = Mockito.mock(Logger.class);
         Mockito.when(mockLogger.isWarnEnabled()).thenReturn(true);
@@ -57,8 +58,8 @@ public class IterablePartitionerTest {
         Mockito.verifyNoMoreInteractions(mockLogger);
     }
 
-    @ParameterizedTest(name = "tableName={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("tableNames")
     public void testWithoutLogging(String tableName) {
         Logger mockLogger = Mockito.mock(Logger.class);
         Mockito.when(mockLogger.isWarnEnabled()).thenReturn(false);
@@ -70,8 +71,8 @@ public class IterablePartitionerTest {
         Mockito.verifyNoMoreInteractions(mockLogger);
     }
 
-    @ParameterizedTest(name = "tableName={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("tableNames")
     public void smallPutsDoNotLog(String tableName) {
         Logger mockLogger = Mockito.mock(Logger.class);
         Mockito.when(mockLogger.isWarnEnabled()).thenReturn(true);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableNameTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableNameTest.java
@@ -29,9 +29,11 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class TableNameTest {
+
+    private static final String PARAMETERIZED_TEST_NAME = "namespace={0}, tableName={1} = internalTableName={2}";
     private static final Pattern PERIOD_REGEX = Pattern.compile("\\.");
 
-    public static List<Arguments> getParameters() {
+    public static List<Arguments> namespacesAndTableNamesAndInternalTableNames() {
         return List.of(
                 Arguments.of(Namespace.DEFAULT_NAMESPACE, "_hidden", "default___hidden"),
                 Arguments.of(Namespace.DEFAULT_NAMESPACE, "foo_bar", "default__foo_bar"),
@@ -47,8 +49,8 @@ public class TableNameTest {
                 Arguments.of(Namespace.create("ns"), "", "ns__"));
     }
 
-    @ParameterizedTest(name = "namespace={0}, tableName={1} = internalTableName={2}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("namespacesAndTableNamesAndInternalTableNames")
     public void roundTrip(Namespace namespace, String tableName, String internalTableName) {
         Assumptions.assumeTrue(Schemas.isTableNameValid(tableName), "Table name must be valid: '" + tableName + "'");
         checkValidTableName(tableName);

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableNameTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableNameTest.java
@@ -17,52 +17,40 @@
 package com.palantir.atlasdb.keyvalue.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assume.assumeTrue;
 
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.table.description.Schemas;
+import java.util.List;
 import java.util.regex.Pattern;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-/* TODO(boyoruk): Migrate to JUnit5 */
-@RunWith(Parameterized.class)
 public class TableNameTest {
     private static final Pattern PERIOD_REGEX = Pattern.compile("\\.");
 
-    private final Namespace namespace;
-    private final String tableName;
-    private final String internalTableName;
-
-    @Parameterized.Parameters(name = "namespace={0}, tableName={1} = internalTableName={2}")
-    public static Object[] data() {
-        return new Object[] {
-            new Object[] {Namespace.DEFAULT_NAMESPACE, "_hidden", "default___hidden"},
-            new Object[] {Namespace.DEFAULT_NAMESPACE, "foo_bar", "default__foo_bar"},
-            new Object[] {Namespace.DEFAULT_NAMESPACE, "test", "default__test"},
-            new Object[] {Namespace.DEFAULT_NAMESPACE, "", "default__"},
-            new Object[] {Namespace.EMPTY_NAMESPACE, "_hidden", "_hidden"},
-            new Object[] {Namespace.EMPTY_NAMESPACE, "test", "test"},
-            new Object[] {Namespace.EMPTY_NAMESPACE, "foo_bar", "foo_bar"},
-            new Object[] {Namespace.EMPTY_NAMESPACE, "", ""},
-            new Object[] {Namespace.create("ns"), "_hidden", "ns___hidden"},
-            new Object[] {Namespace.create("ns"), "foo_bar", "ns__foo_bar"},
-            new Object[] {Namespace.create("ns"), "test", "ns__test"},
-            new Object[] {Namespace.create("ns"), "", "ns__"},
-        };
+    public static List<Arguments> getParameters() {
+        return List.of(
+                Arguments.of(Namespace.DEFAULT_NAMESPACE, "_hidden", "default___hidden"),
+                Arguments.of(Namespace.DEFAULT_NAMESPACE, "foo_bar", "default__foo_bar"),
+                Arguments.of(Namespace.DEFAULT_NAMESPACE, "test", "default__test"),
+                Arguments.of(Namespace.DEFAULT_NAMESPACE, "", "default__"),
+                Arguments.of(Namespace.EMPTY_NAMESPACE, "_hidden", "_hidden"),
+                Arguments.of(Namespace.EMPTY_NAMESPACE, "test", "test"),
+                Arguments.of(Namespace.EMPTY_NAMESPACE, "foo_bar", "foo_bar"),
+                Arguments.of(Namespace.EMPTY_NAMESPACE, "", ""),
+                Arguments.of(Namespace.create("ns"), "_hidden", "ns___hidden"),
+                Arguments.of(Namespace.create("ns"), "foo_bar", "ns__foo_bar"),
+                Arguments.of(Namespace.create("ns"), "test", "ns__test"),
+                Arguments.of(Namespace.create("ns"), "", "ns__"));
     }
 
-    public TableNameTest(Namespace namespace, String tableName, String internalTableName) {
-        this.namespace = namespace;
-        this.tableName = tableName;
-        this.internalTableName = internalTableName;
-    }
-
-    @Test
-    public void roundTrip() {
-        assumeTrue("Table name must be valid: '" + tableName + "'", Schemas.isTableNameValid(tableName));
+    @ParameterizedTest(name = "namespace={0}, tableName={1} = internalTableName={2}")
+    @MethodSource("getParameters")
+    public void roundTrip(Namespace namespace, String tableName, String internalTableName) {
+        Assumptions.assumeTrue(Schemas.isTableNameValid(tableName), "Table name must be valid: '" + tableName + "'");
         checkValidTableName(tableName);
         TableReference tableRef = TableReference.create(namespace, tableName);
         assertThat(AbstractKeyValueService.internalTableName(tableRef))

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/TableMetadataPersistenceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/TableMetadataPersistenceTest.java
@@ -34,7 +34,7 @@ public class TableMetadataPersistenceTest {
     private static final int STREAM_STORE_BLOCK_SIZE_WITH_COMPRESS_IN_DB = 256;
     private static final int UNSET_BLOCK_SIZE = 0;
 
-    public static List<Arguments> getParameters() {
+    public static List<Arguments> tableDefinitions() {
         List<Arguments> params = new ArrayList<>();
 
         params.add(Arguments.of(getRangeScanWithoutCompression(), UNSET_BLOCK_SIZE));
@@ -51,7 +51,7 @@ public class TableMetadataPersistenceTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("tableDefinitions")
     public void testSerializeAndDeserialize(TableDefinition tableDefinition) {
         TableMetadata metadata = tableDefinition.toTableMetadata();
         byte[] metadataAsBytes = metadata.persistToBytes();
@@ -60,7 +60,7 @@ public class TableMetadataPersistenceTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("tableDefinitions")
     public void testMetadataHasExpectedCompressionBlockSize(
             TableDefinition tableDefinition, int compressionBlockSizeKB) {
         TableMetadata metadata = tableDefinition.toTableMetadata();

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/TableMetadataPersistenceTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/TableMetadataPersistenceTest.java
@@ -22,14 +22,11 @@ import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
 import com.palantir.atlasdb.schema.stream.StreamStoreDefinitionBuilder;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import java.util.ArrayList;
-import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-/* TODO(boyoruk): Migrate to JUnit5 */
-@RunWith(Parameterized.class)
 @SuppressWarnings("checkstyle:all") // too many warnings to fix
 public class TableMetadataPersistenceTest {
 
@@ -37,41 +34,35 @@ public class TableMetadataPersistenceTest {
     private static final int STREAM_STORE_BLOCK_SIZE_WITH_COMPRESS_IN_DB = 256;
     private static final int UNSET_BLOCK_SIZE = 0;
 
-    private final TableDefinition tableDefinition;
-    private final int compressionBlockSizeKB;
+    public static List<Arguments> getParameters() {
+        List<Arguments> params = new ArrayList<>();
 
-    @Parameters
-    public static Collection<Object[]> testCases() {
-        Collection<Object[]> params = new ArrayList<>();
-
-        params.add(new Object[] {getRangeScanWithoutCompression(), UNSET_BLOCK_SIZE});
-        params.add(new Object[] {getDefaultExplicit(), AtlasDbConstants.DEFAULT_TABLE_COMPRESSION_BLOCK_SIZE_KB});
-        params.add(new Object[] {
-            getDefaultRangeScanExplicit(), AtlasDbConstants.DEFAULT_TABLE_WITH_RANGESCANS_COMPRESSION_BLOCK_SIZE_KB
-        });
-        params.add(new Object[] {getCustomExplicitCompression(), CUSTOM_COMPRESSION_BLOCK_SIZE});
-        params.add(new Object[] {getCustomTable(), CUSTOM_COMPRESSION_BLOCK_SIZE});
-        params.add(new Object[] {getStreamStoreTableWithCompressInDb(), STREAM_STORE_BLOCK_SIZE_WITH_COMPRESS_IN_DB});
-        params.add(new Object[] {getStreamStoreTableDefault(), UNSET_BLOCK_SIZE});
+        params.add(Arguments.of(getRangeScanWithoutCompression(), UNSET_BLOCK_SIZE));
+        params.add(Arguments.of(getDefaultExplicit(), AtlasDbConstants.DEFAULT_TABLE_COMPRESSION_BLOCK_SIZE_KB));
+        params.add(Arguments.of(
+                getDefaultRangeScanExplicit(),
+                AtlasDbConstants.DEFAULT_TABLE_WITH_RANGESCANS_COMPRESSION_BLOCK_SIZE_KB));
+        params.add(Arguments.of(getCustomExplicitCompression(), CUSTOM_COMPRESSION_BLOCK_SIZE));
+        params.add(Arguments.of(getCustomTable(), CUSTOM_COMPRESSION_BLOCK_SIZE));
+        params.add(Arguments.of(getStreamStoreTableWithCompressInDb(), STREAM_STORE_BLOCK_SIZE_WITH_COMPRESS_IN_DB));
+        params.add(Arguments.of(getStreamStoreTableDefault(), UNSET_BLOCK_SIZE));
 
         return params;
     }
 
-    public TableMetadataPersistenceTest(TableDefinition tableDefinition, int compressionBlockSizeKB) {
-        this.tableDefinition = tableDefinition;
-        this.compressionBlockSizeKB = compressionBlockSizeKB;
-    }
-
-    @Test
-    public void testSerializeAndDeserialize() {
+    @ParameterizedTest
+    @MethodSource("getParameters")
+    public void testSerializeAndDeserialize(TableDefinition tableDefinition) {
         TableMetadata metadata = tableDefinition.toTableMetadata();
         byte[] metadataAsBytes = metadata.persistToBytes();
         TableMetadata metadataFromBytes = TableMetadata.BYTES_HYDRATOR.hydrateFromBytes(metadataAsBytes);
         assertThat(metadataFromBytes).isEqualTo(metadata);
     }
 
-    @Test
-    public void testMetadataHasExpectedCompressionBlockSize() {
+    @ParameterizedTest
+    @MethodSource("getParameters")
+    public void testMetadataHasExpectedCompressionBlockSize(
+            TableDefinition tableDefinition, int compressionBlockSizeKB) {
         TableMetadata metadata = tableDefinition.toTableMetadata();
         assertThat(metadata.getExplicitCompressionBlockSizeKB()).isEqualTo(compressionBlockSizeKB);
     }

--- a/atlasdb-commons/src/test/java/com/palantir/common/compression/StreamCompressionTests.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/compression/StreamCompressionTests.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class StreamCompressionTests {
+    private static final String PARAMETERIZED_TEST_NAME = "{index} {0} compression";
+
     private static final StreamCompression GZIP = StreamCompression.GZIP;
     private static final StreamCompression LZ4 = StreamCompression.LZ4;
     private static final StreamCompression NONE = StreamCompression.NONE;
@@ -40,7 +42,7 @@ public class StreamCompressionTests {
     private InputStream compressingStream;
     private InputStream decompressingStream;
 
-    public static List<StreamCompression> getParameters() {
+    public static List<StreamCompression> streamCompressionAlgorithms() {
         return Arrays.asList(StreamCompression.values());
     }
 
@@ -70,21 +72,21 @@ public class StreamCompressionTests {
                 .isEqualTo(data);
     }
 
-    @ParameterizedTest(name = "{index} {0} compression")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("streamCompressionAlgorithms")
     public void testEmptyStream(StreamCompression compression) throws IOException {
         initializeStreams(new byte[0], compression);
         assertStreamIsEmpty(decompressingStream);
     }
 
-    @ParameterizedTest(name = "{index} {0} compression")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("streamCompressionAlgorithms")
     public void testSingleCharacterStream(StreamCompression compression) throws IOException {
         testStream_incompressible(1, compression); // 1 byte input will always be incompressible
     }
 
-    @ParameterizedTest(name = "{index} {0} compression")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("streamCompressionAlgorithms")
     public void testSingleCharacterStream_singleByteRead(StreamCompression compression) throws IOException {
         byte[] uncompressedData = new byte[] {SINGLE_VALUE};
         initializeStreams(uncompressedData, compression);
@@ -94,32 +96,32 @@ public class StreamCompressionTests {
         assertStreamIsEmpty(decompressingStream);
     }
 
-    @ParameterizedTest(name = "{index} {0} compression")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("streamCompressionAlgorithms")
     public void testSingleBlock_compressible(StreamCompression compression) throws IOException {
         testStream_compressible(BLOCK_SIZE, compression);
     }
 
-    @ParameterizedTest(name = "{index} {0} compression")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("streamCompressionAlgorithms")
     public void testSingleBlock_incompressible(StreamCompression compression) throws IOException {
         testStream_incompressible(BLOCK_SIZE, compression);
     }
 
-    @ParameterizedTest(name = "{index} {0} compression")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("streamCompressionAlgorithms")
     public void testMultiBlock_compressible(StreamCompression compression) throws IOException {
         testStream_compressible(16 * BLOCK_SIZE, compression);
     }
 
-    @ParameterizedTest(name = "{index} {0} compression")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("streamCompressionAlgorithms")
     public void testMultiBlock_incompressible(StreamCompression compression) throws IOException {
         testStream_incompressible(16 * BLOCK_SIZE, compression);
     }
 
-    @ParameterizedTest(name = "{index} {0} compression")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("streamCompressionAlgorithms")
     public void testMultiBlock_singleByteReads(StreamCompression compression) throws IOException {
         byte[] uncompressedData = new byte[16 * BLOCK_SIZE];
         fillWithIncompressibleData(uncompressedData);
@@ -132,8 +134,8 @@ public class StreamCompressionTests {
         assertStreamIsEmpty(decompressingStream);
     }
 
-    @ParameterizedTest(name = "{index} {0} compression")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("streamCompressionAlgorithms")
     public void testMultiBlock_readPastEnd(StreamCompression compression) throws IOException {
         byte[] uncompressedData = new byte[16 * BLOCK_SIZE];
         fillWithCompressibleData(uncompressedData);

--- a/atlasdb-dbkvs/build.gradle
+++ b/atlasdb-dbkvs/build.gradle
@@ -50,9 +50,4 @@ dependencies {
   annotationProcessor 'com.google.auto.service:auto-service'
   annotationProcessor project(":atlasdb-processors")
   compileOnly project(":atlasdb-processors")
-
-  testImplementation 'junit:junit'
-  testRuntimeOnly 'org.junit.vintage:junit-vintage-engine', {
-    because 'allows JUnit 3 and JUnit 4 tests to run'
-  }
 }

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/AlterTableMetadataReferenceTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/AlterTableMetadataReferenceTest.java
@@ -30,7 +30,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AlterTableMetadataReferenceTest {
     private static final ObjectMapper OBJECT_MAPPER = AtlasDbConfigs.OBJECT_MAPPER;

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequestsTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequestsTest.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class RowsColumnRangeBatchRequestsTest {
 
-    public static List<Arguments> getParameters() {
+    private static final String PARAMETERIZED_TEST_NAME = "Partial first row: {0}, partial last row: {1}";
+
+    public static List<Arguments> hasPartialFirstRowsAndHasPartialLastRows() {
         return List.of(
                 Arguments.of(false, false),
                 Arguments.of(false, true),
@@ -37,20 +39,20 @@ public class RowsColumnRangeBatchRequestsTest {
                 Arguments.of(true, true));
     }
 
-    @ParameterizedTest(name = "Partial first row: {0}, partial last row: {1}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("hasPartialFirstRowsAndHasPartialLastRows")
     public void testPartitionSimple(boolean hasPartialFirstRow, boolean hasPartialLastRow) {
         testPartition(createRequest(1000, hasPartialFirstRow, hasPartialLastRow), 100);
     }
 
-    @ParameterizedTest(name = "Partial first row: {0}, partial last row: {1}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("hasPartialFirstRowsAndHasPartialLastRows")
     public void testSinglePartition(boolean hasPartialFirstRow, boolean hasPartialLastRow) {
         testPartition(createRequest(10, hasPartialFirstRow, hasPartialLastRow), 100);
     }
 
-    @ParameterizedTest(name = "Partial first row: {0}, partial last row: {1}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("hasPartialFirstRowsAndHasPartialLastRows")
     public void testPartitionSizeDoesNotDivideNumberOfRows(boolean hasPartialFirstRow, boolean hasPartialLastRow) {
         testPartition(createRequest(100, hasPartialFirstRow, hasPartialLastRow), 23);
     }

--- a/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequestsTest.java
+++ b/atlasdb-dbkvs/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/RowsColumnRangeBatchRequestsTest.java
@@ -17,53 +17,46 @@ package com.palantir.atlasdb.keyvalue.dbkvs.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Ints;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-/* TODO(boyoruk): Upgrade to JUnit5 */
-@RunWith(Parameterized.class)
 public class RowsColumnRangeBatchRequestsTest {
-    private final boolean hasPartialFirstRow;
-    private final boolean hasPartialLastRow;
 
-    public RowsColumnRangeBatchRequestsTest(boolean hasPartialFirstRow, boolean hasPartialLastRow) {
-        this.hasPartialFirstRow = hasPartialFirstRow;
-        this.hasPartialLastRow = hasPartialLastRow;
+    public static List<Arguments> getParameters() {
+        return List.of(
+                Arguments.of(false, false),
+                Arguments.of(false, true),
+                Arguments.of(true, false),
+                Arguments.of(true, true));
     }
 
-    @Parameters(name = "Partial first row: {0}, partial last row: {1}")
-    public static List<Object[]> getParameters() {
-        return ImmutableList.of(
-                new Object[] {false, false}, new Object[] {false, true}, new Object[] {true, false}, new Object[] {
-                    true, true
-                });
+    @ParameterizedTest(name = "Partial first row: {0}, partial last row: {1}")
+    @MethodSource("getParameters")
+    public void testPartitionSimple(boolean hasPartialFirstRow, boolean hasPartialLastRow) {
+        testPartition(createRequest(1000, hasPartialFirstRow, hasPartialLastRow), 100);
     }
 
-    @Test
-    public void testPartitionSimple() {
-        testPartition(createRequest(1000), 100);
+    @ParameterizedTest(name = "Partial first row: {0}, partial last row: {1}")
+    @MethodSource("getParameters")
+    public void testSinglePartition(boolean hasPartialFirstRow, boolean hasPartialLastRow) {
+        testPartition(createRequest(10, hasPartialFirstRow, hasPartialLastRow), 100);
     }
 
-    @Test
-    public void testSinglePartition() {
-        testPartition(createRequest(10), 100);
+    @ParameterizedTest(name = "Partial first row: {0}, partial last row: {1}")
+    @MethodSource("getParameters")
+    public void testPartitionSizeDoesNotDivideNumberOfRows(boolean hasPartialFirstRow, boolean hasPartialLastRow) {
+        testPartition(createRequest(100, hasPartialFirstRow, hasPartialLastRow), 23);
     }
 
-    @Test
-    public void testPartitionSizeDoesNotDivideNumberOfRows() {
-        testPartition(createRequest(100), 23);
-    }
-
-    private RowsColumnRangeBatchRequest createRequest(int numTotalRows) {
+    private RowsColumnRangeBatchRequest createRequest(
+            int numTotalRows, boolean hasPartialFirstRow, boolean hasPartialLastRow) {
         ColumnRangeSelection fullColumnRange = new ColumnRangeSelection(col(0), col(5));
         ImmutableRowsColumnRangeBatchRequest.Builder request =
                 ImmutableRowsColumnRangeBatchRequest.builder().columnRangeSelection(fullColumnRange);

--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -32,11 +32,6 @@ dependencies {
     compileOnly 'org.immutables:value::annotations'
     annotationProcessor project(":atlasdb-processors")
     compileOnly project(":atlasdb-processors")
-
-    testImplementation 'junit:junit'
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
-        because 'allows JUnit 3 and JUnit 4 tests to run'
-    }
 }
 
 recommendedProductDependencies {

--- a/lock-api-objects/src/test/java/com/palantir/util/IndexEncodingUtilsTest.java
+++ b/lock-api-objects/src/test/java/com/palantir/util/IndexEncodingUtilsTest.java
@@ -40,16 +40,13 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.immutables.value.Value;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-/* TODO(boyoruk): Migrate to JUnit5. */
-@RunWith(Parameterized.class)
 public class IndexEncodingUtilsTest {
 
-    @Parameterized.Parameters(name = "checksumType={0}")
-    public static Iterable<ChecksumType> data() {
+    public static List<ChecksumType> getParameters() {
         return Arrays.asList(ChecksumType.values());
     }
 
@@ -58,14 +55,9 @@ public class IndexEncodingUtilsTest {
     private static final Set<DeterministicHashableWrapper<String>> KEYS =
             ImmutableSet.of(wrap("key1"), wrap("key2"), wrap("anotherKey"));
 
-    private final ChecksumType checksumType;
-
-    public IndexEncodingUtilsTest(ChecksumType checksumType) {
-        this.checksumType = checksumType;
-    }
-
-    @Test
-    public void canLookupValidChecksumType() {
+    @ParameterizedTest(name = "checksumType={0}")
+    @MethodSource("getParameters")
+    public void canLookupValidChecksumType(ChecksumType checksumType) {
         assertThat(ChecksumType.valueOf(checksumType.getId())).isEqualTo(checksumType);
     }
 
@@ -77,42 +69,49 @@ public class IndexEncodingUtilsTest {
                 .hasExactlyArgs(SafeArg.of("checksumTypeId", -1));
     }
 
-    @Test
-    public void canEncodeSimpleData() {
-        assertThat(createIndexEncoding().indexToValue())
+    @ParameterizedTest(name = "checksumType={0}")
+    @MethodSource("getParameters")
+    public void canEncodeSimpleData(ChecksumType checksumType) {
+        assertThat(createIndexEncoding(checksumType).indexToValue())
                 .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(1, 1337L, 2, -10L, 0, 42L));
     }
 
-    @Test
-    public void canDecodeSimpleData() {
-        assertThat(IndexEncodingUtils.decode(createIndexEncoding())).containsExactlyInAnyOrderEntriesOf(VALUES);
+    @ParameterizedTest(name = "checksumType={0}")
+    @MethodSource("getParameters")
+    public void canDecodeSimpleData(ChecksumType checksumType) {
+        assertThat(IndexEncodingUtils.decode(createIndexEncoding(checksumType)))
+                .containsExactlyInAnyOrderEntriesOf(VALUES);
     }
 
-    @Test
-    public void canEncodeAndDecodeEmptyData() {
+    @ParameterizedTest(name = "checksumType={0}")
+    @MethodSource("getParameters")
+    public void canEncodeAndDecodeEmptyData(ChecksumType checksumType) {
         assertThat(IndexEncodingUtils.decode(
                         IndexEncodingUtils.encode(ImmutableSet.of(), ImmutableMap.of(), checksumType)))
                 .isEmpty();
     }
 
-    @Test
-    public void canEncodeWithCustomValueMapper() {
+    @ParameterizedTest(name = "checksumType={0}")
+    @MethodSource("getParameters")
+    public void canEncodeWithCustomValueMapper(ChecksumType checksumType) {
         Map<Integer, String> expectedValues = ImmutableMap.of(1, "1327", 2, "-20", 0, "32");
         assertThat(IndexEncodingUtils.encode(KEYS, VALUES, value -> Long.toString(value - 10), checksumType)
                         .indexToValue())
                 .containsExactlyInAnyOrderEntriesOf(expectedValues);
     }
 
-    @Test
-    public void canDecodeWithCustomValueMapper() {
+    @ParameterizedTest(name = "checksumType={0}")
+    @MethodSource("getParameters")
+    public void canDecodeWithCustomValueMapper(ChecksumType checksumType) {
         assertThat(IndexEncodingUtils.decode(
                         IndexEncodingUtils.encode(KEYS, VALUES, value -> Long.toString(value - 10), checksumType),
                         value -> Long.parseLong(value) + 10))
                 .containsExactlyInAnyOrderEntriesOf(VALUES);
     }
 
-    @Test
-    public void encodeFailsForUnknownKeysInValueMap() {
+    @ParameterizedTest(name = "checksumType={0}")
+    @MethodSource("getParameters")
+    public void encodeFailsForUnknownKeysInValueMap(ChecksumType checksumType) {
         assertThatLoggableExceptionThrownBy(
                         () -> IndexEncodingUtils.encode(KEYS, ImmutableMap.of(wrap("unknown-key"), 0L), checksumType))
                 .isExactlyInstanceOf(SafeIllegalArgumentException.class)
@@ -120,10 +119,11 @@ public class IndexEncodingUtilsTest {
                 .hasExactlyArgs(UnsafeArg.of("unknownKeys", ImmutableSet.of(wrap("unknown-key"))));
     }
 
-    @Test
-    public void decodeFailsForInvalidIndices() {
+    @ParameterizedTest(name = "checksumType={0}")
+    @MethodSource("getParameters")
+    public void decodeFailsForInvalidIndices(ChecksumType checksumType) {
         IndexEncodingResult<DeterministicHashableWrapper<String>, Long> encodedWithInvalidIndices =
-                ImmutableIndexEncodingResult.copyOf(createIndexEncoding())
+                ImmutableIndexEncodingResult.copyOf(createIndexEncoding(checksumType))
                         .withIndexToValue(ImmutableMap.of(KEYS.size(), 17L));
         assertThatLoggableExceptionThrownBy(() -> IndexEncodingUtils.decode(encodedWithInvalidIndices))
                 .isExactlyInstanceOf(SafeIllegalArgumentException.class)
@@ -131,9 +131,10 @@ public class IndexEncodingUtilsTest {
                 .hasExactlyArgs(SafeArg.of("index", KEYS.size()), SafeArg.of("keyListSize", KEYS.size()));
     }
 
-    @Test
-    public void integrityCheckFailsForDifferentKeyList() {
-        IndexEncodingResult<DeterministicHashableWrapper<String>, Long> encoded = createIndexEncoding();
+    @ParameterizedTest(name = "checksumType={0}")
+    @MethodSource("getParameters")
+    public void integrityCheckFailsForDifferentKeyList(ChecksumType checksumType) {
+        IndexEncodingResult<DeterministicHashableWrapper<String>, Long> encoded = createIndexEncoding(checksumType);
         List<DeterministicHashableWrapper<String>> modifiedKeyList = new ArrayList<>(KEYS);
         Collections.swap(modifiedKeyList, 0, 1);
         IndexEncodingResult<DeterministicHashableWrapper<String>, Long> encodedWithModifiedKeyList =
@@ -148,9 +149,10 @@ public class IndexEncodingUtilsTest {
                         SafeArg.of("expectedChecksum", encoded.keyListChecksum()));
     }
 
-    @Test
-    public void integrityCheckFailsForDifferentChecksum() {
-        IndexEncodingResult<DeterministicHashableWrapper<String>, Long> encoded = createIndexEncoding();
+    @ParameterizedTest(name = "checksumType={0}")
+    @MethodSource("getParameters")
+    public void integrityCheckFailsForDifferentChecksum(ChecksumType checksumType) {
+        IndexEncodingResult<DeterministicHashableWrapper<String>, Long> encoded = createIndexEncoding(checksumType);
         byte[] modifiedChecksum = encoded.keyListChecksum().value();
         modifiedChecksum[0]++;
         IndexEncodingResult<DeterministicHashableWrapper<String>, Long> encodedWithModifiedChecksum =
@@ -165,8 +167,9 @@ public class IndexEncodingUtilsTest {
                         SafeArg.of("expectedChecksum", encodedWithModifiedChecksum.keyListChecksum()));
     }
 
-    @Test
-    public void decodingEncodedDataYieldsOriginalForRandomData() {
+    @ParameterizedTest(name = "checksumType={0}")
+    @MethodSource("getParameters")
+    public void decodingEncodedDataYieldsOriginalForRandomData(ChecksumType checksumType) {
         int seed = (int) System.currentTimeMillis();
         Random rand = new Random(seed);
         Set<DeterministicHashableWrapper<UUID>> keys = Stream.generate(UUID::randomUUID)
@@ -182,7 +185,8 @@ public class IndexEncodingUtilsTest {
                 .containsExactlyInAnyOrderEntriesOf(data);
     }
 
-    private IndexEncodingResult<DeterministicHashableWrapper<String>, Long> createIndexEncoding() {
+    private IndexEncodingResult<DeterministicHashableWrapper<String>, Long> createIndexEncoding(
+            ChecksumType checksumType) {
         return IndexEncodingUtils.encode(KEYS, VALUES, checksumType);
     }
 

--- a/lock-api-objects/src/test/java/com/palantir/util/IndexEncodingUtilsTest.java
+++ b/lock-api-objects/src/test/java/com/palantir/util/IndexEncodingUtilsTest.java
@@ -45,8 +45,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class IndexEncodingUtilsTest {
+    private static final String PARAMETERIZED_TEST_NAME = "checksumType={0}";
 
-    public static List<ChecksumType> getParameters() {
+    public static List<ChecksumType> checksumTypes() {
         return Arrays.asList(ChecksumType.values());
     }
 
@@ -55,8 +56,8 @@ public class IndexEncodingUtilsTest {
     private static final Set<DeterministicHashableWrapper<String>> KEYS =
             ImmutableSet.of(wrap("key1"), wrap("key2"), wrap("anotherKey"));
 
-    @ParameterizedTest(name = "checksumType={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("checksumTypes")
     public void canLookupValidChecksumType(ChecksumType checksumType) {
         assertThat(ChecksumType.valueOf(checksumType.getId())).isEqualTo(checksumType);
     }
@@ -69,30 +70,30 @@ public class IndexEncodingUtilsTest {
                 .hasExactlyArgs(SafeArg.of("checksumTypeId", -1));
     }
 
-    @ParameterizedTest(name = "checksumType={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("checksumTypes")
     public void canEncodeSimpleData(ChecksumType checksumType) {
         assertThat(createIndexEncoding(checksumType).indexToValue())
                 .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(1, 1337L, 2, -10L, 0, 42L));
     }
 
-    @ParameterizedTest(name = "checksumType={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("checksumTypes")
     public void canDecodeSimpleData(ChecksumType checksumType) {
         assertThat(IndexEncodingUtils.decode(createIndexEncoding(checksumType)))
                 .containsExactlyInAnyOrderEntriesOf(VALUES);
     }
 
-    @ParameterizedTest(name = "checksumType={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("checksumTypes")
     public void canEncodeAndDecodeEmptyData(ChecksumType checksumType) {
         assertThat(IndexEncodingUtils.decode(
                         IndexEncodingUtils.encode(ImmutableSet.of(), ImmutableMap.of(), checksumType)))
                 .isEmpty();
     }
 
-    @ParameterizedTest(name = "checksumType={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("checksumTypes")
     public void canEncodeWithCustomValueMapper(ChecksumType checksumType) {
         Map<Integer, String> expectedValues = ImmutableMap.of(1, "1327", 2, "-20", 0, "32");
         assertThat(IndexEncodingUtils.encode(KEYS, VALUES, value -> Long.toString(value - 10), checksumType)
@@ -100,8 +101,8 @@ public class IndexEncodingUtilsTest {
                 .containsExactlyInAnyOrderEntriesOf(expectedValues);
     }
 
-    @ParameterizedTest(name = "checksumType={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("checksumTypes")
     public void canDecodeWithCustomValueMapper(ChecksumType checksumType) {
         assertThat(IndexEncodingUtils.decode(
                         IndexEncodingUtils.encode(KEYS, VALUES, value -> Long.toString(value - 10), checksumType),
@@ -109,8 +110,8 @@ public class IndexEncodingUtilsTest {
                 .containsExactlyInAnyOrderEntriesOf(VALUES);
     }
 
-    @ParameterizedTest(name = "checksumType={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("checksumTypes")
     public void encodeFailsForUnknownKeysInValueMap(ChecksumType checksumType) {
         assertThatLoggableExceptionThrownBy(
                         () -> IndexEncodingUtils.encode(KEYS, ImmutableMap.of(wrap("unknown-key"), 0L), checksumType))
@@ -119,8 +120,8 @@ public class IndexEncodingUtilsTest {
                 .hasExactlyArgs(UnsafeArg.of("unknownKeys", ImmutableSet.of(wrap("unknown-key"))));
     }
 
-    @ParameterizedTest(name = "checksumType={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("checksumTypes")
     public void decodeFailsForInvalidIndices(ChecksumType checksumType) {
         IndexEncodingResult<DeterministicHashableWrapper<String>, Long> encodedWithInvalidIndices =
                 ImmutableIndexEncodingResult.copyOf(createIndexEncoding(checksumType))
@@ -131,8 +132,8 @@ public class IndexEncodingUtilsTest {
                 .hasExactlyArgs(SafeArg.of("index", KEYS.size()), SafeArg.of("keyListSize", KEYS.size()));
     }
 
-    @ParameterizedTest(name = "checksumType={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("checksumTypes")
     public void integrityCheckFailsForDifferentKeyList(ChecksumType checksumType) {
         IndexEncodingResult<DeterministicHashableWrapper<String>, Long> encoded = createIndexEncoding(checksumType);
         List<DeterministicHashableWrapper<String>> modifiedKeyList = new ArrayList<>(KEYS);
@@ -149,8 +150,8 @@ public class IndexEncodingUtilsTest {
                         SafeArg.of("expectedChecksum", encoded.keyListChecksum()));
     }
 
-    @ParameterizedTest(name = "checksumType={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("checksumTypes")
     public void integrityCheckFailsForDifferentChecksum(ChecksumType checksumType) {
         IndexEncodingResult<DeterministicHashableWrapper<String>, Long> encoded = createIndexEncoding(checksumType);
         byte[] modifiedChecksum = encoded.keyListChecksum().value();
@@ -167,8 +168,8 @@ public class IndexEncodingUtilsTest {
                         SafeArg.of("expectedChecksum", encodedWithModifiedChecksum.keyListChecksum()));
     }
 
-    @ParameterizedTest(name = "checksumType={0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("checksumTypes")
     public void decodingEncodedDataYieldsOriginalForRandomData(ChecksumType checksumType) {
         int seed = (int) System.currentTimeMillis();
         Random rand = new Random(seed);

--- a/timelock-impl/build.gradle
+++ b/timelock-impl/build.gradle
@@ -104,11 +104,6 @@ dependencies {
 
     testAnnotationProcessor 'org.immutables:value'
     testCompileOnly 'org.immutables:value::annotations'
-
-    testImplementation 'junit:junit'
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine") {
-        because 'allows JUnit 3 and JUnit 4 tests to run'
-    }
 }
 
 license {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class PaxosStateLogMigrationIntegrationTest {
+    private static final String PARAMETERIZED_TEST_NAME = "Async migration completed {0}";
 
     private static final Client CLIENT = Client.of("test");
     private static final PaxosUseCase useCase = PaxosUseCase.LEADER_FOR_ALL_CLIENTS;
@@ -74,7 +75,7 @@ public class PaxosStateLogMigrationIntegrationTest {
         fileBasedLearnerLog = createFileSystemLearnerLog(CLIENT);
     }
 
-    @ParameterizedTest(name = "Async migration completed {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void canMigrateWithEmptyLegacy(boolean asyncMigrationCompleted) {
         LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate(asyncMigrationCompleted);
@@ -89,7 +90,7 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isEqualTo(0L);
     }
 
-    @ParameterizedTest(name = "Async migration completed {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void learnerMigratesLogStateFromLatestIncludingBuffer(boolean asyncMigrationCompleted) throws IOException {
         fileBasedLearnerLog.writeRound(ROUND_BEFORE_CUTOFF, valueForRound(ROUND_BEFORE_CUTOFF));
@@ -114,7 +115,7 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isGreaterThanOrEqualTo(1L);
     }
 
-    @ParameterizedTest(name = "Async migration completed {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void legacyLogIsTheSourceOfTruthForValuesBelowCutoff(boolean asyncMigrationCompleted) throws IOException {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
@@ -138,7 +139,7 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isGreaterThanOrEqualTo(1L);
     }
 
-    @ParameterizedTest(name = "Async migration completed {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void currentLogIsTheSourceOfTruthForValuesAboveCutoff(boolean asyncMigrationCompleted) throws IOException {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
@@ -163,7 +164,7 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isGreaterThanOrEqualTo(1L);
     }
 
-    @ParameterizedTest(name = "Async migration completed {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void learningValuesBeforeCutoffPersistsToLegacyLog(boolean asyncMigrationCompleted) throws IOException {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
@@ -184,7 +185,7 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isEqualTo(0L);
     }
 
-    @ParameterizedTest(name = "Async migration completed {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void noCrossClientPollution(boolean asyncMigrationCompleted) {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
@@ -206,7 +207,7 @@ public class PaxosStateLogMigrationIntegrationTest {
         assertValueLearned(otherRound, otherLearner);
     }
 
-    @ParameterizedTest(name = "Async migration completed {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void migrationCutoffForAcceptorBasedOnLearnerWhenEntriesPresent(boolean asyncMigrationCompleted)
             throws IOException {
@@ -227,7 +228,7 @@ public class PaxosStateLogMigrationIntegrationTest {
         assertStatePresent(newRound, sqliteLog);
     }
 
-    @ParameterizedTest(name = "Async migration completed {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void migrationCutoffForAcceptorIncludesAtLeastOneEntry(boolean asyncMigrationCompleted) throws IOException {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
@@ -242,7 +243,7 @@ public class PaxosStateLogMigrationIntegrationTest {
         assertStatePresent(ROUND_BEFORE_CUTOFF, sqliteLog);
     }
 
-    @ParameterizedTest(name = "Async migration completed {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void failWhenOldLogWritesAtGreaterSequenceAfterMigrationAlreadyRan(boolean asyncMigrationCompleted) {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
@@ -259,7 +260,7 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isInstanceOf(IllegalStateException.class);
     }
 
-    @ParameterizedTest(name = "Async migration completed {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void learnerMigratesLogStateWhenValidationDisabledAndTruncates(boolean asyncMigrationCompleted)
             throws IOException {
@@ -290,7 +291,7 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isEqualTo(0L);
     }
 
-    @ParameterizedTest(name = "Async migration completed {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void doNotFailWhenOldLogWritesAtGreaterSequenceAfterMigrationAlreadyRanAndTruncate(
             boolean asyncMigrationCompleted) throws IOException {

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosStateLogMigrationIntegrationTest.java
@@ -35,27 +35,19 @@ import com.palantir.paxos.SqliteConnections;
 import com.palantir.paxos.SqlitePaxosStateLog;
 import com.palantir.paxos.Versionable;
 import com.palantir.sls.versions.OrderableSlsVersion;
+import com.palantir.test.utils.SubdirectoryCreator;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.UUID;
 import javax.sql.DataSource;
 import org.jmock.lib.concurrent.DeterministicScheduler;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-/* TODO(boyoruk): Migrate this to JUnit5 */
-@RunWith(Parameterized.class)
 public class PaxosStateLogMigrationIntegrationTest {
-    @Parameterized.Parameters(name = "Async migration completed {0}")
-    public static Collection<Object[]> succeeded() {
-        return Arrays.asList(new Object[][] {{true}, {false}});
-    }
 
     private static final Client CLIENT = Client.of("test");
     private static final PaxosUseCase useCase = PaxosUseCase.LEADER_FOR_ALL_CLIENTS;
@@ -63,31 +55,29 @@ public class PaxosStateLogMigrationIntegrationTest {
     private static final long CUTOFF = LATEST_ROUND_BEFORE_MIGRATING - PaxosStateLogMigrator.SAFETY_BUFFER;
     private static final long ROUND_BEFORE_CUTOFF = CUTOFF - 1;
 
-    private final boolean asyncMigrationCompleted;
     private final DeterministicScheduler executor = new DeterministicScheduler();
 
     private Path legacyDirectory;
     private DataSource sqlite;
     private PaxosStateLog<PaxosValue> fileBasedLearnerLog;
 
-    @Rule
-    public final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    @TempDir
+    public File TEMPORARY_FOLDER;
 
-    @Before
-    public void setUp() throws IOException {
-        legacyDirectory = TEMPORARY_FOLDER.newFolder("legacy").toPath();
+    @BeforeEach
+    public void setUp() {
+        legacyDirectory = SubdirectoryCreator.createAndGetSubdirectory(TEMPORARY_FOLDER, "legacy")
+                .toPath();
         sqlite = SqliteConnections.getDefaultConfiguredPooledDataSource(
-                TEMPORARY_FOLDER.newFolder("sqlite").toPath());
+                SubdirectoryCreator.createAndGetSubdirectory(TEMPORARY_FOLDER, "sqlite")
+                        .toPath());
         fileBasedLearnerLog = createFileSystemLearnerLog(CLIENT);
     }
 
-    public PaxosStateLogMigrationIntegrationTest(boolean asyncMigrationCompleted) {
-        this.asyncMigrationCompleted = asyncMigrationCompleted;
-    }
-
-    @Test
-    public void canMigrateWithEmptyLegacy() {
-        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate();
+    @ParameterizedTest(name = "Async migration completed {0}")
+    @ValueSource(booleans = {true, false})
+    public void canMigrateWithEmptyLegacy(boolean asyncMigrationCompleted) {
+        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate(asyncMigrationCompleted);
 
         PaxosLearner learner = paxosComponents.learner(CLIENT);
         assertThat(learner.getLearnedValue(0L)).isEmpty();
@@ -99,13 +89,14 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isEqualTo(0L);
     }
 
-    @Test
-    public void learnerMigratesLogStateFromLatestIncludingBuffer() throws IOException {
+    @ParameterizedTest(name = "Async migration completed {0}")
+    @ValueSource(booleans = {true, false})
+    public void learnerMigratesLogStateFromLatestIncludingBuffer(boolean asyncMigrationCompleted) throws IOException {
         fileBasedLearnerLog.writeRound(ROUND_BEFORE_CUTOFF, valueForRound(ROUND_BEFORE_CUTOFF));
         fileBasedLearnerLog.writeRound(CUTOFF, valueForRound(CUTOFF));
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
 
-        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate();
+        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate(asyncMigrationCompleted);
         PaxosLearner learner = paxosComponents.learner(CLIENT);
 
         PaxosStateLog<PaxosValue> sqliteLog = createSqliteLog(paxosComponents.getLearnerParameters(CLIENT));
@@ -123,11 +114,12 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isGreaterThanOrEqualTo(1L);
     }
 
-    @Test
-    public void legacyLogIsTheSourceOfTruthForValuesBelowCutoff() throws IOException {
+    @ParameterizedTest(name = "Async migration completed {0}")
+    @ValueSource(booleans = {true, false})
+    public void legacyLogIsTheSourceOfTruthForValuesBelowCutoff(boolean asyncMigrationCompleted) throws IOException {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
 
-        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate();
+        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate(asyncMigrationCompleted);
         PaxosLearner learner = paxosComponents.learner(CLIENT);
 
         fileBasedLearnerLog.writeRound(CUTOFF, valueForRound(CUTOFF));
@@ -146,11 +138,12 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isGreaterThanOrEqualTo(1L);
     }
 
-    @Test
-    public void currentLogIsTheSourceOfTruthForValuesAboveCutoff() throws IOException {
+    @ParameterizedTest(name = "Async migration completed {0}")
+    @ValueSource(booleans = {true, false})
+    public void currentLogIsTheSourceOfTruthForValuesAboveCutoff(boolean asyncMigrationCompleted) throws IOException {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
 
-        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate();
+        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate(asyncMigrationCompleted);
         paxosComponents.learner(CLIENT);
 
         PaxosStateLog<PaxosValue> sqliteLog = createSqliteLog(paxosComponents.getLearnerParameters(CLIENT));
@@ -170,11 +163,12 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isGreaterThanOrEqualTo(1L);
     }
 
-    @Test
-    public void learningValuesBeforeCutoffPersistsToLegacyLog() throws IOException {
+    @ParameterizedTest(name = "Async migration completed {0}")
+    @ValueSource(booleans = {true, false})
+    public void learningValuesBeforeCutoffPersistsToLegacyLog(boolean asyncMigrationCompleted) throws IOException {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
 
-        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate();
+        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate(asyncMigrationCompleted);
         PaxosLearner learner = paxosComponents.learner(CLIENT);
 
         learner.learn(ROUND_BEFORE_CUTOFF, valueForRound(ROUND_BEFORE_CUTOFF));
@@ -190,8 +184,9 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isEqualTo(0L);
     }
 
-    @Test
-    public void noCrossClientPollution() {
+    @ParameterizedTest(name = "Async migration completed {0}")
+    @ValueSource(booleans = {true, false})
+    public void noCrossClientPollution(boolean asyncMigrationCompleted) {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
 
         int otherRound = 200;
@@ -199,7 +194,7 @@ public class PaxosStateLogMigrationIntegrationTest {
         PaxosStateLog<PaxosValue> otherFileBasedLog = createFileSystemLearnerLog(otherClient);
         otherFileBasedLog.writeRound(otherRound, valueForRound(otherRound));
 
-        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate();
+        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate(asyncMigrationCompleted);
         PaxosLearner learner = paxosComponents.learner(CLIENT);
 
         PaxosLearner otherLearner = paxosComponents.learner(otherClient);
@@ -211,8 +206,10 @@ public class PaxosStateLogMigrationIntegrationTest {
         assertValueLearned(otherRound, otherLearner);
     }
 
-    @Test
-    public void migrationCutoffForAcceptorBasedOnLearnerWhenEntriesPresent() throws IOException {
+    @ParameterizedTest(name = "Async migration completed {0}")
+    @ValueSource(booleans = {true, false})
+    public void migrationCutoffForAcceptorBasedOnLearnerWhenEntriesPresent(boolean asyncMigrationCompleted)
+            throws IOException {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
 
         long newRound = LATEST_ROUND_BEFORE_MIGRATING + 300;
@@ -221,7 +218,7 @@ public class PaxosStateLogMigrationIntegrationTest {
         fileBasedAcceptorLog.writeRound(CUTOFF, stateForRound(CUTOFF));
         fileBasedAcceptorLog.writeRound(newRound, stateForRound(newRound));
 
-        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate();
+        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate(asyncMigrationCompleted);
         paxosComponents.acceptor(CLIENT);
 
         PaxosStateLog<PaxosAcceptorState> sqliteLog = createSqliteLog(paxosComponents.getAcceptorParameters(CLIENT));
@@ -230,43 +227,47 @@ public class PaxosStateLogMigrationIntegrationTest {
         assertStatePresent(newRound, sqliteLog);
     }
 
-    @Test
-    public void migrationCutoffForAcceptorIncludesAtLeastOneEntry() throws IOException {
+    @ParameterizedTest(name = "Async migration completed {0}")
+    @ValueSource(booleans = {true, false})
+    public void migrationCutoffForAcceptorIncludesAtLeastOneEntry(boolean asyncMigrationCompleted) throws IOException {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
 
         PaxosStateLog<PaxosAcceptorState> fileBasedAcceptorLog = createFileSystemAcceptorLog(CLIENT);
         fileBasedAcceptorLog.writeRound(ROUND_BEFORE_CUTOFF, stateForRound(ROUND_BEFORE_CUTOFF));
 
-        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate();
+        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate(asyncMigrationCompleted);
         paxosComponents.acceptor(CLIENT);
 
         PaxosStateLog<PaxosAcceptorState> sqliteLog = createSqliteLog(paxosComponents.getAcceptorParameters(CLIENT));
         assertStatePresent(ROUND_BEFORE_CUTOFF, sqliteLog);
     }
 
-    @Test
-    public void failWhenOldLogWritesAtGreaterSequenceAfterMigrationAlreadyRan() {
+    @ParameterizedTest(name = "Async migration completed {0}")
+    @ValueSource(booleans = {true, false})
+    public void failWhenOldLogWritesAtGreaterSequenceAfterMigrationAlreadyRan(boolean asyncMigrationCompleted) {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
 
-        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate();
+        LocalPaxosComponents paxosComponents = createPaxosComponentsAndMaybeMigrate(asyncMigrationCompleted);
         paxosComponents.learner(CLIENT);
 
         long newRound = LATEST_ROUND_BEFORE_MIGRATING + 3;
         fileBasedLearnerLog.writeRound(newRound, valueForRound(newRound));
 
-        LocalPaxosComponents brokenComponents = createPaxosComponentsAndMaybeMigrate();
+        LocalPaxosComponents brokenComponents = createPaxosComponentsAndMaybeMigrate(asyncMigrationCompleted);
         assertThatThrownBy(() -> brokenComponents.learner(CLIENT))
                 .as("Written to file based log at greater sequence after migration already ran")
                 .isInstanceOf(IllegalStateException.class);
     }
 
-    @Test
-    public void learnerMigratesLogStateWhenValidationDisabledAndTruncates() throws IOException {
+    @ParameterizedTest(name = "Async migration completed {0}")
+    @ValueSource(booleans = {true, false})
+    public void learnerMigratesLogStateWhenValidationDisabledAndTruncates(boolean asyncMigrationCompleted)
+            throws IOException {
         fileBasedLearnerLog.writeRound(ROUND_BEFORE_CUTOFF, valueForRound(ROUND_BEFORE_CUTOFF));
         fileBasedLearnerLog.writeRound(CUTOFF, valueForRound(CUTOFF));
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
 
-        LocalPaxosComponents paxosComponents = createPaxosComponentsSkipValidationAndTruncate();
+        LocalPaxosComponents paxosComponents = createPaxosComponentsSkipValidationAndTruncate(asyncMigrationCompleted);
         PaxosLearner learner = paxosComponents.learner(CLIENT);
 
         PaxosStateLog<PaxosValue> sqliteLog = createSqliteLog(paxosComponents.getLearnerParameters(CLIENT));
@@ -289,17 +290,19 @@ public class PaxosStateLogMigrationIntegrationTest {
                 .isEqualTo(0L);
     }
 
-    @Test
-    public void doNotFailWhenOldLogWritesAtGreaterSequenceAfterMigrationAlreadyRanAndTruncate() throws IOException {
+    @ParameterizedTest(name = "Async migration completed {0}")
+    @ValueSource(booleans = {true, false})
+    public void doNotFailWhenOldLogWritesAtGreaterSequenceAfterMigrationAlreadyRanAndTruncate(
+            boolean asyncMigrationCompleted) throws IOException {
         fileBasedLearnerLog.writeRound(LATEST_ROUND_BEFORE_MIGRATING, valueForRound(LATEST_ROUND_BEFORE_MIGRATING));
 
-        LocalPaxosComponents paxosComponents = createPaxosComponentsSkipValidationAndTruncate();
+        LocalPaxosComponents paxosComponents = createPaxosComponentsSkipValidationAndTruncate(asyncMigrationCompleted);
         paxosComponents.learner(CLIENT);
 
         long newRound = LATEST_ROUND_BEFORE_MIGRATING + 3;
         fileBasedLearnerLog.writeRound(newRound, valueForRound(newRound));
 
-        LocalPaxosComponents newComponents = createPaxosComponentsSkipValidationAndTruncate();
+        LocalPaxosComponents newComponents = createPaxosComponentsSkipValidationAndTruncate(asyncMigrationCompleted);
         PaxosLearner learner = newComponents.learner(CLIENT);
 
         assertThat(fileBasedLearnerLog.getGreatestLogEntry()).isEqualTo(PaxosAcceptor.NO_LOG_ENTRY);
@@ -335,11 +338,11 @@ public class PaxosStateLogMigrationIntegrationTest {
         assertThat(log.readRound(round)).isNull();
     }
 
-    private LocalPaxosComponents createPaxosComponentsAndMaybeMigrate() {
+    private LocalPaxosComponents createPaxosComponentsAndMaybeMigrate(boolean asyncMigrationCompleted) {
         return createPaxosComponents(false, asyncMigrationCompleted);
     }
 
-    private LocalPaxosComponents createPaxosComponentsSkipValidationAndTruncate() {
+    private LocalPaxosComponents createPaxosComponentsSkipValidationAndTruncate(boolean asyncMigrationCompleted) {
         return createPaxosComponents(true, asyncMigrationCompleted);
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -84,7 +84,7 @@ public class PaxosTimestampBoundStoreTest {
     private final List<AtomicBoolean> failureToggles = new ArrayList<>();
     private final Closer closer = Closer.create();
 
-    public static List<Boolean> getParameters() {
+    public static List<Boolean> useBatches() {
         return List.of(UNBATCHED, BATCHED);
     }
 
@@ -107,14 +107,14 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void timestampsBeginFromZero(boolean useBatch) {
         setup(useBatch);
         assertThat(store.getUpperLimit()).isEqualTo(0L);
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void canStoreUpperLimit(boolean useBatch) {
         setup(useBatch);
         store.storeUpperLimit(TIMESTAMP_1);
@@ -122,7 +122,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void throwsIfStoringLimitLessThanUpperLimit(boolean useBatch) {
         setup(useBatch);
         store.storeUpperLimit(TIMESTAMP_2);
@@ -131,7 +131,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void canOperateWithMinorityOfNodesDown(boolean useBatch) {
         setup(useBatch);
         failureToggles.get(1).set(true);
@@ -141,7 +141,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void throwsIfCannotObtainQuorum(boolean useBatch) {
         setup(useBatch);
         failureToggles.get(1).set(true);
@@ -151,7 +151,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void retriesProposeUntilSuccessful(boolean useBatch) throws Exception {
         setup(useBatch);
         PaxosProposer wrapper = spy(new OnceFailingPaxosProposer(createPaxosProposer(0)));
@@ -162,7 +162,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void throwsNotCurrentLeaderExceptionIfBoundUnexpectedlyChangedUnderUs(boolean useBatch) {
         setup(useBatch);
         PaxosTimestampBoundStore additionalStore = createPaxosTimestampBoundStore(1);
@@ -171,7 +171,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void throwsSafeIllegalStateExceptionIfCalledAfterNotCurrentLeaderException(boolean useBatch) {
         setup(useBatch);
         PaxosTimestampBoundStore additionalStore = createPaxosTimestampBoundStore(1);
@@ -183,7 +183,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void canReadStateFromDistributedLogs(boolean useBatch) {
         setup(useBatch);
         PaxosTimestampBoundStore additionalStore = createPaxosTimestampBoundStore(1);
@@ -194,7 +194,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void canReadConsensusProposedByOtherNodes(boolean useBatch) {
         setup(useBatch);
         PaxosTimestampBoundStore additionalStore1 = createPaxosTimestampBoundStore(1);
@@ -211,7 +211,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void canGetAgreedInitialState(boolean useBatch) {
         setup(useBatch);
         PaxosTimestampBoundStore.SequenceAndBound sequenceAndBound = store.getAgreedState(0);
@@ -220,7 +220,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void canGetAgreedState(boolean useBatch) {
         setup(useBatch);
         store.storeUpperLimit(TIMESTAMP_1);
@@ -230,14 +230,14 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void canSafelyGetAgreedStateFromPrehistory(boolean useBatch) {
         setup(useBatch);
         assertThat(store.getAgreedState(Long.MIN_VALUE).getBound()).isEqualTo(0);
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void canGetAgreedStateAfterNodeDown(boolean useBatch) {
         setup(useBatch);
         int nodeId = 1;
@@ -250,14 +250,14 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void cannotGetAgreedStateFromTheFuture(boolean useBatch) {
         setup(useBatch);
         assertThatThrownBy(() -> store.getAgreedState(Long.MAX_VALUE)).isInstanceOf(NullPointerException.class);
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void canSafelyForceAgreedStateFromPrehistory(boolean useBatch) {
         setup(useBatch);
         assertThat(store.forceAgreedState(Long.MIN_VALUE, Long.MIN_VALUE).getBound())
@@ -265,7 +265,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void canForceAgreedState(boolean useBatch) {
         setup(useBatch);
         assertThat(store.forceAgreedState(1, FORTY_TWO)).isEqualTo(ONE_AND_FORTY_TWO);
@@ -273,7 +273,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void forceAgreedStateCanBeUsedToGainKnowledge(boolean useBatch) {
         setup(useBatch);
         assertThat(store.forceAgreedState(1, FORTY_TWO)).isEqualTo(ONE_AND_FORTY_TWO);
@@ -283,7 +283,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void forceAgreedStateReturnsFirstForcedValue(boolean useBatch) {
         setup(useBatch);
         assertThat(store.forceAgreedState(1, FORTY_TWO)).isEqualTo(ONE_AND_FORTY_TWO);
@@ -292,7 +292,7 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void forceAgreedStateOperatesAtSequenceNumberLevel(boolean useBatch) {
         setup(useBatch);
         long fortyThree = FORTY_TWO + 1;
@@ -303,14 +303,14 @@ public class PaxosTimestampBoundStoreTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void forceAgreedStateThrowsIfNoStateWasAgreedUpon(boolean useBatch) {
         setup(useBatch);
         assertThatThrownBy(() -> store.forceAgreedState(1, null)).isInstanceOf(NullPointerException.class);
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("useBatches")
     public void retriesForceAgreedStateUntilSuccessful(boolean useBatch) throws Exception {
         setup(useBatch);
         PaxosProposer wrapper = spy(new OnceFailingPaxosProposer(createPaxosProposer(0)));
@@ -356,52 +356,56 @@ public class PaxosTimestampBoundStoreTest {
         }
 
         if (useBatch) {
-            AutobatchingPaxosAcceptorNetworkClientFactory acceptorNetworkClientFactory =
-                    AutobatchingPaxosAcceptorNetworkClientFactory.create(
-                            batchPaxosAcceptors,
-                            KeyedStream.of(batchPaxosAcceptors.stream())
-                                    .map($ -> new CheckedRejectionExecutorService(executor))
-                                    .collectToMap(),
-                            QUORUM_SIZE);
-            acceptorClient = acceptorNetworkClientFactory.paxosAcceptorForClient(CLIENT);
-
-            List<AutobatchingPaxosLearnerNetworkClientFactory> learnerNetworkClientFactories =
-                    batchPaxosLearners.stream()
-                            .map(localLearner -> LocalAndRemotes.of(
-                                    localLearner,
-                                    batchPaxosLearners.stream()
-                                            .filter(remoteLearners -> remoteLearners != localLearner)
-                                            .collect(toList())))
-                            .map(localAndRemotes -> AutobatchingPaxosLearnerNetworkClientFactory.createForTests(
-                                    localAndRemotes, executor, QUORUM_SIZE))
-                            .collect(toList());
-
-            learnerClientsByNode = learnerNetworkClientFactories.stream()
-                    .map(factory -> factory.paxosLearnerForClient(CLIENT))
-                    .collect(toList());
-
-            closer.register(acceptorNetworkClientFactory);
-            learnerNetworkClientFactories.forEach(closer::register);
+            setupAcceptorClientAndLearnerClientsByNodeUsingBatch(batchPaxosAcceptors, batchPaxosLearners);
         } else {
-            acceptorClient = SingleLeaderAcceptorNetworkClient.createLegacy(
-                    acceptors,
-                    QUORUM_SIZE,
-                    Maps.toMap(acceptors, $ -> executor),
-                    PaxosConstants.CANCEL_REMAINING_CALLS);
-
-            learnerClientsByNode = learners.stream()
-                    .map(learner -> SingleLeaderLearnerNetworkClient.createLegacy(
-                            learner,
-                            learners.stream()
-                                    .filter(otherLearners -> otherLearners != learner)
-                                    .collect(toList()),
-                            QUORUM_SIZE,
-                            Maps.toMap(learners, $ -> executor),
-                            PaxosConstants.CANCEL_REMAINING_CALLS))
-                    .collect(toList());
+            setupAcceptorClientAndLearnerClientsByNodeWithoutUsingBatch(acceptors);
         }
-
         store = createPaxosTimestampBoundStore(0);
+    }
+
+    public void setupAcceptorClientAndLearnerClientsByNodeUsingBatch(
+            List<BatchPaxosAcceptor> batchPaxosAcceptors, List<BatchPaxosLearner> batchPaxosLearners) {
+        AutobatchingPaxosAcceptorNetworkClientFactory acceptorNetworkClientFactory =
+                AutobatchingPaxosAcceptorNetworkClientFactory.create(
+                        batchPaxosAcceptors,
+                        KeyedStream.of(batchPaxosAcceptors.stream())
+                                .map($ -> new CheckedRejectionExecutorService(executor))
+                                .collectToMap(),
+                        QUORUM_SIZE);
+        acceptorClient = acceptorNetworkClientFactory.paxosAcceptorForClient(CLIENT);
+
+        List<AutobatchingPaxosLearnerNetworkClientFactory> learnerNetworkClientFactories = batchPaxosLearners.stream()
+                .map(localLearner -> LocalAndRemotes.of(
+                        localLearner,
+                        batchPaxosLearners.stream()
+                                .filter(remoteLearners -> remoteLearners != localLearner)
+                                .collect(toList())))
+                .map(localAndRemotes -> AutobatchingPaxosLearnerNetworkClientFactory.createForTests(
+                        localAndRemotes, executor, QUORUM_SIZE))
+                .collect(toList());
+
+        learnerClientsByNode = learnerNetworkClientFactories.stream()
+                .map(factory -> factory.paxosLearnerForClient(CLIENT))
+                .collect(toList());
+
+        closer.register(acceptorNetworkClientFactory);
+        learnerNetworkClientFactories.forEach(closer::register);
+    }
+
+    public void setupAcceptorClientAndLearnerClientsByNodeWithoutUsingBatch(List<PaxosAcceptor> acceptors) {
+        acceptorClient = SingleLeaderAcceptorNetworkClient.createLegacy(
+                acceptors, QUORUM_SIZE, Maps.toMap(acceptors, $ -> executor), PaxosConstants.CANCEL_REMAINING_CALLS);
+
+        learnerClientsByNode = learners.stream()
+                .map(learner -> SingleLeaderLearnerNetworkClient.createLegacy(
+                        learner,
+                        learners.stream()
+                                .filter(otherLearners -> otherLearners != learner)
+                                .collect(toList()),
+                        QUORUM_SIZE,
+                        Maps.toMap(learners, $ -> executor),
+                        PaxosConstants.CANCEL_REMAINING_CALLS))
+                .collect(toList());
     }
 
     private PaxosTimestampBoundStore createPaxosTimestampBoundStore(int nodeIndex) {


### PR DESCRIPTION
In [this issue](https://github.com/palantir/atlasdb/issues/6796), we are upgrading our test classes from JUnit4 to JUnit5. 

In this pull request, we replace `@RunWith(Parameterized.class)` with `@ParameterizedTest` because the former is no longer supported in JUnit5. 

This PR is for every package except `atlasdb-shared-impl`

- There will be decrease in `StreamCompressionTest` count because there were unnecessary parameterised test cases. Decrease is -4 for test-suite-0

- There will be decrease in `CoalescingSupplierTest` count because there were unnecessary parameterised test cases. Decrease is -2 for test-suite-0