### PR TITLE
impl shared

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/ResilientCommitTimestampAtomicTableTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/ResilientCommitTimestampAtomicTableTest.java
@@ -65,6 +65,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class ResilientCommitTimestampAtomicTableTest {
+    private static final String PARAMETERIZED_TEST_NAME = "validating staging values: {0}";
 
     private final KeyValueService spiedKvs = spy(new InMemoryKeyValueService(true));
     private final UnreliablePueConsensusForgettingStore spiedStore = spy(new UnreliablePueConsensusForgettingStore(
@@ -76,7 +77,7 @@ public class ResilientCommitTimestampAtomicTableTest {
     private final TwoPhaseEncodingStrategy encodingStrategy =
             new TwoPhaseEncodingStrategy(BaseProgressEncodingStrategy.INSTANCE);
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void canPutAndGet(boolean validating) throws ExecutionException, InterruptedException {
         setup(validating);
@@ -87,14 +88,14 @@ public class ResilientCommitTimestampAtomicTableTest {
         verify(spiedStore).getMultiple(any());
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void emptyReturnsInProgress(boolean validating) throws ExecutionException, InterruptedException {
         setup(validating);
         assertThat(atomicTable.get(3L).get()).isEqualTo(TransactionStatus.inProgress());
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void canPutAndGetAbortedTransactions(boolean validating) throws ExecutionException, InterruptedException {
         setup(validating);
@@ -102,7 +103,7 @@ public class ResilientCommitTimestampAtomicTableTest {
         assertThat(atomicTable.get(1L).get()).isEqualTo(TransactionStatus.aborted());
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void cannotPueTwice(boolean validating) {
         setup(validating);
@@ -111,7 +112,7 @@ public class ResilientCommitTimestampAtomicTableTest {
                 .isInstanceOf(KeyAlreadyExistsException.class);
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void canPutAndGetMultiple(boolean validating) throws ExecutionException, InterruptedException {
         setup(validating);
@@ -132,7 +133,7 @@ public class ResilientCommitTimestampAtomicTableTest {
         assertThat(result.get(7L)).isEqualTo(TransactionStatus.committed(8L));
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void pueThatThrowsIsCorrectedOnGet(boolean validating) throws ExecutionException, InterruptedException {
         setup(validating);
@@ -145,7 +146,7 @@ public class ResilientCommitTimestampAtomicTableTest {
         verify(spiedStore, times(2)).put(anyMap());
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void getReturnsStagingValuesThatWereCommittedBySomeoneElse(boolean validating)
             throws ExecutionException, InterruptedException {
@@ -168,7 +169,7 @@ public class ResilientCommitTimestampAtomicTableTest {
         assertThat(atomicTable.get(startTimestamp).get()).isEqualTo(commitStatus);
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void onceNonNullValueIsReturnedItIsAlwaysReturned(boolean validating) {
         setup(validating);
@@ -202,7 +203,7 @@ public class ResilientCommitTimestampAtomicTableTest {
         }
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void inAbsenceOfConcurrencyGetRetriesBothTouchAndPut(boolean validating)
             throws ExecutionException, InterruptedException {
@@ -237,7 +238,7 @@ public class ResilientCommitTimestampAtomicTableTest {
         verify(spiedStore, times(102)).put(anyMap());
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void noSuperfluousCasOrPuts(boolean validating) {
         setup(validating);
@@ -262,7 +263,7 @@ public class ResilientCommitTimestampAtomicTableTest {
         verify(spiedStore, times(1 + 50)).put(anyMap());
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void touchesForSameRowAreSerial(boolean validating) {
         setup(validating);
@@ -292,7 +293,7 @@ public class ResilientCommitTimestampAtomicTableTest {
         assertThat(spiedStore.maximumConcurrentTouches()).isEqualTo(validating ? 1 : 0);
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void allowParallelTouchesForDifferentRows(boolean validating) {
         setup(validating);
@@ -324,7 +325,7 @@ public class ResilientCommitTimestampAtomicTableTest {
         }
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void doNotPutIfAlreadyCommitted(boolean validating) throws ExecutionException, InterruptedException {
         setup(validating);
@@ -339,7 +340,7 @@ public class ResilientCommitTimestampAtomicTableTest {
         verify(spiedStore, times(1)).put(anyMap());
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void acceptStagingAsCommittedWhenCommittingIsSlow(boolean validating)
             throws ExecutionException, InterruptedException {
@@ -362,7 +363,7 @@ public class ResilientCommitTimestampAtomicTableTest {
         verify(spiedStore, times(1 + 3)).put(anyMap());
     }
 
-    @ParameterizedTest(name = "validating staging values: {0}")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
     @ValueSource(booleans = {true, false})
     public void acceptStagingAsCommittedWhenRetryingTooMuch(boolean validating)
             throws ExecutionException, InterruptedException {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/SimpleCommitTimestampAtomicTableTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/SimpleCommitTimestampAtomicTableTest.java
@@ -36,14 +36,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class SimpleCommitTimestampAtomicTableTest {
 
-    public static List<TransactionStatusEncodingStrategy<TransactionStatus>> getParameters() {
+    public static List<TransactionStatusEncodingStrategy<TransactionStatus>> encodingStrategies() {
         return List.of(V1EncodingStrategy.INSTANCE, TicketsEncodingStrategy.INSTANCE);
     }
 
     private AtomicTable<Long, TransactionStatus> atomicTable;
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("encodingStrategies")
     public void canPutAndGet(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
         atomicTable = createPueTable(encodingStrategy);
@@ -52,7 +52,7 @@ public class SimpleCommitTimestampAtomicTableTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("encodingStrategies")
     public void emptyReturnsInProgress(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
         atomicTable = createPueTable(encodingStrategy);
@@ -60,7 +60,7 @@ public class SimpleCommitTimestampAtomicTableTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("encodingStrategies")
     public void cannotPueTwice(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy) {
         atomicTable = createPueTable(encodingStrategy);
         atomicTable.update(1L, TransactionStatus.committed(2L));
@@ -69,7 +69,7 @@ public class SimpleCommitTimestampAtomicTableTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("encodingStrategies")
     public void canPutAndGetMultiple(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
         atomicTable = createPueTable(encodingStrategy);
@@ -90,7 +90,7 @@ public class SimpleCommitTimestampAtomicTableTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("encodingStrategies")
     public void canPutAndGetAbortedTransactions(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
         atomicTable = createPueTable(encodingStrategy);
@@ -103,7 +103,7 @@ public class SimpleCommitTimestampAtomicTableTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("encodingStrategies")
     public void getsAllTimestamps(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
         atomicTable = createPueTable(encodingStrategy);
@@ -118,7 +118,7 @@ public class SimpleCommitTimestampAtomicTableTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("encodingStrategies")
     public void doesNotThrowForDuplicateValues(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
         atomicTable = createPueTable(encodingStrategy);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/SimpleCommitTimestampAtomicTableTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/SimpleCommitTimestampAtomicTableTest.java
@@ -40,13 +40,11 @@ public class SimpleCommitTimestampAtomicTableTest {
         return List.of(V1EncodingStrategy.INSTANCE, TicketsEncodingStrategy.INSTANCE);
     }
 
-    private AtomicTable<Long, TransactionStatus> atomicTable;
-
     @ParameterizedTest
     @MethodSource("encodingStrategies")
     public void canPutAndGet(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
-        atomicTable = createPueTable(encodingStrategy);
+        AtomicTable<Long, TransactionStatus> atomicTable = createPueTable(encodingStrategy);
         atomicTable.update(1L, TransactionStatus.committed(2L));
         assertThat(atomicTable.get(1L).get()).isEqualTo(TransactionStatus.committed(2L));
     }
@@ -55,14 +53,14 @@ public class SimpleCommitTimestampAtomicTableTest {
     @MethodSource("encodingStrategies")
     public void emptyReturnsInProgress(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
-        atomicTable = createPueTable(encodingStrategy);
+        AtomicTable<Long, TransactionStatus> atomicTable = createPueTable(encodingStrategy);
         assertThat(atomicTable.get(3L).get()).isEqualTo(TransactionStatus.inProgress());
     }
 
     @ParameterizedTest
     @MethodSource("encodingStrategies")
     public void cannotPueTwice(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy) {
-        atomicTable = createPueTable(encodingStrategy);
+        AtomicTable<Long, TransactionStatus> atomicTable = createPueTable(encodingStrategy);
         atomicTable.update(1L, TransactionStatus.committed(2L));
         assertThatThrownBy(() -> atomicTable.update(1L, TransactionStatus.committed(2L)))
                 .isInstanceOf(KeyAlreadyExistsException.class);
@@ -72,7 +70,7 @@ public class SimpleCommitTimestampAtomicTableTest {
     @MethodSource("encodingStrategies")
     public void canPutAndGetMultiple(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
-        atomicTable = createPueTable(encodingStrategy);
+        AtomicTable<Long, TransactionStatus> atomicTable = createPueTable(encodingStrategy);
         ImmutableMap<Long, TransactionStatus> inputs = ImmutableMap.of(
                 1L,
                 TransactionStatus.committed(2L),
@@ -93,7 +91,7 @@ public class SimpleCommitTimestampAtomicTableTest {
     @MethodSource("encodingStrategies")
     public void canPutAndGetAbortedTransactions(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
-        atomicTable = createPueTable(encodingStrategy);
+        AtomicTable<Long, TransactionStatus> atomicTable = createPueTable(encodingStrategy);
         ImmutableMap<Long, TransactionStatus> inputs = ImmutableMap.of(1L, TransactionStatus.aborted());
         atomicTable.updateMultiple(inputs);
         Map<Long, TransactionStatus> result =
@@ -106,7 +104,7 @@ public class SimpleCommitTimestampAtomicTableTest {
     @MethodSource("encodingStrategies")
     public void getsAllTimestamps(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
-        atomicTable = createPueTable(encodingStrategy);
+        AtomicTable<Long, TransactionStatus> atomicTable = createPueTable(encodingStrategy);
         ImmutableMap<Long, TransactionStatus> inputs = ImmutableMap.of(1L, TransactionStatus.committed(2L));
         atomicTable.updateMultiple(inputs);
         Map<Long, TransactionStatus> result =
@@ -121,7 +119,7 @@ public class SimpleCommitTimestampAtomicTableTest {
     @MethodSource("encodingStrategies")
     public void doesNotThrowForDuplicateValues(TransactionStatusEncodingStrategy<TransactionStatus> encodingStrategy)
             throws ExecutionException, InterruptedException {
-        atomicTable = createPueTable(encodingStrategy);
+        AtomicTable<Long, TransactionStatus> atomicTable = createPueTable(encodingStrategy);
         ImmutableMap<Long, TransactionStatus> inputs = ImmutableMap.of(1L, TransactionStatus.committed(2L));
         atomicTable.updateMultiple(inputs);
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/ScrubberTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/cleaner/ScrubberTest.java
@@ -46,7 +46,7 @@ public class ScrubberTest {
     private ScrubberStore scrubStore;
     private Scrubber scrubber;
 
-    public static List<Function<KeyValueService, TransactionService>> getParameters() {
+    public static List<Function<KeyValueService, TransactionService>> transactionServices() {
         return List.of(SimpleTransactionService::createV1, SimpleTransactionService::createV2);
     }
 
@@ -57,7 +57,7 @@ public class ScrubberTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("transactionServices")
     public void isInitializedWhenPrerequisitesAreInitialized(
             Function<KeyValueService, TransactionService> transactionServiceForKvs) {
         setup(transactionServiceForKvs);
@@ -72,7 +72,7 @@ public class ScrubberTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("transactionServices")
     public void isNotInitializedWhenKvsIsNotInitialized(
             Function<KeyValueService, TransactionService> transactionServiceForKvs) {
         setup(transactionServiceForKvs);
@@ -87,7 +87,7 @@ public class ScrubberTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("transactionServices")
     public void isNotInitializedWhenScrubberStoreIsNotInitialized(
             Function<KeyValueService, TransactionService> transactionServiceForKvs) {
         setup(transactionServiceForKvs);
@@ -102,7 +102,7 @@ public class ScrubberTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("transactionServices")
     public void testScrubQueueIsCleared(Function<KeyValueService, TransactionService> transactionServiceForKvs) {
         setup(transactionServiceForKvs);
         Cell cell1 = Cell.create(new byte[] {1}, new byte[] {2});
@@ -124,7 +124,7 @@ public class ScrubberTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getParameters")
+    @MethodSource("transactionServices")
     public void scrubberIsResilientToTableDeletion(
             Function<KeyValueService, TransactionService> transactionServiceForKvs) {
         setup(transactionServiceForKvs);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
@@ -31,18 +31,14 @@ import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-/* TODO(boyoruk): Migrate to JUnit5 */
-@RunWith(Parameterized.class)
 public class SweepableCellFilterParametrizedTest {
     private static final ImmutableSet<Boolean> BOOLEANS = ImmutableSet.of(true, false);
 
@@ -58,54 +54,31 @@ public class SweepableCellFilterParametrizedTest {
     private final CommitTsCache commitTsCache = CommitTsCache.create(mockTransactionService);
     private List<CandidateCellForSweeping> candidate;
 
-    @Parameterized.Parameter
-    public boolean lastIsTombstone;
-
-    @Parameterized.Parameter(value = 1)
-    public Committed status;
-
-    @Parameterized.Parameter(value = 2)
-    public Sweeper sweeper;
-
-    @Parameterized.Parameters(name = "{0}, {1}, {2}")
-    public static Collection<Object[]> parameters() {
-        return Sets.<Object>cartesianProduct(
+    public static List<Arguments> getParameters() {
+        return Sets.cartesianProduct(
                         BOOLEANS, ImmutableSet.copyOf(Committed.values()), ImmutableSet.copyOf(Sweeper.values()))
                 .stream()
                 .map(List::toArray)
+                .map(Arguments::of)
                 .collect(Collectors.toList());
-    }
-
-    @Before
-    @SuppressWarnings("unchecked")
-    public void setup() {
-        Map<Long, Long> startTsToCommitTs = new HashMap<>();
-        COMMITTED_BEFORE.forEach(startTs -> startTsToCommitTs.put(startTs, startTs));
-        COMMITTED_AFTER.forEach(startTs -> startTsToCommitTs.put(startTs, startTs + SWEEP_TS));
-        ABORTED_TS.forEach(startTs -> startTsToCommitTs.put(startTs, TransactionConstants.FAILED_COMMIT_TS));
-        startTsToCommitTs.put(LAST_TS, status.commitTs);
-        when(mockTransactionService.get(anyCollection())).thenReturn(startTsToCommitTs);
-        candidate = ImmutableList.of(ImmutableCandidateCellForSweeping.builder()
-                .cell(SINGLE_CELL)
-                .sortedTimestamps(ImmutableList.sortedCopyOf(startTsToCommitTs.keySet()))
-                .isLatestValueEmpty(lastIsTombstone)
-                .build());
     }
 
     /**
      * The following tests are testing all combinations of whether the last write with start timestamp before the sweep
      * timestamp was a tombstone; whether that last write was committed before, after sweep ts, or was aborted; and
      * sweep strategy.
-     *
+     * <p>
      * Writes that were aborted should always appear.
      * Writes that were committed after should never appear.
      * Writes that were committed before should appear, in sorted order. However, the greatest such write should appear
      * (if and) only if it is a tombstone (we only have this information for the greatest overall write), and sweep is
      * thorough.
      */
-    @Test
-    public void sweepableCellFilterTest() {
-        List<Long> timestamps = getCellsToSweepFor().sortedTimestamps();
+    @ParameterizedTest(name = "{0}, {1}, {2}")
+    @MethodSource("getParameters")
+    public void sweepableCellFilterTest(boolean lastIsTombstone, Committed status, Sweeper sweeper) {
+        setup(lastIsTombstone, status);
+        List<Long> timestamps = getCellsToSweepFor(sweeper).sortedTimestamps();
 
         assertThat(timestamps).doesNotContainAnyElementsOf(COMMITTED_AFTER);
 
@@ -130,7 +103,21 @@ public class SweepableCellFilterParametrizedTest {
         assertThat(timestamps.stream().filter(expectedCommitted::contains)).isSorted();
     }
 
-    private CellToSweep getCellsToSweepFor() {
+    public void setup(boolean lastIsTombstone, Committed status) {
+        Map<Long, Long> startTsToCommitTs = new HashMap<>();
+        COMMITTED_BEFORE.forEach(startTs -> startTsToCommitTs.put(startTs, startTs));
+        COMMITTED_AFTER.forEach(startTs -> startTsToCommitTs.put(startTs, startTs + SWEEP_TS));
+        ABORTED_TS.forEach(startTs -> startTsToCommitTs.put(startTs, TransactionConstants.FAILED_COMMIT_TS));
+        startTsToCommitTs.put(LAST_TS, status.commitTs);
+        when(mockTransactionService.get(anyCollection())).thenReturn(startTsToCommitTs);
+        candidate = ImmutableList.of(ImmutableCandidateCellForSweeping.builder()
+                .cell(SINGLE_CELL)
+                .sortedTimestamps(ImmutableList.sortedCopyOf(startTsToCommitTs.keySet()))
+                .isLatestValueEmpty(lastIsTombstone)
+                .build());
+    }
+
+    private CellToSweep getCellsToSweepFor(Sweeper sweeper) {
         SweepableCellFilter filter = new SweepableCellFilter(commitTsCache, sweeper, SWEEP_TS);
         List<CellToSweep> cells = filter.getCellsToSweep(candidate).cells();
         assertThat(cells).hasSize(1);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/SweepableCellFilterParametrizedTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class SweepableCellFilterParametrizedTest {
+    private static final String PARAMETERIZED_TEST_NAME = "{0}, {1}, {2}";
     private static final ImmutableSet<Boolean> BOOLEANS = ImmutableSet.of(true, false);
 
     private static final Cell SINGLE_CELL =
@@ -54,7 +55,7 @@ public class SweepableCellFilterParametrizedTest {
     private final CommitTsCache commitTsCache = CommitTsCache.create(mockTransactionService);
     private List<CandidateCellForSweeping> candidate;
 
-    public static List<Arguments> getParameters() {
+    public static List<Arguments> lastIsTombstonesAndStatusesAndSweepers() {
         return Sets.cartesianProduct(
                         BOOLEANS, ImmutableSet.copyOf(Committed.values()), ImmutableSet.copyOf(Sweeper.values()))
                 .stream()
@@ -74,8 +75,8 @@ public class SweepableCellFilterParametrizedTest {
      * (if and) only if it is a tombstone (we only have this information for the greatest overall write), and sweep is
      * thorough.
      */
-    @ParameterizedTest(name = "{0}, {1}, {2}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("lastIsTombstonesAndStatusesAndSweepers")
     public void sweepableCellFilterTest(boolean lastIsTombstone, Committed status, Sweeper sweeper) {
         setup(lastIsTombstone, status);
         List<Long> timestamps = getCellsToSweepFor(sweeper).sortedTimestamps();


### PR DESCRIPTION
In [this issue](https://github.com/palantir/atlasdb/issues/6796), we are upgrading our test classes from JUnit4 to JUnit5. 

In this pull request, we replace `@RunWith(Parameterized.class)` with `@ParameterizedTest` because the former is no longer supported in JUnit5. 

This PR only for `atlasdb-shared-impl`