### PR TITLE
parametrize with mockitoextension

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/LastSweptTimestampUpdaterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/LastSweptTimestampUpdaterTest.java
@@ -54,13 +54,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class LastSweptTimestampUpdaterTest {
+    private static final String PARAMETERIZED_TEST_NAME = "shards = {0}";
+
     private static final long REFRESH_MILLIS = 10L;
     private static final int TICK_COUNT = 5;
     private static final long CONS_TS = 100L;
     private static final long THOR_TS = 200L;
     private static final ShardAndStrategy CONS_SHARD = ShardAndStrategy.conservative(0);
 
-    public static List<Integer> getParameters() {
+    public static List<Integer> numberOfShards() {
         return List.of(1, 8, 16);
     }
 
@@ -87,23 +89,23 @@ public class LastSweptTimestampUpdaterTest {
         lastSweptTimestampUpdater = new LastSweptTimestampUpdater(queue, metrics, executorService);
     }
 
-    @ParameterizedTest(name = "shards = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("numberOfShards")
     public void unscheduledTaskDoesNotInteractWithExecutorService(int shards) {
         setup(shards);
         verifyNoInteractions(executorService);
     }
 
-    @ParameterizedTest(name = "shards = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("numberOfShards")
     public void taskThrowsOnInvalidRefreshMillis(int shards) {
         setup(shards);
         assertThrows(SafeIllegalArgumentException.class, () -> lastSweptTimestampUpdater.schedule(0L));
         assertThrows(SafeIllegalArgumentException.class, () -> lastSweptTimestampUpdater.schedule(-REFRESH_MILLIS));
     }
 
-    @ParameterizedTest(name = "shards = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("numberOfShards")
     public void scheduleCallSubmitsRunnableToExecutorServiceOnce(int shards) {
         setup(shards);
         lastSweptTimestampUpdater.schedule(REFRESH_MILLIS);
@@ -113,8 +115,8 @@ public class LastSweptTimestampUpdaterTest {
                 .scheduleWithFixedDelay(any(), eq(REFRESH_MILLIS), eq(REFRESH_MILLIS), eq(TimeUnit.MILLISECONDS));
     }
 
-    @ParameterizedTest(name = "shards = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("numberOfShards")
     public void scheduledTaskDoesNotInteractWithMetricsOrQueueBeforeDelayIsElapsed(int shards) {
         setup(shards);
         lastSweptTimestampUpdater.schedule(REFRESH_MILLIS);
@@ -122,8 +124,8 @@ public class LastSweptTimestampUpdaterTest {
         verifyNoMoreInteractions(queue, metrics);
     }
 
-    @ParameterizedTest(name = "shards = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("numberOfShards")
     public void scheduledTaskUpdatesProgressForShardsOnceAfterOneDelay(int shards) {
         setup(shards);
         stubWithRealisticReturnValues(shards);
@@ -143,8 +145,8 @@ public class LastSweptTimestampUpdaterTest {
         verifyNoMoreInteractions(queue, metrics);
     }
 
-    @ParameterizedTest(name = "shards = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("numberOfShards")
     public void scheduledTaskInteractsWithMetricsAndQueueAsExpectedAfterMultipleDelays(int shards) {
         setup(shards);
         stubWithRealisticReturnValues(shards);
@@ -165,8 +167,8 @@ public class LastSweptTimestampUpdaterTest {
         verifyNoMoreInteractions(queue, metrics);
     }
 
-    @ParameterizedTest(name = "shards = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("numberOfShards")
     public void scheduledTaskKeepsRunningAfterUpdateProgressForShardFails(int shards) {
         setup(shards);
         setNumShardsMock(1);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingKeyValueServiceReadInfoTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingKeyValueServiceReadInfoTest.java
@@ -62,8 +62,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
  */
 @ExtendWith(MockitoExtension.class)
 public final class TrackingKeyValueServiceReadInfoTest {
+    private static final String PARAMETERIZED_TEST_NAME = "size = {0}";
 
-    public static List<Integer> getParameters() {
+    public static List<Integer> sizes() {
         return List.of(12 * 129, 12 * 365, 12 * 411);
     }
 
@@ -92,8 +93,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
     @Mock
     private Map<Cell, Long> timestampByCellMap;
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetAsyncCallAndFutureConsumption(int size) {
         setup(size);
         when(kvs.getAsync(tableReference, timestampByCellMap))
@@ -104,8 +105,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForReadForTable("getAsync", size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void getAsyncTracksNothingBeforeDelegateResultCompletionAndTracksReadsAfterCompletion(int size) {
         setup(size);
         SettableFuture<Map<Cell, Value>> delegateFuture = SettableFuture.create();
@@ -126,8 +127,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForReadForTable("getAsync", size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void throwingGetAsyncResultTracksNothing(int size) {
         setup(size);
         when(kvs.getAsync(tableReference, timestampByCellMap))
@@ -145,8 +146,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         assertThat(trackingKvs.getReadInfoByTable()).isEmpty();
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetRowsCall(int size) {
         setup(size);
         ColumnSelection columnSelection = mock(ColumnSelection.class);
@@ -157,8 +158,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForReadForTable("getRows", size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetRowsBatchColumnRangeCallAndIteratorsConsumption(int size) {
         setup(size);
         BatchColumnRangeSelection batchColumnRangeSelection = mock(BatchColumnRangeSelection.class);
@@ -174,8 +175,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForLazyRead(size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetRowsColumnRangeCallAndIteratorConsumption(int size) {
         setup(size);
         int cellBatchHint = 17;
@@ -191,8 +192,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForLazyRead(size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetCall(int size) {
         setup(size);
         when(kvs.get(tableReference, timestampByCellMap)).thenReturn(valueByCellMapOfSize);
@@ -202,8 +203,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForReadForTable("get", size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetLatestTimestampsCall(int size) {
         setup(size);
         Map<Cell, Long> timestampByCellMapOfSize = TrackingKeyValueServiceTestUtils.createLongByCellMapWithSize(size);
@@ -215,8 +216,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
     }
 
     @SuppressWarnings("MustBeClosedChecker")
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetRangeCallAndIteratorConsumption(int size) {
         setup(size);
         List<RowResult<Value>> backingValueRowResultListOfSize =
@@ -231,8 +232,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
     }
 
     @SuppressWarnings("MustBeClosedChecker")
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetRangeOfTimestampsCallAndIteratorConsumption(int size) {
         setup(size);
         List<RowResult<Set<Long>>> backingLongSetRowResultListOfSize =
@@ -249,8 +250,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
     }
 
     @SuppressWarnings("MustBeClosedChecker")
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetCandidateCellsForSweepingCallAndIteratorConsumption(int size) {
         setup(size);
         CandidateCellForSweepingRequest candidateCellForSweepingRequest = mock(CandidateCellForSweepingRequest.class);
@@ -268,8 +269,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForLazyRead(size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetFirstBatchForRangesCall(int size) {
         setup(size);
         Iterable<RangeRequest> rangeRequests = mock(Iterable.class);
@@ -284,8 +285,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForReadForTable("getFirstBatchForRanges", size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetAllTableNamesCall(int size) {
         setup(size);
         when(kvs.getAllTableNames()).thenReturn(TrackingKeyValueServiceTestUtils.createTableReferenceSetWithSize(size));
@@ -295,8 +296,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForTableAgnosticRead("getAllTableNames", size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetMetadataForTableCall(int size) {
         setup(size);
         when(kvs.getMetadataForTable(tableReference)).thenReturn(new byte[size]);
@@ -306,8 +307,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForTableAgnosticRead("getMetadataForTable", size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetMetadataForTablesCall(int size) {
         setup(size);
         Map<TableReference, byte[]> metadataForTablesOfSize =
@@ -320,8 +321,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForTableAgnosticRead("getMetadataForTables", size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetAllTimestampsCall(int size) {
         setup(size);
         Set<Cell> cells = mock(Set.class);
@@ -334,8 +335,8 @@ public final class TrackingKeyValueServiceReadInfoTest {
         validateReadInfoForReadForTable("getAllTimestamps", size);
     }
 
-    @ParameterizedTest(name = "size = {0}")
-    @MethodSource("getParameters")
+    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
+    @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetRowsKeysInRangeCall(int size) {
         setup(size);
         int maxResults = 13;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingKeyValueServiceReadInfoTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingKeyValueServiceReadInfoTest.java
@@ -46,34 +46,28 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-/* TODO(boyoruk): Migrate to JUnit5 */
 /**
- * {@link #size} must be divisible by 12 due to
+ * size must be divisible by 12 due to
  * {@link TrackingKeyValueServiceTestUtils#createByteArrayByTableReferenceMapWithSize}.
  * Refer to {@link TrackingKeyValueServiceTestUtils} javadoc.
  * Also, the range of permitted sizes is constrained as some objects have size bounds.
  * Note that the range of possible sizes will be larger if we use different sizes for different tests.
  */
-@RunWith(Parameterized.class)
+@ExtendWith(MockitoExtension.class)
 public final class TrackingKeyValueServiceReadInfoTest {
-    @Parameterized.Parameters(name = "size = {0}")
-    public static Object[] size() {
-        return new Object[] {12 * 129, 12 * 365, 12 * 411};
+
+    public static List<Integer> getParameters() {
+        return List.of(12 * 129, 12 * 365, 12 * 411);
     }
 
     private static final long TIMESTAMP = 14L;
-
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
     private List<byte[]> rows;
@@ -84,17 +78,11 @@ public final class TrackingKeyValueServiceReadInfoTest {
     @Mock
     private KeyValueService kvs;
 
-    private final int size;
     private TrackingKeyValueService trackingKvs;
-    private final ImmutableMap<Cell, Value> valueByCellMapOfSize;
+    private ImmutableMap<Cell, Value> valueByCellMapOfSize;
 
-    public TrackingKeyValueServiceReadInfoTest(int size) {
-        this.size = size;
-        this.valueByCellMapOfSize = TrackingKeyValueServiceTestUtils.createValueByCellMapWithSize(size);
-    }
-
-    @Before
-    public void setUp() {
+    @BeforeEach
+    public void beforeEach() {
         this.trackingKvs = new TrackingKeyValueServiceImpl(kvs);
     }
 
@@ -104,18 +92,22 @@ public final class TrackingKeyValueServiceReadInfoTest {
     @Mock
     private Map<Cell, Long> timestampByCellMap;
 
-    @Test
-    public void readInfoIsCorrectAfterGetAsyncCallAndFutureConsumption() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetAsyncCallAndFutureConsumption(int size) {
+        setup(size);
         when(kvs.getAsync(tableReference, timestampByCellMap))
                 .thenReturn(Futures.immediateFuture(valueByCellMapOfSize));
 
         trackingKvs.getAsync(tableReference, timestampByCellMap);
 
-        validateReadInfoForReadForTable("getAsync");
+        validateReadInfoForReadForTable("getAsync", size);
     }
 
-    @Test
-    public void getAsyncTracksNothingBeforeDelegateResultCompletionAndTracksReadsAfterCompletion() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void getAsyncTracksNothingBeforeDelegateResultCompletionAndTracksReadsAfterCompletion(int size) {
+        setup(size);
         SettableFuture<Map<Cell, Value>> delegateFuture = SettableFuture.create();
         when(kvs.getAsync(tableReference, timestampByCellMap)).thenReturn(delegateFuture);
         trackingKvs.getAsync(tableReference, timestampByCellMap);
@@ -131,11 +123,13 @@ public final class TrackingKeyValueServiceReadInfoTest {
         // completes the future
         delegateFuture.set(valueByCellMapOfSize);
 
-        validateReadInfoForReadForTable("getAsync");
+        validateReadInfoForReadForTable("getAsync", size);
     }
 
-    @Test
-    public void throwingGetAsyncResultTracksNothing() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void throwingGetAsyncResultTracksNothing(int size) {
+        setup(size);
         when(kvs.getAsync(tableReference, timestampByCellMap))
                 .thenReturn(Futures.immediateFailedFuture(new RuntimeException()));
 
@@ -151,18 +145,22 @@ public final class TrackingKeyValueServiceReadInfoTest {
         assertThat(trackingKvs.getReadInfoByTable()).isEmpty();
     }
 
-    @Test
-    public void readInfoIsCorrectAfterGetRowsCall() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetRowsCall(int size) {
+        setup(size);
         ColumnSelection columnSelection = mock(ColumnSelection.class);
         when(kvs.getRows(tableReference, rows, columnSelection, TIMESTAMP)).thenReturn(valueByCellMapOfSize);
 
         trackingKvs.getRows(tableReference, rows, columnSelection, TIMESTAMP);
 
-        validateReadInfoForReadForTable("getRows");
+        validateReadInfoForReadForTable("getRows", size);
     }
 
-    @Test
-    public void readInfoIsCorrectAfterGetRowsBatchColumnRangeCallAndIteratorsConsumption() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetRowsBatchColumnRangeCallAndIteratorsConsumption(int size) {
+        setup(size);
         BatchColumnRangeSelection batchColumnRangeSelection = mock(BatchColumnRangeSelection.class);
         when(kvs.getRowsColumnRange(tableReference, rows, batchColumnRangeSelection, TIMESTAMP))
                 .thenReturn(TrackingKeyValueServiceTestUtils.createRowColumnRangeIteratorByByteArrayMutableMapWithSize(
@@ -173,11 +171,13 @@ public final class TrackingKeyValueServiceReadInfoTest {
                 .values()
                 .forEach(iterator -> iterator.forEachRemaining(_unused -> {}));
 
-        validateReadInfoForLazyRead();
+        validateReadInfoForLazyRead(size);
     }
 
-    @Test
-    public void readInfoIsCorrectAfterGetRowsColumnRangeCallAndIteratorConsumption() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetRowsColumnRangeCallAndIteratorConsumption(int size) {
+        setup(size);
         int cellBatchHint = 17;
         ColumnRangeSelection columnRangeSelection = mock(ColumnRangeSelection.class);
         when(kvs.getRowsColumnRange(tableReference, rows, columnRangeSelection, cellBatchHint, TIMESTAMP))
@@ -188,31 +188,37 @@ public final class TrackingKeyValueServiceReadInfoTest {
                 .getRowsColumnRange(tableReference, rows, columnRangeSelection, cellBatchHint, TIMESTAMP)
                 .forEachRemaining(_unused -> {});
 
-        validateReadInfoForLazyRead();
+        validateReadInfoForLazyRead(size);
     }
 
-    @Test
-    public void readInfoIsCorrectAfterGetCall() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetCall(int size) {
+        setup(size);
         when(kvs.get(tableReference, timestampByCellMap)).thenReturn(valueByCellMapOfSize);
 
         trackingKvs.get(tableReference, timestampByCellMap);
 
-        validateReadInfoForReadForTable("get");
+        validateReadInfoForReadForTable("get", size);
     }
 
-    @Test
-    public void readInfoIsCorrectAfterGetLatestTimestampsCall() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetLatestTimestampsCall(int size) {
+        setup(size);
         Map<Cell, Long> timestampByCellMapOfSize = TrackingKeyValueServiceTestUtils.createLongByCellMapWithSize(size);
         when(kvs.getLatestTimestamps(tableReference, timestampByCellMap)).thenReturn(timestampByCellMapOfSize);
 
         trackingKvs.getLatestTimestamps(tableReference, timestampByCellMap);
 
-        validateReadInfoForReadForTable("getLatestTimestamps");
+        validateReadInfoForReadForTable("getLatestTimestamps", size);
     }
 
     @SuppressWarnings("MustBeClosedChecker")
-    @Test
-    public void readInfoIsCorrectAfterGetRangeCallAndIteratorConsumption() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetRangeCallAndIteratorConsumption(int size) {
+        setup(size);
         List<RowResult<Value>> backingValueRowResultListOfSize =
                 TrackingKeyValueServiceTestUtils.createValueRowResultListWithSize(size);
 
@@ -221,12 +227,14 @@ public final class TrackingKeyValueServiceReadInfoTest {
 
         trackingKvs.getRange(tableReference, rangeRequest, TIMESTAMP).forEachRemaining(_unused -> {});
 
-        validateReadInfoForLazyRead();
+        validateReadInfoForLazyRead(size);
     }
 
     @SuppressWarnings("MustBeClosedChecker")
-    @Test
-    public void readInfoIsCorrectAfterGetRangeOfTimestampsCallAndIteratorConsumption() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetRangeOfTimestampsCallAndIteratorConsumption(int size) {
+        setup(size);
         List<RowResult<Set<Long>>> backingLongSetRowResultListOfSize =
                 TrackingKeyValueServiceTestUtils.createLongSetRowResultListWithSize(size);
 
@@ -237,12 +245,14 @@ public final class TrackingKeyValueServiceReadInfoTest {
                 .getRangeOfTimestamps(tableReference, rangeRequest, TIMESTAMP)
                 .forEachRemaining(_unused -> {});
 
-        validateReadInfoForLazyRead();
+        validateReadInfoForLazyRead(size);
     }
 
     @SuppressWarnings("MustBeClosedChecker")
-    @Test
-    public void readInfoIsCorrectAfterGetCandidateCellsForSweepingCallAndIteratorConsumption() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetCandidateCellsForSweepingCallAndIteratorConsumption(int size) {
+        setup(size);
         CandidateCellForSweepingRequest candidateCellForSweepingRequest = mock(CandidateCellForSweepingRequest.class);
 
         ImmutableList<ImmutableList<CandidateCellForSweeping>> backingCandidateForSweepingTableOfSize =
@@ -255,11 +265,13 @@ public final class TrackingKeyValueServiceReadInfoTest {
                 .getCandidateCellsForSweeping(tableReference, candidateCellForSweepingRequest)
                 .forEachRemaining(_unused -> {});
 
-        validateReadInfoForLazyRead();
+        validateReadInfoForLazyRead(size);
     }
 
-    @Test
-    public void readInfoIsCorrectAfterGetFirstBatchForRangesCall() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetFirstBatchForRangesCall(int size) {
+        setup(size);
         Iterable<RangeRequest> rangeRequests = mock(Iterable.class);
         Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> pageByRangeRequestMapOfSize =
                 TrackingKeyValueServiceTestUtils.createPageByRangeRequestMapWithSize(size);
@@ -269,29 +281,35 @@ public final class TrackingKeyValueServiceReadInfoTest {
 
         trackingKvs.getFirstBatchForRanges(tableReference, rangeRequests, TIMESTAMP);
 
-        validateReadInfoForReadForTable("getFirstBatchForRanges");
+        validateReadInfoForReadForTable("getFirstBatchForRanges", size);
     }
 
-    @Test
-    public void readInfoIsCorrectAfterGetAllTableNamesCall() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetAllTableNamesCall(int size) {
+        setup(size);
         when(kvs.getAllTableNames()).thenReturn(TrackingKeyValueServiceTestUtils.createTableReferenceSetWithSize(size));
 
         trackingKvs.getAllTableNames();
 
-        validateReadInfoForTableAgnosticRead("getAllTableNames");
+        validateReadInfoForTableAgnosticRead("getAllTableNames", size);
     }
 
-    @Test
-    public void readInfoIsCorrectAfterGetMetadataForTableCall() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetMetadataForTableCall(int size) {
+        setup(size);
         when(kvs.getMetadataForTable(tableReference)).thenReturn(new byte[size]);
 
         trackingKvs.getMetadataForTable(tableReference);
 
-        validateReadInfoForTableAgnosticRead("getMetadataForTable");
+        validateReadInfoForTableAgnosticRead("getMetadataForTable", size);
     }
 
-    @Test
-    public void readInfoIsCorrectAfterGetMetadataForTablesCall() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetMetadataForTablesCall(int size) {
+        setup(size);
         Map<TableReference, byte[]> metadataForTablesOfSize =
                 TrackingKeyValueServiceTestUtils.createByteArrayByTableReferenceMapWithSize(size);
 
@@ -299,24 +317,27 @@ public final class TrackingKeyValueServiceReadInfoTest {
 
         trackingKvs.getMetadataForTables();
 
-        validateReadInfoForTableAgnosticRead("getMetadataForTables");
+        validateReadInfoForTableAgnosticRead("getMetadataForTables", size);
     }
 
-    @Test
-    public void readInfoIsCorrectAfterGetAllTimestampsCall() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetAllTimestampsCall(int size) {
+        setup(size);
         Set<Cell> cells = mock(Set.class);
         Multimap<Cell, Long> longByCellMultimapOfSize =
                 TrackingKeyValueServiceTestUtils.createLongByCellMultimapWithSize(size);
 
         when(kvs.getAllTimestamps(tableReference, cells, TIMESTAMP)).thenReturn(longByCellMultimapOfSize);
-
         trackingKvs.getAllTimestamps(tableReference, cells, TIMESTAMP);
 
-        validateReadInfoForReadForTable("getAllTimestamps");
+        validateReadInfoForReadForTable("getAllTimestamps", size);
     }
 
-    @Test
-    public void readInfoIsCorrectAfterGetRowsKeysInRangeCall() {
+    @ParameterizedTest(name = "size = {0}")
+    @MethodSource("getParameters")
+    public void readInfoIsCorrectAfterGetRowsKeysInRangeCall(int size) {
+        setup(size);
         int maxResults = 13;
         byte[] startRow = new byte[1];
         byte[] endRow = new byte[3];
@@ -328,10 +349,14 @@ public final class TrackingKeyValueServiceReadInfoTest {
 
         trackingKvs.getRowKeysInRange(tableReference, startRow, endRow, maxResults);
 
-        validateReadInfoForReadForTable("getRowKeysInRange");
+        validateReadInfoForReadForTable("getRowKeysInRange", size);
     }
 
-    private void validateReadInfoForReadForTable(String methodName) {
+    private void setup(int size) {
+        valueByCellMapOfSize = TrackingKeyValueServiceTestUtils.createValueByCellMapWithSize(size);
+    }
+
+    private void validateReadInfoForReadForTable(String methodName, int size) {
         TransactionReadInfo readInfo = ImmutableTransactionReadInfo.builder()
                 .bytesRead(size)
                 .kvsCalls(1)
@@ -341,7 +366,7 @@ public final class TrackingKeyValueServiceReadInfoTest {
         assertThat(trackingKvs.getReadInfoByTable()).containsOnlyKeys(ImmutableList.of(tableReference));
     }
 
-    private void validateReadInfoForLazyRead() {
+    private void validateReadInfoForLazyRead(int size) {
         TransactionReadInfo readInfo = ImmutableTransactionReadInfo.builder()
                 .bytesRead(size)
                 .kvsCalls(1)
@@ -350,7 +375,7 @@ public final class TrackingKeyValueServiceReadInfoTest {
         assertThat(trackingKvs.getReadInfoByTable()).containsOnlyKeys(ImmutableList.of(tableReference));
     }
 
-    private void validateReadInfoForTableAgnosticRead(String methodName) {
+    private void validateReadInfoForTableAgnosticRead(String methodName, int size) {
         TransactionReadInfo readInfo = ImmutableTransactionReadInfo.builder()
                 .bytesRead(size)
                 .kvsCalls(1)


### PR DESCRIPTION
In [this issue](https://github.com/palantir/atlasdb/issues/6796), we are upgrading our test classes from JUnit4 to JUnit5. 

In this pull request, we replace `@RunWith(Parameterized.class)` with `@ParameterizedTest` because the former is no longer supported in JUnit5. 

This PR is for test classes that have both `@ParameterizedTest`  and `@ExtendWith(MockitoExtension.class)`