### PR TITLE
flaky retry replace

### DIFF
--- a/atlasdb-api/build.gradle
+++ b/atlasdb-api/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   testImplementation 'com.palantir.refreshable:refreshable'
   testImplementation 'io.dropwizard.metrics:metrics-core'
   testImplementation project(':lock-api-objects')
-  testImplementation project(path: ':flake-rule')
+  testImplementation project(path: ':flake-extension')
 
   annotationProcessor 'org.immutables:value'
   compileOnly 'org.immutables:value::annotations'
@@ -48,9 +48,4 @@ dependencies {
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testImplementation 'org.mockito:mockito-junit-jupiter'
-
-  testImplementation 'junit:junit'
-  testRuntimeOnly 'org.junit.vintage:junit-vintage-engine', {
-    because 'allows JUnit 3 and JUnit 4 tests to run'
-  }
 }

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CellReferenceTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/CellReferenceTest.java
@@ -21,25 +21,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.math.IntMath;
 import com.palantir.atlasdb.encoding.PtBytes;
-import com.palantir.flake.FlakeRetryingRule;
-import com.palantir.flake.ShouldRetry;
+import com.palantir.flake.FlakeRetryTest;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.assertj.core.data.Percentage;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-/* TODO(boyoruk): Do not forget to upgrade this to JUnit5 once we implemented new com.palantir.flake package.  */
 public class CellReferenceTest {
     private static final TableReference TABLE = createFromFullyQualifiedName("fixed.table");
     private static final byte[] ROW = PtBytes.toBytes("row");
     private static final byte[] COL = PtBytes.toBytes("col");
-
-    @Rule
-    public final FlakeRetryingRule retryingRule = new FlakeRetryingRule();
 
     @Test
     public void dynamicSequentialColumns() {
@@ -51,8 +45,7 @@ public class CellReferenceTest {
         assertDistributionUniform(hashes, totalCount);
     }
 
-    @ShouldRetry
-    @Test
+    @FlakeRetryTest
     public void dynamicRandomColumns() {
         ThreadLocalRandom random = ThreadLocalRandom.current();
         int totalCount = 50_000;

--- a/atlasdb-cli/build.gradle
+++ b/atlasdb-cli/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':atlasdb-client')
     api project(':atlasdb-config')
     api project(':timestamp-api')
-    testImplementation project(path: ':flake-rule')
+    testImplementation project(path: ':flake-extension')
 
     compileOnly 'com.google.dagger:dagger'
     implementation 'io.airlift:airline'

--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -84,7 +84,7 @@ dependencies {
   testImplementation project(':atlasdb-client-protobufs')
   testImplementation project(':commons-annotations')
   testImplementation project(':commons-executors')
-  testImplementation project(':flake-rule')
+  testImplementation project(':flake-extension')
   testImplementation project(':lock-api')
   testImplementation project(':lock-api-objects')
   testImplementation project(':timelock-api:timelock-api-objects')

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLogTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLogTest.java
@@ -26,8 +26,7 @@ import com.palantir.atlasdb.keyvalue.api.cache.CacheMetrics;
 import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.common.concurrent.PTExecutors;
-import com.palantir.flake.FlakeRetryingRule;
-import com.palantir.flake.ShouldRetry;
+import com.palantir.flake.FlakeRetryTest;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.v2.LockToken;
@@ -49,11 +48,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
+import org.junit.jupiter.api.Test;
 
-/* TODO(boyoruk): Migrate to JUnit5*/
 public final class LockWatchEventLogTest {
     private static final int MIN_EVENTS = 1;
     private static final int MAX_EVENTS = 25;
@@ -143,9 +139,6 @@ public final class LockWatchEventLogTest {
 
     private final LockWatchEventLog eventLog =
             LockWatchEventLog.create(CacheMetrics.create(MetricsManagers.createForTests()), MIN_EVENTS, MAX_EVENTS);
-
-    @Rule
-    public final TestRule flakeRetryingRule = new FlakeRetryingRule();
 
     @Test
     public void doesNotHaveInitialVersion() {
@@ -498,8 +491,7 @@ public final class LockWatchEventLogTest {
         assertThat(events.events().events()).containsExactly(CREATED_UP_TO_VERSION_4);
     }
 
-    @Test
-    @ShouldRetry
+    @FlakeRetryTest
     public void eventLogDoesNotDeadlockUnderConcurrentLoad() throws InterruptedException {
         eventLog.processUpdate(INITIAL_SNAPSHOT_VERSION_1);
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/KeyValueServiceDataTrackerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/KeyValueServiceDataTrackerTest.java
@@ -25,13 +25,12 @@ import com.palantir.atlasdb.transaction.api.expectations.ImmutableTransactionRea
 import com.palantir.atlasdb.transaction.api.expectations.KvsCallReadInfo;
 import com.palantir.atlasdb.transaction.api.expectations.TransactionReadInfo;
 import com.palantir.common.concurrent.PTExecutors;
-import com.palantir.flake.ShouldRetry;
+import com.palantir.flake.FlakeRetryTest;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-/* TODO(boyoruk): Migrate to JUnit5 */
 public final class KeyValueServiceDataTrackerTest {
     private static final TableReference TABLE_1 = TableReference.createWithEmptyNamespace("Table1");
     private static final TableReference TABLE_2 = TableReference.createWithEmptyNamespace("Table2");
@@ -172,8 +171,7 @@ public final class KeyValueServiceDataTrackerTest {
                                 ImmutableKvsCallReadInfo.of(KVS_METHOD_NAME_1, SMALL_BYTES_READ))));
     }
 
-    @Test
-    @ShouldRetry
+    @FlakeRetryTest
     public void interleavedMethodCallsAreTracked() throws InterruptedException {
         ExecutorService executor = PTExecutors.newFixedThreadPool(100);
         int concurrencyRounds = 20_000;

--- a/timelock-server/build.gradle
+++ b/timelock-server/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     testImplementation project(':atlasdb-dbkvs')
     testImplementation project(':atlasdb-impl-shared')
     testImplementation project(':atlasdb-tests-shared')
+    testImplementation project(':flake-extension')
     testImplementation project(':flake-rule')
     testImplementation project(':lock-api-objects')
     testImplementation project(':timelock-impl')


### PR DESCRIPTION
In [this issue](https://github.com/palantir/atlasdb/issues/6796), we are upgrading our test classes from JUnit4 to JUnit5. 

In this pull request, we replace `@ShouldRetry` with `@FlakeRetryTest` because the former is no longer supported in JUnit5. 
