### PR TITLE
Remove useless enableErrorProne property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-enableErrorProne=false
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2g --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/scripts/circle-ci/run-circle-tests.sh
+++ b/scripts/circle-ci/run-circle-tests.sh
@@ -104,5 +104,5 @@ case "$test_suite_index" in
     11) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_11[@]} ;;
     12) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_12[@]} ;;
     13) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_13[@]} ;;
-    14) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_14[@]} --stacktrace -PenableErrorProne=true && checkDocsBuild ;;
+    14) ./gradlew $BASE_GRADLE_ARGS ${CONTAINER_14[@]} --stacktrace && checkDocsBuild ;;
 esac


### PR DESCRIPTION
AFAICT this option doesn't actually do anything. It's not an option used by [gradle-baseline](https://github.com/palantir/gradle-baseline) or [gradle-errorprone-plugin](https://github.com/tbroyer/gradle-errorprone-plugin) (which gradle-baseline uses internally).

If we want to suppress particular error-prone checks, that can and should be done in a per-check basis. In fact, we already do this:

https://github.com/palantir/atlasdb/blob/52fadbb7a7b16591c0d2930f8da84abda45ba588/build.gradle#L99-L106