### PR TITLE
[PDS-435038] Close Only Relevant Delegates On Encountering (Suspected)NotCurrentLeaderException False Alarms

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/leader/SuspectedNotCurrentLeaderException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/leader/SuspectedNotCurrentLeaderException.java
@@ -45,8 +45,7 @@ public class SuspectedNotCurrentLeaderException extends RuntimeException impleme
     private final String logMessage;
     private final List<Arg<?>> args;
 
-    public SuspectedNotCurrentLeaderException(
-            @CompileTimeConstant String logMessage, Arg<?>... args) {
+    public SuspectedNotCurrentLeaderException(@CompileTimeConstant String logMessage, Arg<?>... args) {
         super(SafeExceptions.renderMessage(logMessage, args));
         this.logMessage = logMessage;
         this.args = List.of(args);

--- a/atlasdb-commons/src/main/java/com/palantir/leader/SuspectedNotCurrentLeaderException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/leader/SuspectedNotCurrentLeaderException.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.leader;
+
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.exceptions.SafeExceptions;
+import java.util.List;
+
+/**
+ * This exception may be thrown when an operation that indicates a possible leadership loss has occurred. This does
+ * not mean that leadership has been lost; the handler should check the leadership status and act accordingly.
+ * <p>
+ * This exception may additionally provide a callback that an external environment can use as a mechanism for feedback
+ * to the original class, that leadership was indeed lost. This is slightly horrible, but the creation path of the
+ * objects that might produce this exception is sufficiently complex that the architecturally preferable solution of
+ * passing the leadership coordinator or mechanism for checking if we still have leadership to the relevant objects is
+ * not feasible without invasive refactoring, which we don't have the resources for right now.
+ * <p>
+ * A precondition of this callback is that it does not throw exceptions. If it does, the behaviour of the system is
+ * undefined.
+ * <p>
+ * If leadership was not actually lost, we assume that requests on throwers should be able to be retried without issue.
+ * Throwers which require availability must not throw this exception when they are in an irrecoverable state, even if
+ * the source of that state is only a possible leadership loss. They should instead consider throwing
+ * {@link NotCurrentLeaderException}.
+ */
+public class SuspectedNotCurrentLeaderException extends RuntimeException implements SafeLoggable {
+    private final String logMessage;
+    private final List<Arg<?>> args;
+    private final Runnable lostLeadershipCallback;
+
+    public SuspectedNotCurrentLeaderException(
+            @CompileTimeConstant String logMessage, Runnable lostLeadershipCallback, Arg<?>... args) {
+        super(SafeExceptions.renderMessage(logMessage, args));
+        this.logMessage = logMessage;
+        this.lostLeadershipCallback = lostLeadershipCallback;
+        this.args = List.of(args);
+    }
+
+    @Override
+    public @Safe String getLogMessage() {
+        return logMessage;
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return args;
+    }
+
+    public void runLostLeadershipCallback() {
+        // Should only be called if we actually have lost leadership.
+        lostLeadershipCallback.run();
+    }
+}

--- a/atlasdb-commons/src/main/java/com/palantir/leader/SuspectedNotCurrentLeaderException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/leader/SuspectedNotCurrentLeaderException.java
@@ -27,19 +27,8 @@ import java.util.List;
  * This exception may be thrown when an operation that indicates a possible leadership loss has occurred. This does
  * not mean that leadership has been lost; the handler should check the leadership status and act accordingly.
  * <p>
- * This exception may additionally provide a callback that an external environment can use as a mechanism for feedback
- * to the original class, that leadership was indeed lost. This is slightly horrible, but the creation path of the
- * objects that might produce this exception is sufficiently complex that the architecturally preferable solution of
- * passing the leadership coordinator or mechanism for checking if we still have leadership to the relevant objects is
- * not feasible without invasive refactoring, which we don't have the resources for right now.
- * <p>
- * A precondition of this callback is that it does not throw exceptions. If it does, the behaviour of the system is
- * undefined.
- * <p>
- * If leadership was not actually lost,
- * Throwers which require availability must not throw this exception when they are in an irrecoverable state, even if
- * the source of that state is only a possible leadership loss. They should instead consider throwing
- * {@link NotCurrentLeaderException}.
+ * If leadership was not actually lost, the underlying object may be in an inconsistent state, and will be recreated
+ * before further requests are sent to it.
  */
 public class SuspectedNotCurrentLeaderException extends RuntimeException implements SafeLoggable {
     private final String logMessage;

--- a/atlasdb-commons/src/main/java/com/palantir/leader/SuspectedNotCurrentLeaderException.java
+++ b/atlasdb-commons/src/main/java/com/palantir/leader/SuspectedNotCurrentLeaderException.java
@@ -36,7 +36,7 @@ import java.util.List;
  * A precondition of this callback is that it does not throw exceptions. If it does, the behaviour of the system is
  * undefined.
  * <p>
- * If leadership was not actually lost, we assume that requests on throwers should be able to be retried without issue.
+ * If leadership was not actually lost,
  * Throwers which require availability must not throw this exception when they are in an irrecoverable state, even if
  * the source of that state is only a possible leadership loss. They should instead consider throwing
  * {@link NotCurrentLeaderException}.
@@ -44,13 +44,11 @@ import java.util.List;
 public class SuspectedNotCurrentLeaderException extends RuntimeException implements SafeLoggable {
     private final String logMessage;
     private final List<Arg<?>> args;
-    private final Runnable lostLeadershipCallback;
 
     public SuspectedNotCurrentLeaderException(
-            @CompileTimeConstant String logMessage, Runnable lostLeadershipCallback, Arg<?>... args) {
+            @CompileTimeConstant String logMessage, Arg<?>... args) {
         super(SafeExceptions.renderMessage(logMessage, args));
         this.logMessage = logMessage;
-        this.lostLeadershipCallback = lostLeadershipCallback;
         this.args = List.of(args);
     }
 
@@ -62,10 +60,5 @@ public class SuspectedNotCurrentLeaderException extends RuntimeException impleme
     @Override
     public List<Arg<?>> getArgs() {
         return args;
-    }
-
-    public void runLostLeadershipCallback() {
-        // Should only be called if we actually have lost leadership.
-        lostLeadershipCallback.run();
     }
 }

--- a/changelog/@unreleased/pr-6824.v2.yml
+++ b/changelog/@unreleased/pr-6824.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Fixed a TimeLock race condition where it can enter a probabilistic
+    livelock state where a node remains the leader but fails the majority of its requests
+    with 503s.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6824

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -219,9 +219,6 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
                     e);
             cause.addSuppressed(e);
             return StillLeadingStatus.NOT_LEADING;
-        } catch (Exception e) {
-            log.info("Lol lol lol lol lol", e);
-            return StillLeadingStatus.NOT_LEADING;
         }
     }
 }

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -81,7 +81,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         AwaitingLeadershipProxy<U> proxy =
                 new AwaitingLeadershipProxy<>(awaitingLeadership, delegateSupplier, interfaceClass);
         return (U) Proxy.newProxyInstance(
-                interfaceClass.getClassLoader(), new Class<?>[] {interfaceClass, Closeable.class}, proxy);
+                interfaceClass.getClassLoader(), new Class<?>[]{interfaceClass, Closeable.class}, proxy);
     }
 
     @SuppressWarnings("ThrowError") // Possible legacy API
@@ -191,7 +191,6 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
             case NO_QUORUM:
                 // Treating as not leading is consistent with uses of ServiceNotAvailableException elsewhere.
             case NOT_LEADING:
-                cause.runLostLeadershipCallback();
                 leadershipStateManager.handleNotLeading(leadershipToken, cause);
                 break;
             default:

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -82,7 +82,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         AwaitingLeadershipProxy<U> proxy =
                 new AwaitingLeadershipProxy<>(awaitingLeadership, delegateSupplier, interfaceClass);
         return (U) Proxy.newProxyInstance(
-                interfaceClass.getClassLoader(), new Class<?>[]{interfaceClass, Closeable.class}, proxy);
+                interfaceClass.getClassLoader(), new Class<?>[] {interfaceClass, Closeable.class}, proxy);
     }
 
     @SuppressWarnings("ThrowError") // Possible legacy API

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -83,7 +83,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         AwaitingLeadershipProxy<U> proxy =
                 new AwaitingLeadershipProxy<>(awaitingLeadership, delegateSupplier, interfaceClass);
         return (U) Proxy.newProxyInstance(
-                interfaceClass.getClassLoader(), new Class<?>[]{interfaceClass, Closeable.class}, proxy);
+                interfaceClass.getClassLoader(), new Class<?>[] {interfaceClass, Closeable.class}, proxy);
     }
 
     @SuppressWarnings("ThrowError") // Possible legacy API
@@ -203,7 +203,8 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
     }
 
     // Chosen to match past behaviour, where interruptions are propagated to the caller.
-    private StillLeadingStatus determineCurrentLeadershipStatus(LeadershipToken leadershipToken, SuspectedNotCurrentLeaderException cause) throws InterruptedException {
+    private StillLeadingStatus determineCurrentLeadershipStatus(
+            LeadershipToken leadershipToken, SuspectedNotCurrentLeaderException cause) throws InterruptedException {
         try {
             ListenableFuture<StillLeadingStatus> stillLeading = leadershipCoordinator.isStillLeading(leadershipToken);
             return stillLeading.get();
@@ -212,7 +213,10 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
             cause.addSuppressed(e.getCause());
             return StillLeadingStatus.NOT_LEADING;
         } catch (CancellationException e) {
-            log.info("Attempt to check if we were still leading was cancelled. Being defensive, and saying we are not leading.", e);
+            log.info(
+                    "Attempt to check if we were still leading was cancelled. Being defensive, and saying we are not"
+                            + " leading.",
+                    e);
             cause.addSuppressed(e);
             return StillLeadingStatus.NOT_LEADING;
         } catch (Exception e) {

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -28,7 +28,6 @@ import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 import com.palantir.leader.LeaderElectionService.LeadershipToken;
 import com.palantir.leader.LeaderElectionService.StillLeadingStatus;
-import com.palantir.leader.NotCurrentLeaderException;
 import com.palantir.leader.SuspectedNotCurrentLeaderException;
 import com.palantir.leader.proxy.LeadershipStateManager.LeadershipState;
 import com.palantir.logsafe.Preconditions;
@@ -83,7 +82,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         AwaitingLeadershipProxy<U> proxy =
                 new AwaitingLeadershipProxy<>(awaitingLeadership, delegateSupplier, interfaceClass);
         return (U) Proxy.newProxyInstance(
-                interfaceClass.getClassLoader(), new Class<?>[] {interfaceClass, Closeable.class}, proxy);
+                interfaceClass.getClassLoader(), new Class<?>[]{interfaceClass, Closeable.class}, proxy);
     }
 
     @SuppressWarnings("ThrowError") // Possible legacy API

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -168,7 +168,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         if (cause instanceof SuspectedNotCurrentLeaderException) {
             handleSuspectedNotCurrentLeader(leadershipToken, (SuspectedNotCurrentLeaderException) cause);
         }
-        if (cause instanceof ServiceNotAvailableException || cause instanceof NotCurrentLeaderException) {
+        if (cause instanceof ServiceNotAvailableException) {
             leadershipStateManager.invalidateStateOnLostLeadership(leadershipToken, cause);
         }
         // Prevent blocked lock requests from receiving a non-retryable 500 on interrupts

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -81,7 +81,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         AwaitingLeadershipProxy<U> proxy =
                 new AwaitingLeadershipProxy<>(awaitingLeadership, delegateSupplier, interfaceClass);
         return (U) Proxy.newProxyInstance(
-                interfaceClass.getClassLoader(), new Class<?>[]{interfaceClass, Closeable.class}, proxy);
+                interfaceClass.getClassLoader(), new Class<?>[] {interfaceClass, Closeable.class}, proxy);
     }
 
     @SuppressWarnings("ThrowError") // Possible legacy API

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
@@ -37,7 +37,7 @@ public class LeadershipStateManager<T> {
 
     /**
      * delegate reference is atomic as {@link #clearDelegate()} can be accessed by multiple threads.
-     * */
+     */
     private final AtomicReference<T> delegateRef;
 
     private final AtomicReference<LeadershipToken> maybeValidLeadershipTokenRef;
@@ -90,6 +90,7 @@ public class LeadershipStateManager<T> {
     /**
      * This method refreshes the delegateRef which can be a very expensive operation. This should be executed exactly
      * once for one leadershipToken update.
+     *
      * @throws NotCurrentLeaderException if we do not have leadership anymore.
      */
     private void tryToUpdateLeadershipToken() {
@@ -133,6 +134,13 @@ public class LeadershipStateManager<T> {
                 log.warn("problem closing delegate", ex);
             }
         }
+    }
+
+    void handleDelegateNoLongerValid() {
+        // This looks janky af, but there are reasons. Essentially, this forces a recreation on the next call to
+        // getOrUpdateLeadershipToken. We can't just clear the delegate reference, because otherwise there is no impetus
+        // to recreate it.
+        maybeValidLeadershipTokenRef.set(null);
     }
 
     /**

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -116,7 +116,7 @@ public class AwaitingLeadershipProxyTest {
         inProgressCheck.set(StillLeadingStatus.NOT_LEADING);
 
         assertThatThrownBy(future::get).cause().satisfies(exc -> assertThatLoggableException(
-                (Throwable & SafeLoggable) exc)
+                        (Throwable & SafeLoggable) exc)
                 .isInstanceOf(NotCurrentLeaderException.class)
                 .hasLogMessage("method invoked on a non-leader (leadership lost)"));
     }
@@ -370,12 +370,12 @@ public class AwaitingLeadershipProxyTest {
                 .doesNotThrowAnyException();
 
         assertThatCode(() -> {
-            proxy.val();
-            bystanderProxy.val();
-            proxy.val();
-            bystanderProxy.val();
-            proxy.val();
-        })
+                    proxy.val();
+                    bystanderProxy.val();
+                    proxy.val();
+                    bystanderProxy.val();
+                    proxy.val();
+                })
                 .as("the proxies are still able to forward requests")
                 .doesNotThrowAnyException();
 
@@ -397,9 +397,9 @@ public class AwaitingLeadershipProxyTest {
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-            loseLeadershipOnLeaderElectionService(StillLeadingStatus.NOT_LEADING);
-            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-        })
+                    loseLeadershipOnLeaderElectionService(StillLeadingStatus.NOT_LEADING);
+                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+                })
                 .when(mock)
                 .val();
 
@@ -422,9 +422,9 @@ public class AwaitingLeadershipProxyTest {
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-            loseLeadershipOnLeaderElectionService(StillLeadingStatus.NO_QUORUM);
-            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-        })
+                    loseLeadershipOnLeaderElectionService(StillLeadingStatus.NO_QUORUM);
+                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+                })
                 .when(mock)
                 .val();
 
@@ -449,8 +449,8 @@ public class AwaitingLeadershipProxyTest {
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-        })
+                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+                })
                 .when(mock)
                 .val();
 
@@ -486,8 +486,8 @@ public class AwaitingLeadershipProxyTest {
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-        })
+                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+                })
                 .when(mock)
                 .val();
 

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -340,7 +340,8 @@ public class AwaitingLeadershipProxyTest {
     }
 
     @Test
-    public void clearsOnlyRelevantDelegateOnSuspectedNotCurrentLeaderFalseAlarm() throws IOException {
+    public void clearsOnlyRelevantDelegateOnSuspectedNotCurrentLeaderFalseAlarm()
+            throws IOException, InterruptedException {
         MyCloseable mock = mock(MyCloseable.class);
         doThrow(new SuspectedNotCurrentLeaderException("There is one imposter among us"))
                 .doNothing()
@@ -354,6 +355,8 @@ public class AwaitingLeadershipProxyTest {
         Supplier<MyCloseable> bystanderFactory = createSpyableSupplier(bystander);
         MyCloseable bystanderProxy =
                 AwaitingLeadershipProxy.newProxyInstance(MyCloseable.class, bystanderFactory, coordinator);
+
+        waitForLeadershipToBeGained();
 
         bystanderProxy.val();
 

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -115,7 +115,7 @@ public class AwaitingLeadershipProxyTest {
         inProgressCheck.set(StillLeadingStatus.NOT_LEADING);
 
         assertThatThrownBy(future::get).cause().satisfies(exc -> assertThatLoggableException(
-                (Throwable & SafeLoggable) exc)
+                        (Throwable & SafeLoggable) exc)
                 .isInstanceOf(NotCurrentLeaderException.class)
                 .hasLogMessage("method invoked on a non-leader (leadership lost)"));
     }
@@ -366,12 +366,12 @@ public class AwaitingLeadershipProxyTest {
                 .doesNotThrowAnyException();
 
         assertThatCode(() -> {
-            proxy.val();
-            bystanderProxy.val();
-            proxy.val();
-            bystanderProxy.val();
-            proxy.val();
-        })
+                    proxy.val();
+                    bystanderProxy.val();
+                    proxy.val();
+                    bystanderProxy.val();
+                    proxy.val();
+                })
                 .as("the proxies are still able to forward requests")
                 .doesNotThrowAnyException();
 
@@ -390,9 +390,9 @@ public class AwaitingLeadershipProxyTest {
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-            loseLeadershipOnLeaderElectionService(StillLeadingStatus.NOT_LEADING);
-            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-        })
+                    loseLeadershipOnLeaderElectionService(StillLeadingStatus.NOT_LEADING);
+                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+                })
                 .when(mock)
                 .val();
 
@@ -408,17 +408,16 @@ public class AwaitingLeadershipProxyTest {
     }
 
     @Test
-    public void shouldLoseLeadershipOnSuspectedNotCurrentLeaderWhenNoQuorum()
-            throws InterruptedException, IOException {
+    public void shouldLoseLeadershipOnSuspectedNotCurrentLeaderWhenNoQuorum() throws InterruptedException, IOException {
         MyCloseable mock = mock(MyCloseable.class);
         MyCloseable proxy = AwaitingLeadershipProxy.newProxyInstance(
                 MyCloseable.class, () -> mock, LeadershipCoordinator.create(leaderElectionService));
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-            loseLeadershipOnLeaderElectionService(StillLeadingStatus.NO_QUORUM);
-            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-        })
+                    loseLeadershipOnLeaderElectionService(StillLeadingStatus.NO_QUORUM);
+                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+                })
                 .when(mock)
                 .val();
 
@@ -441,10 +440,9 @@ public class AwaitingLeadershipProxyTest {
                 MyCloseable.class, () -> mock, LeadershipCoordinator.create(leaderElectionService));
         waitForLeadershipToBeGained();
 
-
         doAnswer(_invocation -> {
-            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-        })
+                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+                })
                 .when(mock)
                 .val();
 

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -517,7 +517,7 @@ public class AwaitingLeadershipProxyTest {
     private void loseLeadershipOnLeaderElectionService(StillLeadingStatus leadingStatus) throws InterruptedException {
         Preconditions.checkState(
                 leadingStatus != StillLeadingStatus.LEADING,
-                "Cannot lose leadership status and think that we are still leading");
+                "Cannot lose leadership and think that we are still leading");
 
         when(leaderElectionService.isStillLeading(any())).thenReturn(Futures.immediateFuture(leadingStatus));
         when(leaderElectionService.blockOnBecomingLeader()).thenAnswer(invocation -> {

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -115,7 +115,7 @@ public class AwaitingLeadershipProxyTest {
         inProgressCheck.set(StillLeadingStatus.NOT_LEADING);
 
         assertThatThrownBy(future::get).cause().satisfies(exc -> assertThatLoggableException(
-                (Throwable & SafeLoggable) exc)
+                        (Throwable & SafeLoggable) exc)
                 .isInstanceOf(NotCurrentLeaderException.class)
                 .hasLogMessage("method invoked on a non-leader (leadership lost)"));
     }
@@ -367,12 +367,12 @@ public class AwaitingLeadershipProxyTest {
                 .doesNotThrowAnyException();
 
         assertThatCode(() -> {
-            proxy.val();
-            bystanderProxy.val();
-            proxy.val();
-            bystanderProxy.val();
-            proxy.val();
-        })
+                    proxy.val();
+                    bystanderProxy.val();
+                    proxy.val();
+                    bystanderProxy.val();
+                    proxy.val();
+                })
                 .as("the proxies are still able to forward requests")
                 .doesNotThrowAnyException();
 
@@ -391,9 +391,9 @@ public class AwaitingLeadershipProxyTest {
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-            loseLeadershipOnLeaderElectionService(StillLeadingStatus.NOT_LEADING);
-            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-        })
+                    loseLeadershipOnLeaderElectionService(StillLeadingStatus.NOT_LEADING);
+                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+                })
                 .when(mock)
                 .val();
 
@@ -417,9 +417,9 @@ public class AwaitingLeadershipProxyTest {
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-            loseLeadershipOnLeaderElectionService(StillLeadingStatus.NO_QUORUM);
-            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-        })
+                    loseLeadershipOnLeaderElectionService(StillLeadingStatus.NO_QUORUM);
+                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+                })
                 .when(mock)
                 .val();
 

--- a/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
+++ b/leader-election-impl/src/test/java/com/palantir/leader/proxy/AwaitingLeadershipProxyTest.java
@@ -116,7 +116,7 @@ public class AwaitingLeadershipProxyTest {
         inProgressCheck.set(StillLeadingStatus.NOT_LEADING);
 
         assertThatThrownBy(future::get).cause().satisfies(exc -> assertThatLoggableException(
-                        (Throwable & SafeLoggable) exc)
+                (Throwable & SafeLoggable) exc)
                 .isInstanceOf(NotCurrentLeaderException.class)
                 .hasLogMessage("method invoked on a non-leader (leadership lost)"));
     }
@@ -370,12 +370,12 @@ public class AwaitingLeadershipProxyTest {
                 .doesNotThrowAnyException();
 
         assertThatCode(() -> {
-                    proxy.val();
-                    bystanderProxy.val();
-                    proxy.val();
-                    bystanderProxy.val();
-                    proxy.val();
-                })
+            proxy.val();
+            bystanderProxy.val();
+            proxy.val();
+            bystanderProxy.val();
+            proxy.val();
+        })
                 .as("the proxies are still able to forward requests")
                 .doesNotThrowAnyException();
 
@@ -397,9 +397,9 @@ public class AwaitingLeadershipProxyTest {
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-                    loseLeadershipOnLeaderElectionService(StillLeadingStatus.NOT_LEADING);
-                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-                })
+            loseLeadershipOnLeaderElectionService(StillLeadingStatus.NOT_LEADING);
+            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+        })
                 .when(mock)
                 .val();
 
@@ -422,9 +422,9 @@ public class AwaitingLeadershipProxyTest {
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-                    loseLeadershipOnLeaderElectionService(StillLeadingStatus.NO_QUORUM);
-                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-                })
+            loseLeadershipOnLeaderElectionService(StillLeadingStatus.NO_QUORUM);
+            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+        })
                 .when(mock)
                 .val();
 
@@ -439,6 +439,7 @@ public class AwaitingLeadershipProxyTest {
         verify(mock).close();
     }
 
+    // TODO (jkong): Collapse this test and the next into a single Parameterised one when we move to JUnit 5.
     @Test
     public void shouldLoseLeadershipOnSuspectedNotCurrentLeaderWhenFailingToCheckLeadershipState()
             throws InterruptedException, IOException {
@@ -448,8 +449,8 @@ public class AwaitingLeadershipProxyTest {
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-                })
+            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+        })
                 .when(mock)
                 .val();
 
@@ -485,8 +486,8 @@ public class AwaitingLeadershipProxyTest {
         waitForLeadershipToBeGained();
 
         doAnswer(_invocation -> {
-                    throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
-                })
+            throw new SuspectedNotCurrentLeaderException("There is one imposter among us");
+        })
                 .when(mock)
                 .val();
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -228,7 +228,7 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
      */
     @Override
     public synchronized void storeUpperLimit(long limit) throws MultipleRunningTimestampServiceError {
-        Preconditions.checkState(!hasLostLeadership, "Cannot store upper limit as leadership has been lost.");
+        Preconditions.checkState(!hasLostLeadership, "Cannot store upper limit as leadership has been lost, or this store is no longer current.");
         long newSeq = PaxosAcceptor.NO_LOG_ENTRY + 1;
         if (agreedState != null) {
             Preconditions.checkArgument(

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -119,9 +119,8 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
      * <p>
      * The semantics of this method are as follows:
      * - If any learner knows that a value has already been agreed for this sequence number, return said value.
-     * - Otherwise, poll learners for the state of the previous sequence number.
-     * - If this is unavailable, the cluster must have agreed on (seq - 2), so read it and then force (seq - 1)
-     * to that value.
+     * - Otherwise, poll learners for the state of the previous sequence number. If this is unavailable, the cluster
+     * must have agreed on (seq - 2), so read it and then force (seq - 1) to that value.
      * - Finally, force agreement for seq to be the same value as that agreed for (seq - 1).
      * <p>
      * This method has a precondition that (seq - 2) must be agreed upon; note that numbers up to and including
@@ -224,7 +223,7 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
      *
      * @param limit the new upper limit to be stored
      * @throws IllegalArgumentException if trying to persist a limit smaller than the agreed limit
-     * @throws NotCurrentLeaderException if the timestamp limit has changed out from under us
+     * @throws SuspectedNotCurrentLeaderException if the timestamp limit has changed out from under us
      */
     @Override
     public synchronized void storeUpperLimit(long limit) throws MultipleRunningTimestampServiceError {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -309,13 +309,14 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
         hasLostLeadership = true;
     }
 
-    private synchronized void throwNotCurrentLeaderException(@CompileTimeConstant String message, Arg<?>... args) {
+    private void throwNotCurrentLeaderException(@CompileTimeConstant String message, Arg<?>... args) {
         markLeadershipLost();
         throw new NotCurrentLeaderException(message, args);
     }
 
     private void throwSuspectedNotCurrentLeaderException(@CompileTimeConstant String message, Arg<?>... args) {
-        throw new SuspectedNotCurrentLeaderException(message, this::markLeadershipLost, args);
+        markLeadershipLost();
+        throw new SuspectedNotCurrentLeaderException(message, args);
     }
 
     /**

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStore.java
@@ -228,7 +228,9 @@ public class PaxosTimestampBoundStore implements TimestampBoundStore {
      */
     @Override
     public synchronized void storeUpperLimit(long limit) throws MultipleRunningTimestampServiceError {
-        Preconditions.checkState(!hasLostLeadership, "Cannot store upper limit as leadership has been lost, or this store is no longer current.");
+        Preconditions.checkState(
+                !hasLostLeadership,
+                "Cannot store upper limit as leadership has been lost, or this store is no longer current.");
         long newSeq = PaxosAcceptor.NO_LOG_ENTRY + 1;
         if (agreedState != null) {
             Preconditions.checkArgument(

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/paxos/PaxosTimestampBoundStoreTest.java
@@ -262,7 +262,8 @@ public class PaxosTimestampBoundStoreTest {
         assertThatThrownBy(() -> store.storeUpperLimit(TIMESTAMP_2))
                 .as("no further requests should be permitted after a SuspectedNotCurrentLeaderException")
                 .isInstanceOf(SafeIllegalStateException.class)
-                .hasMessage("Cannot store upper limit as leadership has been lost, or this store is no longer current.");
+                .hasMessage(
+                        "Cannot store upper limit as leadership has been lost, or this store is no longer current.");
     }
 
     @Test


### PR DESCRIPTION
## General
**Before this PR**:
TimeLock suffers from a race condition that can lead it into a probabilistic livelock state where a node remains the leader but fails the majority of its requests with 503s. More concretely,

* Timelock nodes participate in two distinct Paxos sequences: one for leadership, and one for timestamps.
* There exists a race condition.
    * Node A can win leadership, and then begin a timestamp proposal.
    * Node B can win leadership (with Node A losing it), and then begin a timestamp proposal.
    * Node A’s timestamp proposal wins, even though it views itself as no longer the leader.
    * Node B sees that Node A’s timestamp proposal won, and steps down.
* Normally, this means that no one thinks they are the leader, and there will be another round of Paxos - which is fine. A fresh leadership election will occur; the winner of this will begin a timestamp proposal, and should win since there are probably no more live timestamp proposals going around. Though this isn't quite true if leader election is very fast.
* In this case, that node immediately wins leadership again, because as far as the leader election service is concerned, we did not actually ever lose leadership. Thus, we can create a fresh timestamp bound store and initiate new timestamp proposals. This applies for each namespace, and can cause fresh races as many proposers may be created for a given leadership term, and these can all contend on winning the timestamp paxos.

**After this PR**:
When encountering a Paxos timestamp entry that does not correspond to the current leadership term, we throw `SuspectedNotCurrentLeaderException` instead of `NotCurrentLeaderException`. This is handled in the `LeadershipStateManager`, where we check if we are still the leader - if we are, we _only_ invalidate the current delegate, and not that for all namespaces. I claim this suffices (in the absence of further leader elections):

* Suppose there were N requests being processed by other live PaxosTimestampBoundStores (maybe from past leader election terms or on other nodes). No new requests can come in, since we are the leader and there are no more leader elections.
* Since we reached an error state, that must have been caused by a proposal stemming from at least one of the other N requests.
* We will recreate the timestamp bound store, and this will read the bound proposed by the new node (or some even newer value). But now there are only N-1 (or fewer) requests from other live PaxosTimestampBoundStores that we can race with - at the time we throw an exception, we are not making a live (timestamp) Paxos proposal.
* Eventually, this will converge to zero, at which point our timestamp Paxos proposal should not fail.
* (Previously, because we would interrupt the delegates for all namespaces whenever any one of them complained about the NCLE, this convergence doesn’t exist as it was possible for a delegate to begin a Paxos proposal and then be invalidated.)

==COMMIT_MSG==
Fixed a TimeLock race condition where it can enter a probabilistic livelock state where a node remains the leader but fails the majority of its requests with 503s.
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
- Invalidating the entire timestamp service seems non-ideal, though there are a lot of classes it is uses that are stateful and it's nontrivial to reset this. (Note that simply retrying the request will cause **SEVERE DATA CORRUPTION**(tm) 🔥  because of state elsewhere in the timestamp service that assumes that we own the bound.)
- Please check the mechanism for invalidating/recreating the delegate **very** carefully; I believe it is correct, but that class historically has been fraught with complex concurrency, and needs to be navigated very carefully.
- Is the `isStillLeading` check too expensive? I believe no: checks to the leader election service are batched, and because of real user requests coming in that need to perform this check, I'm pretty sure the relevant Autobatcher is very busy anyway.

**Is documentation needed?**: No, or at least not other than on this PR.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes - during a blue-green deploy, the nodes on the previous version will still be vulnerable to this bug, but that's it.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing specific

**What was existing testing like? What have you done to improve it?**: I added some tests for the cases in ALP and PTBS that use the new behaviour.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: I believe so: see arguments inline.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: The only one that's really relevant here is the delegate token/reference, for which I've written the semantics I expect in comments on the class in question.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: We see the cluster recover more quickly when **Suspected**NotCurrentLeaderExceptions are thrown.

**Has the safety of all log arguments been decided correctly?**: Only one logging arg - a SafeArg of an enum.

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: We still have the symptoms of a node not losing leadership but repeatedly recreating its delegates, with the relevant error messages on having the bound changed under us being printed.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: -

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: Maybe, especially if I've got the reasoning about the cost of calling `isStillLeading` incorrect. Though the large stacks are very unlikely to run into this problem anyway.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: If we change the timestamp bound stores to account for resets (not sure if we want to do that ever) this PR can be implemented more efficiently.

## Development Process
**Where should we start reviewing?**: AwaitingLeadershipProxy

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: -

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
