### PR TITLE
Hint GET_ROWS_COLUMN_RANGE in Oracle

### DIFF
--- a/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
+++ b/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/OracleQueryFactory.java
@@ -346,7 +346,10 @@ public class OracleQueryFactory extends AbstractDbQueryFactory {
     protected FullQuery getRowsColumnRangeSubQuery(
             byte[] row, long ts, BatchColumnRangeSelection columnRangeSelection) {
         String query = " /* GET_ROWS_COLUMN_RANGE (" + tableName + ") */ "
-                + "SELECT s.row_name, s.col_name, s.ts" + getValueSubselect("s", true)
+                + "SELECT "
+                + "/*+ NO_INDEX_FFS(@SEL$2 M@SEL$2(" + tableName + ".row_name, " + tableName + ".col_name, "
+                + tableName + ".ts)) */"
+                + " s.row_name, s.col_name, s.ts" + getValueSubselect("s", true)
                 + " FROM ( SELECT m.row_name, m.col_name, max(m.ts) as ts"
                 + getValueSubselectForGroupBy("m")
                 + "   FROM " + tableName + " m"

--- a/changelog/@unreleased/pr-6825.v2.yml
+++ b/changelog/@unreleased/pr-6825.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Hint GET_ROWS_COLUMN_RANGE to avoid bad plan where stats are out of
+    date.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6825

--- a/changelog/@unreleased/pr-6825.v2.yml
+++ b/changelog/@unreleased/pr-6825.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: Hint GET_ROWS_COLUMN_RANGE to avoid bad plan where stats are out of
-    date.
+  description: Hint Oracle GET_ROWS_COLUMN_RANGE to avoid bad plan where stats are
+    out of date.
   links:
   - https://github.com/palantir/atlasdb/pull/6825


### PR DESCRIPTION
## General
**Before this PR**:

In unusual circumstances (where stats are out of date) Oracle can generate the following bad plan:

```
/* UnregisteredSQLString */ ( /* GET_ROWS_COLUMN_RANGE (pt_met__
n_214008720) */ SELECT s.row_name, s.col_name, s.ts, s.val, s.ov
erflow FROM ( SELECT m.row_name, m.col_name, max(m.ts) as ts, MA
X(m.val) KEEP (DENSE_RANK LAST ORDER BY m.ts ASC) AS val, MAX(m.
overflow) KEEP (DENSE_RANK LAST ORDER BY m.ts ASC) AS overflow  
 FROM pt_met__n_214008720 m  WHERE m.row_name = :1     AND m.ts 
< :2   AND m.col_name >= :3  AND m.col_name < :4  GROUP BY m.row
_name, m.col_name ORDER BY m.row_name ASC, m.col_name ASC ) s WH
ERE rownum <= :5 ) ORDER BY row_name ASC, col_name ASC

               Operation                 |             Options              |            Object Name           | Cardinality  |    Bytes     |     Cost
---------------------------------------- | -------------------------------- | -------------------------------- | ------------ | ------------ | ------------
SELECT STATEMENT                         |                                  |                                  |            0 |            0 |            3
 COUNT                                   | STOPKEY                          |                                  |            0 |            0 |            0
  VIEW                                   |                                  |                                  |            1 |         2532 |            3
   SORT                                  | GROUP BY STOPKEY                 |                                  |            1 |         2532 |            3
    FILTER                               |                                  |                                  |            0 |            0 |            0
     INDEX                               | FAST FULL SCAN                   | PK_PT_MET__N_214008720           |            1 |         2532 |            2
```

Performance of this query is terrible of the table is large - massive amounts of IO/buffer gets and CPU.

In all cases, the correct plan is:
```
               Operation                 |             Options              |            Object Name           | Cardinality  |    Bytes     |     Cost
---------------------------------------- | -------------------------------- | -------------------------------- | ------------ | ------------ | ------------
SELECT STATEMENT                         |                                  |                                  |            0 |            0 |            8
 COUNT                                   | STOPKEY                          |                                  |            0 |            0 |            0
  VIEW                                   |                                  |                                  |            2 |         5064 |            8
   SORT                                  | GROUP BY NOSORT                  |                                  |            2 |          100 |            8
    FILTER                               |                                  |                                  |            0 |            0 |            0
     INDEX                               | RANGE SCAN                       | PK_PT_MET__N_3556015040          |          253 |        12650 |            8
```
See PDS-443019 where DB entirely saturated by Targeted sweep issuing these queries.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Hint GET_ROWS_COLUMN_RANGE to avoid bad plan where stats are out of date.
==COMMIT_MSG==

The change here is not perfect, as the queries generated by this code can be UNIONed together by certain API - however this is a relatively unusual use case for consumers of Atlas API on Oracle, and is subject of a larger project to refactor (as there are known performance issues with very large UNIONs PROJECT-8231). When terms are UNIONed together, the hints added here will be ignored.

I've not been able to repro the bad plan and hinted to get a good plan - however I have been able to do the reverse (hint to a bad plan) which is orthogonal, so I know the (complex) hint is logically correct:


Bad plan:
```
SELECT /*+ INDEX_FFS(@SEL$2 M@SEL$2 (pt_met__n_10044.row_name, pt_met__n_10044.col_name, pt_met__n_10044.ts)) */  s.row_name, s.col_name, s.ts, s.val, s.overflow FROM ( SELECT  m.row_name, m.col_name, max(m.ts) as ts, MAX(m.val) KEEP (DENSE_RANK LAST ORDER BY m.ts ASC) AS val, 
MAX(m.overflow) KEEP (DENSE_RANK LAST ORDER BY m.ts ASC) AS overflow  FROM pt_met__n_10044 m  WHERE m.row_name = hextoraw('1234')     AND m.ts < 6666666   AND m.col_name >=  hextoraw('1234')  AND m.col_name <  hextoraw('1234')  
GROUP BY m.row_name, m.col_name ORDER BY m.row_name ASC, m.col_name ASC ) s WHERE rownum <= 100;
```
![image](https://github.com/palantir/atlasdb/assets/69226052/7361782d-0354-4c20-ba08-1997d2903382)


Good plan:
```
SELECT /*+ NO_INDEX_FFS(@SEL$2 M@SEL$2 (pt_met__n_10044.row_name, pt_met__n_10044.col_name, pt_met__n_10044.ts)) */  s.row_name, s.col_name, s.ts, s.val, s.overflow FROM ( SELECT  m.row_name, m.col_name, max(m.ts) as ts, MAX(m.val) KEEP (DENSE_RANK LAST ORDER BY m.ts ASC) AS val, 
MAX(m.overflow) KEEP (DENSE_RANK LAST ORDER BY m.ts ASC) AS overflow  FROM pt_met__n_10044 m  WHERE m.row_name = hextoraw('1234')     AND m.ts < 6666666   AND m.col_name >=  hextoraw('1234')  AND m.col_name <  hextoraw('1234')  
GROUP BY m.row_name, m.col_name ORDER BY m.row_name ASC, m.col_name ASC ) s WHERE rownum <= 100;
```
![image](https://github.com/palantir/atlasdb/assets/69226052/829fb627-5c5a-430d-bb0e-dc3349b11a45)



**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
