### PR TITLE
Immediately invalidate on lost leadership

### DIFF
--- a/changelog/@unreleased/pr-6828.v2.yml
+++ b/changelog/@unreleased/pr-6828.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Immediately invalidate on lost leadership
+  links:
+  - https://github.com/palantir/atlasdb/pull/6828

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -161,7 +161,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         Throwable cause = exception.getCause();
         if (cause instanceof SuspectedNotCurrentLeaderException) {
             handleSuspectedNotCurrentLeader(leadershipToken, (SuspectedNotCurrentLeaderException) cause);
-        } else if (cause instanceof ServiceNotAvailableException) {
+        } else if (cause instanceof ServiceNotAvailableException) { // implicitly covers NotCurrentLeaderException
             throw leadershipStateManager.invalidateStateOnLostLeadership(leadershipToken, cause);
         } else if (cause instanceof InterruptedException) {
             Thread.currentThread().interrupt();

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/AwaitingLeadershipProxy.java
@@ -113,13 +113,8 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
                     // treat a repeated NO_QUORUM as NOT_LEADING; likely we've been cut off from the other nodes
                     // and should assume we're not the leader
                     if (leading == StillLeadingStatus.NOT_LEADING || leading == StillLeadingStatus.NO_QUORUM) {
-                        return Futures.submitAsync(
-                                () -> {
-                                    leadershipStateManager.invalidateStateOnLostLeadership(
-                                            leadershipToken, null /* cause */);
-                                    throw new AssertionError("should not reach here");
-                                },
-                                executionExecutor);
+                        return Futures.immediateFailedFuture(leadershipStateManager.invalidateStateOnLostLeadership(
+                                leadershipToken, null /* cause */));
                     }
 
                     if (isClosed) {
@@ -166,15 +161,16 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
         Throwable cause = exception.getCause();
         if (cause instanceof SuspectedNotCurrentLeaderException) {
             handleSuspectedNotCurrentLeader(leadershipToken, (SuspectedNotCurrentLeaderException) cause);
-        }
-        if (cause instanceof ServiceNotAvailableException) {
-            leadershipStateManager.invalidateStateOnLostLeadership(leadershipToken, cause);
-        }
-        // Prevent blocked lock requests from receiving a non-retryable 500 on interrupts
-        // in case of a leader election.
-        if (cause instanceof InterruptedException && !leadershipCoordinator.isStillCurrentToken(leadershipToken)) {
-            throw leadershipCoordinator.notCurrentLeaderException(
-                    "received an interrupt due to leader election.", cause);
+        } else if (cause instanceof ServiceNotAvailableException) {
+            throw leadershipStateManager.invalidateStateOnLostLeadership(leadershipToken, cause);
+        } else if (cause instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+            if (!leadershipCoordinator.isStillCurrentToken(leadershipToken)) {
+                // Prevent blocked lock requests from receiving a non-retryable 500 on interrupts
+                // in case of a leader election.
+                throw leadershipCoordinator.notCurrentLeaderException(
+                        "received an interrupt due to leader election.", cause);
+            }
         }
         Throwables.propagateIfPossible(cause, Exception.class);
         throw new RuntimeException(cause);
@@ -204,8 +200,7 @@ public final class AwaitingLeadershipProxy<T> extends AbstractInvocationHandler 
                         SafeArg.of("leadershipToken", leadershipToken),
                         SafeArg.of("leadershipStatus", status),
                         cause);
-                leadershipStateManager.invalidateStateOnLostLeadership(leadershipToken, cause);
-                break;
+                throw leadershipStateManager.invalidateStateOnLostLeadership(leadershipToken, cause);
             default:
                 throw new SafeIllegalStateException("Unexpected StillLeadingStatus", SafeArg.of("status", status));
         }

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipCoordinator.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipCoordinator.java
@@ -44,7 +44,7 @@ import javax.annotation.Nullable;
  *
  * {@link LeadershipCoordinator} is finally used by {@link AwaitingLeadershipProxy} instances to check if this node
  *  can service requests or not.
- *
+ * <p>
  * {@link LeadershipCoordinator} relies on {@link LeaderElectionService} for the following -
  * 1. To get leadership token if we are already leading
  * 2. To block on becoming the leader if we not the leader anymore

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
@@ -166,7 +166,7 @@ public class LeadershipStateManager<T> {
 
             leadershipCoordinator.markAsNotLeading(leadershipToken, cause);
         }
-        throw leadershipCoordinator.notCurrentLeaderException(
+        return leadershipCoordinator.notCurrentLeaderException(
                 "method invoked on a non-leader (leadership lost)", cause);
     }
 

--- a/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/proxy/LeadershipStateManager.java
@@ -153,7 +153,8 @@ public class LeadershipStateManager<T> {
      * LeadershipCoordinator has updated its state. Then, the next request can release the delegateRef in
      * `getOrUpdateLeadershipToken`.
      */
-    void invalidateStateOnLostLeadership(final LeadershipToken leadershipToken, @Nullable Throwable cause) {
+    NotCurrentLeaderException invalidateStateOnLostLeadership(
+            LeadershipToken leadershipToken, @Nullable Throwable cause) {
         if (maybeValidLeadershipTokenRef.compareAndSet(leadershipToken, null)) {
             // We are not clearing delegateTokenRef here. This is fine as we are relying on `getOrUpdateLeadershipToken`
             // to claim the resources for the next request if this node loses leadership.


### PR DESCRIPTION
Comments on #6824 , expanding AwaitingLeadershipProxy tests for various scenarios