### PR TITLE
[Antithesis] Buggify - randomly fast forward timestamps

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -370,3 +370,47 @@ acceptedBreaks:
         \ com.palantir.logsafe.Arg<?>[])"
       justification: "Verified that internal consumers are using compiletimeconstant\
         \ strings"
+  "0.977.0":
+    com.palantir.atlasdb:atlasdb-config:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter com.palantir.atlasdb.factory.ImmutableTransactionManagers com.palantir.atlasdb.factory.ImmutableTransactionManagers::withDefaultTimelockClientFactory(===java.util.function.Function<com.palantir.lock.v2.TimelockService,\
+        \ com.palantir.lock.client.TimeLockClient>===)"
+      new: "parameter com.palantir.atlasdb.factory.ImmutableTransactionManagers com.palantir.atlasdb.factory.ImmutableTransactionManagers::withDefaultTimelockClientFactory(===java.util.function.BiFunction<com.palantir.lock.v2.TimelockService,\
+        \ com.palantir.timestamp.TimestampManagementService, com.palantir.lock.client.TimeLockClient>===)"
+      justification: "This is only used for antithesis tests"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter com.palantir.atlasdb.factory.ImmutableTransactionManagers.BuildFinal\
+        \ com.palantir.atlasdb.factory.ImmutableTransactionManagers.BuildFinal::defaultTimelockClientFactory(===java.util.function.Function<com.palantir.lock.v2.TimelockService,\
+        \ com.palantir.lock.client.TimeLockClient>===)"
+      new: "parameter com.palantir.atlasdb.factory.ImmutableTransactionManagers.BuildFinal\
+        \ com.palantir.atlasdb.factory.ImmutableTransactionManagers.BuildFinal::defaultTimelockClientFactory(===java.util.function.BiFunction<com.palantir.lock.v2.TimelockService,\
+        \ com.palantir.timestamp.TimestampManagementService, com.palantir.lock.client.TimeLockClient>===)"
+      justification: "This is only used for antithesis tests"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter com.palantir.atlasdb.factory.ImmutableTransactionManagers.Builder\
+        \ com.palantir.atlasdb.factory.ImmutableTransactionManagers.Builder::defaultTimelockClientFactory(===java.util.function.Function<com.palantir.lock.v2.TimelockService,\
+        \ com.palantir.lock.client.TimeLockClient>===)"
+      new: "parameter com.palantir.atlasdb.factory.ImmutableTransactionManagers.Builder\
+        \ com.palantir.atlasdb.factory.ImmutableTransactionManagers.Builder::defaultTimelockClientFactory(===java.util.function.BiFunction<com.palantir.lock.v2.TimelockService,\
+        \ com.palantir.timestamp.TimestampManagementService, com.palantir.lock.client.TimeLockClient>===)"
+      justification: "This is only used for antithesis tests"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void com.palantir.atlasdb.factory.DefaultLockAndTimestampServiceFactory::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.AtlasDbConfig, com.palantir.refreshable.Refreshable<com.palantir.atlasdb.config.AtlasDbRuntimeConfig>,\
+        \ java.util.function.Supplier<com.palantir.lock.LockService>, java.util.function.Supplier<com.palantir.timestamp.ManagedTimestampService>,\
+        \ com.palantir.timestamp.TimestampStoreInvalidator, com.palantir.conjure.java.api.config.service.UserAgent,\
+        \ java.util.Optional<com.palantir.atlasdb.debug.LockDiagnosticComponents>,\
+        \ com.palantir.dialogue.clients.DialogueClients.ReloadingFactory, java.util.Optional<com.palantir.lock.client.metrics.TimeLockFeedbackBackgroundTask>,\
+        \ java.util.Optional<com.palantir.atlasdb.config.TimeLockRequestBatcherProviders>,\
+        \ java.util.Set<com.palantir.atlasdb.table.description.Schema>, ===java.util.function.Function<com.palantir.lock.v2.TimelockService,\
+        \ com.palantir.lock.client.TimeLockClient>===)"
+      new: "parameter void com.palantir.atlasdb.factory.DefaultLockAndTimestampServiceFactory::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.config.AtlasDbConfig, com.palantir.refreshable.Refreshable<com.palantir.atlasdb.config.AtlasDbRuntimeConfig>,\
+        \ java.util.function.Supplier<com.palantir.lock.LockService>, java.util.function.Supplier<com.palantir.timestamp.ManagedTimestampService>,\
+        \ com.palantir.timestamp.TimestampStoreInvalidator, com.palantir.conjure.java.api.config.service.UserAgent,\
+        \ java.util.Optional<com.palantir.atlasdb.debug.LockDiagnosticComponents>,\
+        \ com.palantir.dialogue.clients.DialogueClients.ReloadingFactory, java.util.Optional<com.palantir.lock.client.metrics.TimeLockFeedbackBackgroundTask>,\
+        \ java.util.Optional<com.palantir.atlasdb.config.TimeLockRequestBatcherProviders>,\
+        \ java.util.Set<com.palantir.atlasdb.table.description.Schema>, ===java.util.function.BiFunction<com.palantir.lock.v2.TimelockService,\
+        \ com.palantir.timestamp.TimestampManagementService, com.palantir.lock.client.TimeLockClient>===)"
+      justification: "This is only used for antithesis tests"

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DefaultLockAndTimestampServiceFactory.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DefaultLockAndTimestampServiceFactory.java
@@ -123,7 +123,7 @@ public final class DefaultLockAndTimestampServiceFactory implements LockAndTimes
                 timeLockFeedbackBackgroundTask,
                 timelockRequestBatcherProviders,
                 schemas,
-                (service, management) -> TimeLockClient.createDefault(service));
+                (service, _management) -> TimeLockClient.createDefault(service));
     }
 
     public DefaultLockAndTimestampServiceFactory(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DefaultLockAndTimestampServiceFactory.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DefaultLockAndTimestampServiceFactory.java
@@ -78,7 +78,7 @@ import com.palantir.timestamp.TimestampStoreInvalidator;
 import com.palantir.util.OptionalResolver;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 public final class DefaultLockAndTimestampServiceFactory implements LockAndTimestampServiceFactory {
@@ -95,7 +95,7 @@ public final class DefaultLockAndTimestampServiceFactory implements LockAndTimes
     private final Optional<TimeLockRequestBatcherProviders> timelockRequestBatcherProviders;
     private final Set<Schema> schemas;
 
-    private final Function<TimelockService, TimeLockClient> timelockClientFactory;
+    private final BiFunction<TimelockService, TimestampManagementService, TimeLockClient> timelockClientFactory;
 
     public DefaultLockAndTimestampServiceFactory(
             MetricsManager metricsManager,
@@ -123,7 +123,7 @@ public final class DefaultLockAndTimestampServiceFactory implements LockAndTimes
                 timeLockFeedbackBackgroundTask,
                 timelockRequestBatcherProviders,
                 schemas,
-                TimeLockClient::createDefault);
+                (service, management) -> TimeLockClient.createDefault(service));
     }
 
     public DefaultLockAndTimestampServiceFactory(
@@ -139,7 +139,7 @@ public final class DefaultLockAndTimestampServiceFactory implements LockAndTimes
             Optional<TimeLockFeedbackBackgroundTask> timeLockFeedbackBackgroundTask,
             Optional<TimeLockRequestBatcherProviders> timelockRequestBatcherProviders,
             Set<Schema> schemas,
-            Function<TimelockService, TimeLockClient> timelockClientFactory) {
+            BiFunction<TimelockService, TimestampManagementService, TimeLockClient> timelockClientFactory) {
         this.metricsManager = metricsManager;
         this.config = config;
         this.runtimeConfig = runtimeConfig;
@@ -174,7 +174,8 @@ public final class DefaultLockAndTimestampServiceFactory implements LockAndTimes
     }
 
     private LockAndTimestampServices withRefreshingLockService(LockAndTimestampServices lockAndTimestampServices) {
-        TimeLockClient timeLockClient = timelockClientFactory.apply(lockAndTimestampServices.timelock());
+        TimeLockClient timeLockClient = timelockClientFactory.apply(
+                lockAndTimestampServices.timelock(), lockAndTimestampServices.managedTimestampService());
         ProfilingTimelockService profilingService = ProfilingTimelockService.create(timeLockClient);
         return ImmutableLockAndTimestampServices.builder()
                 .from(lockAndTimestampServices)

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -207,7 +207,7 @@ public abstract class TransactionManagers {
 
     @Value.Default
     BiFunction<TimelockService, TimestampManagementService, TimeLockClient> defaultTimelockClientFactory() {
-        return (service, management) -> TimeLockClient.createDefault(service);
+        return (service, _management) -> TimeLockClient.createDefault(service);
     }
 
     abstract Optional<LockAndTimestampServiceFactory> lockAndTimestampServiceFactory();

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -136,6 +136,7 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.timestamp.ManagedTimestampService;
+import com.palantir.timestamp.TimestampManagementService;
 import com.palantir.timestamp.TimestampStoreInvalidator;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
@@ -144,6 +145,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -204,8 +206,8 @@ public abstract class TransactionManagers {
     }
 
     @Value.Default
-    Function<TimelockService, TimeLockClient> defaultTimelockClientFactory() {
-        return TimeLockClient::createDefault;
+    BiFunction<TimelockService, TimestampManagementService, TimeLockClient> defaultTimelockClientFactory() {
+        return (service, management) -> TimeLockClient.createDefault(service);
     }
 
     abstract Optional<LockAndTimestampServiceFactory> lockAndTimestampServiceFactory();

--- a/atlasdb-workload-server/build.gradle
+++ b/atlasdb-workload-server/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':atlasdb-client-protobufs')
     implementation project(':atlasdb-config')
     implementation project(':atlasdb-impl-shared')
+    implementation project(':timestamp-api')
     implementation project(':lock-api')
     implementation project(':lock-api-objects')
 

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreFactory.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreFactory.java
@@ -153,8 +153,9 @@ public final class AtlasDbTransactionStoreFactory implements TransactionStoreFac
                 .globalMetricsRegistry(metricsManager.getRegistry())
                 .globalTaggedMetricRegistry(metricsManager.getTaggedRegistry())
                 .runtimeConfigSupplier(atlasDbRuntimeConfig)
-                .defaultTimelockClientFactory(lockService -> TimeLockClient.createDefault(
-                        UnreliableTimeLockService.create(lockService), LOCK_REFRESH_INTERVAL_MS))
+                .defaultTimelockClientFactory((lockService, timestampManagementService) -> TimeLockClient.createDefault(
+                        UnreliableTimeLockService.create(lockService, timestampManagementService),
+                        LOCK_REFRESH_INTERVAL_MS))
                 .build()
                 .serializable();
 

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreFactory.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreFactory.java
@@ -154,7 +154,10 @@ public final class AtlasDbTransactionStoreFactory implements TransactionStoreFac
                 .globalTaggedMetricRegistry(metricsManager.getTaggedRegistry())
                 .runtimeConfigSupplier(atlasDbRuntimeConfig)
                 .defaultTimelockClientFactory((lockService, timestampManagementService) -> TimeLockClient.createDefault(
-                        UnreliableTimeLockService.create(lockService, timestampManagementService),
+                        UnreliableTimeLockService.create(
+                                lockService,
+                                UnreliableTimestampManager.create(
+                                        lockService, timestampManagementService::fastForwardTimestamp)),
                         LOCK_REFRESH_INTERVAL_MS))
                 .build()
                 .serializable();

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/UnreliableTimestampManager.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/UnreliableTimestampManager.java
@@ -38,6 +38,8 @@ public final class UnreliableTimestampManager implements TimestampManager {
 
     // A partition is sized at 2^23 timestamps, and we want to skip through potentially many at a time.
     private static final long THOUSAND_COARSE_PARTITIONS_SIZE = 1000 * (1L << 23);
+
+    // This is a SecureRandom whose seed can be set by the Antithesis framework.
     private static final SecureRandom SECURE_RANDOM = DefaultNativeSamplingSecureRandomFactory.INSTANCE.create();
     private final ReadWriteLock timestampLock;
     private final TimelockService delegate;

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/UnreliableTimestampManager.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/UnreliableTimestampManager.java
@@ -1,0 +1,123 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.store;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.atlasdb.buggify.impl.DefaultNativeSamplingSecureRandomFactory;
+import com.palantir.lock.client.TimestampManager;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.timestamp.TimestampRange;
+import java.security.SecureRandom;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.LongConsumer;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+public final class UnreliableTimestampManager implements TimestampManager {
+    private static final SafeLogger log = SafeLoggerFactory.get(UnreliableTimestampManager.class);
+
+    // A partition is sized at 2^23 timestamps, and we want to skip through potentially many at a time.
+    private static final long THOUSAND_COARSE_PARTITIONS_SIZE = 1000 * (1L << 23);
+    private static final SecureRandom SECURE_RANDOM = DefaultNativeSamplingSecureRandomFactory.INSTANCE.create();
+    private final ReadWriteLock timestampLock;
+    private final TimelockService delegate;
+
+    private final LongSupplier getFreshTimestamp;
+    private final LongConsumer fastForwardTimestamp;
+
+    static UnreliableTimestampManager create(TimelockService timelockService, LongConsumer randomlyIncreaseTimestamp) {
+        return new UnreliableTimestampManager(
+                timelockService, timelockService::getFreshTimestamp, randomlyIncreaseTimestamp);
+    }
+
+    @VisibleForTesting
+    static UnreliableTimestampManager create(
+            TimelockService timelockService, LongSupplier getFreshTimestamp, LongConsumer fastForwardTimestamp) {
+        return new UnreliableTimestampManager(timelockService, getFreshTimestamp, fastForwardTimestamp);
+    }
+
+    private UnreliableTimestampManager(
+            TimelockService delegate, LongSupplier getFreshTimestamp, LongConsumer fastForwardTimestamp) {
+        // Fast forward doesn't actually verify it's going forward, so we need to make sure we don't end up
+        // with a situation where we buggify -> getFreshTimestamp -> calculate next timestamp -> get stuck
+        // while the timestamp progresses, then the original thread then fast forwards (but actually goes back in time)
+        // It's an unfair lock to add more chaos to the buggified requests.
+        timestampLock = new ReentrantReadWriteLock(false);
+        this.delegate = delegate;
+        this.getFreshTimestamp = getFreshTimestamp;
+        this.fastForwardTimestamp = fastForwardTimestamp;
+    }
+
+    @Override
+    public void randomlyIncreaseTimestamp() {
+        runWithWriteLock(() -> {
+            long currentTimestamp = getFreshTimestamp.getAsLong();
+            long newTimestamp = SECURE_RANDOM
+                    .longs(1, currentTimestamp + 1, currentTimestamp + THOUSAND_COARSE_PARTITIONS_SIZE)
+                    .findFirst()
+                    .getAsLong();
+            log.info(
+                    "BUGGIFY: Increasing timestamp from {} to {}",
+                    SafeArg.of("currentTimestamp", currentTimestamp),
+                    SafeArg.of("newTimestamp", newTimestamp));
+            fastForwardTimestamp.accept(newTimestamp);
+            return null;
+        });
+    }
+
+    @Override
+    public long getFreshTimestamp() {
+        return runWithReadLock(delegate::getFreshTimestamp);
+    }
+
+    @Override
+    public long getCommitTimestamp(long startTs, LockToken commitLocksToken) {
+        return runWithReadLock(() -> delegate.getCommitTimestamp(startTs, commitLocksToken));
+    }
+
+    @Override
+    public TimestampRange getFreshTimestamps(int numTimestampsRequested) {
+        return runWithReadLock(() -> delegate.getFreshTimestamps(numTimestampsRequested));
+    }
+
+    private <T> T runWithReadLock(Supplier<T> task) {
+        Lock lock = timestampLock.readLock();
+        lock.lock();
+        try {
+            return task.get();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private <T> T runWithWriteLock(Supplier<T> task) {
+        Lock lock = timestampLock.writeLock();
+        lock.lock();
+
+        try {
+            return task.get();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/UnreliableTimestampManagerTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/UnreliableTimestampManagerTest.java
@@ -1,0 +1,170 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Iterables;
+import com.palantir.lock.client.TimestampManager;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.TimelockService;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UnreliableTimestampManagerTest {
+
+    @Mock
+    private TimelockService timelockService;
+
+    @Test
+    public void randomlyIncreaseTimestampRandomlyIncreasesTimestamp() {
+        List<Long> allValues = new ArrayList<>(List.of(0L));
+        UnreliableTimestampManager timestampManager =
+                UnreliableTimestampManager.create(timelockService, () -> Iterables.getLast(allValues), allValues::add);
+        for (int i = 0; i < 10; i++) {
+            timestampManager.randomlyIncreaseTimestamp();
+        }
+
+        assertListRandomlyIncreasesInValue(allValues);
+    }
+
+    @Test
+    public void randomlyIncreaseTimestampRandomlyIncreasesTimestampWithMultipleThreads() throws InterruptedException {
+        ArrayList<Long> allValues = new ArrayList<>(List.of(0L));
+        UnreliableTimestampManager timestampManager = createThreadsafeArrayBackedTimestampManager(allValues);
+
+        ExecutorService executor = Executors.newCachedThreadPool();
+        try {
+            for (int i = 0; i < 10; i++) {
+                executor.execute(timestampManager::randomlyIncreaseTimestamp);
+            }
+        } finally {
+            executor.shutdown();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+
+        assertListRandomlyIncreasesInValue(allValues);
+    }
+
+    @ParameterizedTest
+    @MethodSource("timestampMethods")
+    public void gettingTimestampsBlocksOnPendingFastForward(Consumer<TimestampManager> task)
+            throws InterruptedException {
+        CountDownLatch startingFastForward = new CountDownLatch(1);
+        CountDownLatch blockFastForward = new CountDownLatch(1);
+
+        UnreliableTimestampManager timestampManager =
+                UnreliableTimestampManager.create(timelockService, () -> 0L, _value -> {
+                    startingFastForward.countDown();
+                    try {
+                        blockFastForward.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        ExecutorService executor = Executors.newCachedThreadPool();
+        try {
+            Future<?> increaseTimestampFuture = executor.submit(timestampManager::randomlyIncreaseTimestamp);
+            startingFastForward.await();
+            Future<?> getTimestamp = executor.submit(() -> task.accept(timestampManager));
+            assertThat(getTimestamp).isNotDone();
+            blockFastForward.countDown();
+            assertThat(increaseTimestampFuture).succeedsWithin(Duration.ofSeconds(1));
+            assertThat(getTimestamp).succeedsWithin(Duration.ofSeconds(1));
+
+        } finally {
+            executor.shutdown();
+            boolean shutdownSuccessfully = executor.awaitTermination(10, TimeUnit.SECONDS);
+            executor.shutdownNow();
+            assertThat(shutdownSuccessfully).isTrue();
+        }
+    }
+
+    private static void assertListRandomlyIncreasesInValue(List<Long> timestamps) {
+        assertThat(timestamps).isSorted();
+        assertThat(new HashSet<>(timestamps)).hasSameSizeAs(timestamps);
+
+        List<Long> differencesBetweenValues = new ArrayList<>();
+        for (int i = 1; i < timestamps.size(); i++) {
+            differencesBetweenValues.add(timestamps.get(i) - timestamps.get(i - 1));
+        }
+
+        // Verifying things increase randomly. We can't assert that every delta is random, since it's possible that at
+        // least one delta is the same as another, but there's a minuscule chance that, in the domain of all longs, we
+        // roll each unique long that we draw, 4 times.
+        assertThat(new HashSet<>(differencesBetweenValues)).hasSizeGreaterThan(differencesBetweenValues.size() / 4);
+    }
+
+    private UnreliableTimestampManager createThreadsafeArrayBackedTimestampManager(List<Long> timestampList) {
+        ReadWriteLock rwlock = new ReentrantReadWriteLock();
+        return UnreliableTimestampManager.create(
+                timelockService,
+                () -> {
+                    Lock lock = rwlock.readLock();
+                    lock.lock();
+                    try {
+                        return Iterables.getLast(timestampList);
+                    } finally {
+                        lock.unlock();
+                    }
+                },
+                value -> {
+                    Lock lock = rwlock.writeLock();
+                    lock.lock();
+                    try {
+                        timestampList.add(value);
+                    } finally {
+                        lock.unlock();
+                    }
+                });
+    }
+
+    static Stream<Named<Consumer<TimestampManager>>> timestampMethods() {
+        return Stream.of(
+                namedTask("getFreshTimestamp", TimestampManager::getFreshTimestamp),
+                namedTask(
+                        "getCommitTimestamp",
+                        service -> service.getCommitTimestamp(1, LockToken.of(UUID.randomUUID()))),
+                namedTask("getFreshTimestamps", service -> service.getFreshTimestamps(10)));
+    }
+
+    private static Named<Consumer<TimestampManager>> namedTask(String name, Consumer<TimestampManager> task) {
+        return Named.of(name, task);
+    }
+}

--- a/changelog/@unreleased/pr-6830.v2.yml
+++ b/changelog/@unreleased/pr-6830.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '[Antithesis] Support randomly fast forwarding timestamps to potentially
+    induce a different class of failures during fuzzing'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6830

--- a/lock-api/src/main/java/com/palantir/lock/client/RandomizedTimestampManager.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RandomizedTimestampManager.java
@@ -23,7 +23,7 @@ import com.palantir.timestamp.TimestampRange;
  * Intended to be used for the {@link UnreliableTimeLockService} to randomly fast-forward the timestamp for the purpose
  * of Antithesis testing.
  */
-public interface TimestampManager {
+public interface RandomizedTimestampManager {
     void randomlyIncreaseTimestamp();
 
     long getFreshTimestamp();

--- a/lock-api/src/main/java/com/palantir/lock/client/TimestampManager.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimestampManager.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.palantir.lock.v2.LockToken;
+import com.palantir.timestamp.TimestampRange;
+
+/**
+ * Intended to be used for the {@link UnreliableTimeLockService} to randomly fast-forward the timestamp for the purpose
+ * of Antithesis testing.
+ */
+public interface TimestampManager {
+    void randomlyIncreaseTimestamp();
+
+    long getFreshTimestamp();
+
+    long getCommitTimestamp(long startTs, LockToken commitLocksToken);
+
+    TimestampRange getFreshTimestamps(int numTimestampsRequested);
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/UnreliableTimeLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/UnreliableTimeLockService.java
@@ -38,7 +38,8 @@ import java.util.stream.Collectors;
 
 /**
  * A version of timelock service that has a chance to randomly lose locks during refresh or immediately after
- * acquiring. This is useful for testing the behavior of clients when locks are lost.
+ * acquiring, or randomly fast forwarding timestamps every time we get a new timestamp.
+ * This is useful for testing the behavior of clients when locks are lost or timestamps randomly jump forward.
  */
 public final class UnreliableTimeLockService implements TimelockService {
     private static final SafeLogger log = SafeLoggerFactory.get(UnreliableTimeLockService.class);
@@ -48,15 +49,16 @@ public final class UnreliableTimeLockService implements TimelockService {
 
     private final TimelockService delegate;
     private final BuggifyFactory buggify;
-    private final TimestampManager timestampManager;
+    private final RandomizedTimestampManager timestampManager;
 
-    public static UnreliableTimeLockService create(TimelockService timelockService, TimestampManager timestampManager) {
+    public static UnreliableTimeLockService create(
+            TimelockService timelockService, RandomizedTimestampManager timestampManager) {
         return new UnreliableTimeLockService(timelockService, timestampManager, DefaultBuggifyFactory.INSTANCE);
     }
 
     @VisibleForTesting
     UnreliableTimeLockService(
-            TimelockService delegate, TimestampManager timestampManager, BuggifyFactory buggifyFactory) {
+            TimelockService delegate, RandomizedTimestampManager timestampManager, BuggifyFactory buggifyFactory) {
         this.delegate = delegate;
         this.buggify = buggifyFactory;
         this.timestampManager = timestampManager;

--- a/lock-api/src/test/java/com/palantir/lock/client/UnreliableTimelockClientTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/UnreliableTimelockClientTest.java
@@ -217,14 +217,6 @@ public final class UnreliableTimelockClientTest {
         return factory;
     }
 
-    // Visible as it's used as a method source
-    static Stream<Named<Consumer<UnreliableTimeLockService>>> timestampMethods() {
-        return Stream.of(
-                namedTask("getFreshTimestamp", UnreliableTimeLockService::getFreshTimestamp),
-                namedTask("getCommitTimestamp", service -> service.getCommitTimestamp(1, LOCK_TOKEN)),
-                namedTask("getFreshTimestamps", service -> service.getFreshTimestamps(10)));
-    }
-
     private static Named<Consumer<UnreliableTimeLockService>> namedTask(
             String name, Consumer<UnreliableTimeLockService> task) {
         return Named.of(name, task);
@@ -242,5 +234,13 @@ public final class UnreliableTimelockClientTest {
         // Verifying things increase randomly. We can't assert that every delta is random, since it's possible that at
         // least one delta is the same as another.
         assertThat(new HashSet<>(differencesBetweenValues)).hasSizeGreaterThan(1);
+    }
+
+    // Visible as it's used as a method source
+    static Stream<Named<Consumer<UnreliableTimeLockService>>> timestampMethods() {
+        return Stream.of(
+                namedTask("getFreshTimestamp", UnreliableTimeLockService::getFreshTimestamp),
+                namedTask("getCommitTimestamp", service -> service.getCommitTimestamp(1, LOCK_TOKEN)),
+                namedTask("getFreshTimestamps", service -> service.getFreshTimestamps(10)));
     }
 }

--- a/lock-api/src/test/java/com/palantir/lock/client/UnreliableTimelockClientTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/UnreliableTimelockClientTest.java
@@ -227,7 +227,7 @@ public final class UnreliableTimelockClientTest {
         assertThat(new HashSet<>(list)).hasSameSizeAs(list);
 
         List<Long> differencesBetweenValues = new ArrayList<>();
-        for (int i = list.size() - 1; i > 0; i--) {
+        for (int i = 1; i < list.size(); i++) {
             differencesBetweenValues.add(list.get(i) - list.get(i - 1));
         }
 


### PR DESCRIPTION
## General
**Before this PR**:
The workload server doesn't really affect timestamps, even though for a myriad of reasons timestamps could be fast forwarded (or at least - don't progress in increments of 1)


**After this PR**:
Now, before getting timestamps, there's a chance that we'll fast forward timestamps before returning the next timestamp. This better mimics what can happen in the real world, and enables better testing of sweep invariants (as sweep partitions are divided by timestamps)

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
The management service has always been exposed via TimestampManager, but now it's in the client factory thing. The client factory is only really used by antithesis testing, and it was added for that. It's a bit wonky though.

Are the probabilities to low / high?
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No


## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/a
**What was existing testing like? What have you done to improve it?**:
Added additional tests to show that things randomly increase. (If I've messed up the locking, antithesis should catch it ;) )

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Antithesis catches bugs
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A

## Development Process
**Where should we start reviewing?**:
UnreliableTimeLockService

**Please tag any other people who should be aware of this PR**:
@jeremyk-91

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
