### PR TITLE
fix(oracle): namespace deleter tests were not included

### DIFF
--- a/atlasdb-dbkvs-tests/build.gradle
+++ b/atlasdb-dbkvs-tests/build.gradle
@@ -51,6 +51,7 @@ task postgresTest(type: Test) {
 task oracleTest(type: Test) {
     maxHeapSize = "1024m"
     include '**/DbKvsOracleTestSuite.class'
+    include '**/OracleNamespaceDeleterTests.class'
     maxParallelForks 2
 }
 

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/SqliteOracleAdapter.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/SqliteOracleAdapter.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.endsWith;
 import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.doAnswer;
@@ -356,8 +355,7 @@ final class SqliteOracleAdapter implements ConnectionSupplier {
                         return null;
                     })
                     .when(spy)
-                    .executeUnregisteredQuery(
-                            AdditionalMatchers.and(startsWith("DROP TABLE"), endsWith("PURGE")), any());
+                    .executeUnregisteredQuery(AdditionalMatchers.and(startsWith("DROP TABLE"), endsWith("PURGE")));
             return spy;
         }
     }


### PR DESCRIPTION
When I added these tests, I did not notice that the unit tests weren't running! Thankfully the integration tests ran and passed. I needed to make a change to the adapter since any() arg matcher doesn't include empty varargs, so tests were spuriously failing.

The reviewer should verify these tests are now running correctly

h/t @barisoyoruk for the tip off