### PR TITLE
Boy/cassandra integration tests

### DIFF
--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -1,5 +1,9 @@
 apply from: "../gradle/shared.gradle"
 
+versionsLock {
+    testProject()
+}
+
 dependencies {
     testImplementation 'com.google.guava:guava'
     testImplementation 'com.palantir.common:streams'

--- a/atlasdb-cassandra-integration-tests/build.gradle
+++ b/atlasdb-cassandra-integration-tests/build.gradle
@@ -1,9 +1,5 @@
 apply from: "../gradle/shared.gradle"
 
-versionsLock {
-    testProject()
-}
-
 dependencies {
     testImplementation 'com.google.guava:guava'
     testImplementation 'com.palantir.common:streams'
@@ -14,46 +10,36 @@ dependencies {
     testImplementation 'org.awaitility:awaitility'
     testImplementation 'org.slf4j:slf4j-api'
     testImplementation 'org.apache.commons:commons-pool2'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
 
     testImplementation project(':atlasdb-api')
+    testImplementation project(":atlasdb-cassandra")
+    testImplementation project(":atlasdb-cli")
     testImplementation project(':atlasdb-client')
     testImplementation project(':atlasdb-client-protobufs')
     testImplementation project(':atlasdb-commons')
+    testImplementation project(":atlasdb-container-test-utils")
+    testImplementation project(":atlasdb-ete-test-utils")
     testImplementation project(':atlasdb-impl-shared')
+    testImplementation project(":atlasdb-tests-shared")
+    testImplementation project(':flake-extension')
+    testImplementation project(":timelock-impl")
     testImplementation project(':timestamp-api')
     testImplementation project(':commons-executors')
 
-    testImplementation project(":atlasdb-cassandra")
-    testImplementation project(":atlasdb-cli")
-    testImplementation project(":atlasdb-tests-shared")
-    testImplementation project(":atlasdb-container-test-utils")
-    testImplementation project(":atlasdb-ete-test-utils")
-    testImplementation project(":timelock-impl")
-
     testImplementation('com.palantir.cassandra:cassandra-all') {
         exclude module: 'junit'
-
-      exclude group: 'org.apache.httpcomponents'
-  }
-  testImplementation ('com.palantir.cassandra:cassandra-thrift') {
-    exclude module: 'junit'
-
-    exclude group: 'org.apache.httpcomponents'
-  }
-
-    testImplementation project(':flake-rule')
-
+        exclude group: 'org.apache.httpcomponents'
+    }
+    testImplementation ('com.palantir.cassandra:cassandra-thrift') {
+        exclude module: 'junit'
+        exclude group: 'org.apache.httpcomponents'
+    }
     testImplementation('com.datastax.cassandra:cassandra-driver-core') {
         exclude(group: 'com.codahale.metrics', module: 'metrics-core')
-    }
-
-    testImplementation 'org.mockito:mockito-core'
-    testImplementation 'com.palantir.docker.compose:docker-compose-rule-core'
-
-    /* TODO(boyoruk): Upgrade all package to JUnit5. */
-    testImplementation 'junit:junit'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine', {
-        because 'allows JUnit 3 and JUnit 4 tests to run'
     }
 }
 
@@ -68,9 +54,12 @@ test {
 task testSubset1(type: Test) {
     include '**/CassandraKeyValueServiceTableCreationIntegrationTest.class'
     include '**/CassandraKeyValueServiceTableManipulationIntegrationTest.class'
-    include '**/CassandraKeyValueServiceTransactionIntegrationTest.class'
+    include '**/TicketsEncodingCassandraKeyValueServiceTransactionIntegrationTest.class'
+    include '**/DirectEncodingCassandraKeyValueServiceTransactionIntegrationTest.class'
+    include '**/TwoStageEncodingCassandraKeyValueServiceTransactionIntegrationTest.class'
     include '**/CassandraKvsAsyncFallbackMechanismsTests.class'
-    include '**/CassandraKvsSerializableTransactionTest.class'
+    include '**/AsyncCassandraKvsSerializableTransactionTest.class'
+    include '**/SyncCassandraKvsSerializableTransactionTest.class'
 }
 
 task testSubset2(type: Test) {
@@ -78,12 +67,16 @@ task testSubset2(type: Test) {
     include '**/*Tests.class'
     exclude '**/CassandraKeyValueServiceTableCreationIntegrationTest.class'
     exclude '**/CassandraKeyValueServiceTableManipulationIntegrationTest.class'
-    exclude '**/CassandraKeyValueServiceTransactionIntegrationTest.class'
+    exclude '**/TicketsEncodingCassandraKeyValueServiceTransactionIntegrationTest.class'
+    exclude '**/DirectEncodingCassandraKeyValueServiceTransactionIntegrationTest.class'
+    exclude '**/TwoStageEncodingCassandraKeyValueServiceTransactionIntegrationTest.class'
     exclude '**/CassandraKvsAsyncFallbackMechanismsTests.class'
-    exclude '**/CassandraKvsSerializableTransactionTest.class'
+    exclude '**/AsyncCassandraKvsSerializableTransactionTest.class'
+    exclude '**/SyncCassandraKvsSerializableTransactionTest.class'
 }
 
 tasks.withType(Test) {
+    useJUnitPlatform()
     testLogging {
         // set options for log level LIFECYCLE
         events "passed", "skipped", "failed"

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceTransactionIntegrationTest.java
@@ -15,95 +15,48 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.Futures;
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.containers.CassandraResource;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
-import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.transaction.api.Transaction;
-import com.palantir.atlasdb.transaction.impl.AbstractTransactionTest;
-import com.palantir.atlasdb.transaction.impl.GetAsyncDelegate;
-import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.impl.AbstractTransactionTestV2;
 import com.palantir.atlasdb.transaction.impl.TransactionSchemaVersionEnforcement;
 import com.palantir.atlasdb.transaction.impl.TransactionTables;
 import com.palantir.atlasdb.transaction.service.SimpleTransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.WriteBatchingTransactionService;
-import com.palantir.flake.FlakeRetryingRule;
-import com.palantir.flake.ShouldRetry;
-import java.util.Arrays;
-import java.util.Collection;
+import com.palantir.flake.FlakeRetryTest;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ShouldRetry // The first test can fail with a TException: No host tried was able to create the keyspace requested.
-@RunWith(Parameterized.class)
-public class CassandraKeyValueServiceTransactionIntegrationTest extends AbstractTransactionTest {
-    private static final String SYNC_TRANSACTIONS_1 = "sync, transactions1";
-    private static final String ASYNC_TRANSACTIONS_2 = "async, transactions2";
-    private static final String ASYNC_TRANSACTIONS_3 = "async, transactions3";
-    private static final Supplier<KeyValueService> KVS_SUPPLIER =
-            Suppliers.memoize(CassandraKeyValueServiceTransactionIntegrationTest::createAndRegisterKeyValueService);
+public abstract class AbstractCassandraKeyValueServiceTransactionIntegrationTest extends AbstractTransactionTestV2 {
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        Object[][] data = new Object[][] {
-            {
-                SYNC_TRANSACTIONS_1,
-                UnaryOperator.identity(),
-                TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION
-            },
-            {
-                ASYNC_TRANSACTIONS_2,
-                (UnaryOperator<Transaction>) GetAsyncDelegate::new,
-                TransactionConstants.TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION
-            },
-            {
-                ASYNC_TRANSACTIONS_3,
-                (UnaryOperator<Transaction>) GetAsyncDelegate::new,
-                TransactionConstants.TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION
-            }
-        };
-        return Arrays.asList(data);
-    }
-
-    @ClassRule
-    public static final CassandraResource CASSANDRA = new CassandraResource(KVS_SUPPLIER);
+    @RegisterExtension
+    public static final CassandraResource CASSANDRA = new CassandraResource();
 
     // This constant exists so that fresh timestamps are always greater than the write timestamps of values used in the
     // test.
     private static final long ONE_BILLION = 1_000_000_000;
 
-    @Rule
-    public final TestRule flakeRetryingRule = new FlakeRetryingRule();
-
-    private final String name;
     private final UnaryOperator<Transaction> transactionWrapper;
     private final int transactionsSchemaVersion;
 
-    public CassandraKeyValueServiceTransactionIntegrationTest(
-            String name, UnaryOperator<Transaction> transactionWrapper, int transactionsSchemaVersion) {
+    public AbstractCassandraKeyValueServiceTransactionIntegrationTest(
+            UnaryOperator<Transaction> transactionWrapper, int transactionsSchemaVersion) {
         super(CASSANDRA, CASSANDRA);
-        this.name = name;
         this.transactionWrapper = transactionWrapper;
         this.transactionsSchemaVersion = transactionsSchemaVersion;
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         advanceTimestamp();
         installTransactionsVersion();
@@ -119,7 +72,7 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
                 transactionSchemaManager, timestampService, timestampManagementService, transactionsSchemaVersion);
     }
 
-    @Test
+    @FlakeRetryTest
     public void canUntangleHighlyConflictingPutUnlessExists() {
         TransactionTables.createTables(keyValueService);
         TransactionTables.truncateTables(keyValueService);
@@ -143,13 +96,6 @@ public class CassandraKeyValueServiceTransactionIntegrationTest extends Abstract
         } catch (KeyAlreadyExistsException ex) {
             // OK
         }
-    }
-
-    private static KeyValueService createAndRegisterKeyValueService() {
-        CassandraKeyValueService kvs =
-                CassandraKeyValueServiceImpl.createForTesting(CASSANDRA.getConfig(), CASSANDRA.getRuntimeConfig());
-        CASSANDRA.registerKvs(kvs);
-        return kvs;
     }
 
     @Override

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKvsSerializableTransactionTest.java
@@ -25,54 +25,27 @@ import com.palantir.atlasdb.sweep.queue.SweepQueue;
 import com.palantir.atlasdb.sweep.queue.SweepQueueReader;
 import com.palantir.atlasdb.sweep.queue.TargetedSweeper;
 import com.palantir.atlasdb.transaction.api.Transaction;
-import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest;
-import com.palantir.atlasdb.transaction.impl.GetAsyncDelegate;
-import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTestV2;
 import com.palantir.atlasdb.transaction.impl.TransactionSchemaVersionEnforcement;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.function.UnaryOperator;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-@RunWith(Parameterized.class)
-public class CassandraKvsSerializableTransactionTest extends AbstractSerializableTransactionTest {
-    @ClassRule
+public abstract class AbstractCassandraKvsSerializableTransactionTest extends AbstractSerializableTransactionTestV2 {
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
-
-    private static final String SYNC_TRANSACTIONS_1 = "sync, transactions1";
-    private static final String ASYNC_TRANSACTIONS_3 = "async, transactions3";
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        Object[][] data = new Object[][] {
-            {
-                SYNC_TRANSACTIONS_1,
-                UnaryOperator.identity(),
-                TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION
-            },
-            {
-                ASYNC_TRANSACTIONS_3,
-                (UnaryOperator<Transaction>) GetAsyncDelegate::new,
-                TransactionConstants.TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION
-            }
-        };
-        return Arrays.asList(data);
-    }
 
     private final UnaryOperator<Transaction> transactionWrapper;
     private final int transactionsSchemaVersion;
 
-    public CassandraKvsSerializableTransactionTest(
-            String name, UnaryOperator<Transaction> transactionWrapper, int transactionsSchemaVersion) {
+    public AbstractCassandraKvsSerializableTransactionTest(
+            UnaryOperator<Transaction> transactionWrapper, int transactionsSchemaVersion) {
         super(CASSANDRA, CASSANDRA);
         this.transactionWrapper = transactionWrapper;
         this.transactionsSchemaVersion = transactionsSchemaVersion;
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         keyValueService.truncateTable(AtlasDbConstants.COORDINATION_TABLE);
         TransactionSchemaVersionEnforcement.ensureTransactionsGoingForwardHaveSchemaVersion(

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AsyncCassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AsyncCassandraKeyValueServiceIntegrationTest.java
@@ -15,16 +15,8 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import com.palantir.atlasdb.containers.CassandraResource;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
-public class CassandraConnectionIntegrationTest {
-    @RegisterExtension
-    public static final CassandraResource CASSANDRA = new CassandraResource();
-
-    @Test
-    public void testAuthProvided() {
-        CASSANDRA.getDefaultKvs();
+public class AsyncCassandraKeyValueServiceIntegrationTest extends AbstractCassandraKeyValueServiceIntegrationTest {
+    public AsyncCassandraKeyValueServiceIntegrationTest() {
+        super(AsyncDelegate::new);
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AsyncCassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AsyncCassandraKvsSerializableTransactionTest.java
@@ -15,16 +15,11 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import com.palantir.atlasdb.containers.CassandraResource;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import com.palantir.atlasdb.transaction.impl.GetAsyncDelegate;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
-public class CassandraConnectionIntegrationTest {
-    @RegisterExtension
-    public static final CassandraResource CASSANDRA = new CassandraResource();
-
-    @Test
-    public void testAuthProvided() {
-        CASSANDRA.getDefaultKvs();
+public class AsyncCassandraKvsSerializableTransactionTest extends AbstractCassandraKvsSerializableTransactionTest {
+    public AsyncCassandraKvsSerializableTransactionTest() {
+        super(GetAsyncDelegate::new, TransactionConstants.TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackedPueTableTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackedPueTableTest.java
@@ -45,10 +45,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CassandraBackedPueTableTest {
     private final KeyValueService kvs = CASSANDRA.getDefaultKvs();
@@ -62,17 +62,17 @@ public class CassandraBackedPueTableTest {
     private final ListeningExecutorService readExecutors =
             MoreExecutors.listeningDecorator(PTExecutors.newFixedThreadPool(10));
 
-    @ClassRule
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
-    @Before
+    @BeforeEach
     public void setup() {
         kvs.createTable(
                 TransactionConstants.TRANSACTIONS2_TABLE,
                 TableMetadata.allDefault().persistToBytes());
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         writeExecutor.shutdownNow();
         readExecutors.shutdownNow();

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackgroundSweeperIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraBackgroundSweeperIntegrationTest.java
@@ -17,12 +17,12 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.palantir.atlasdb.containers.CassandraResource;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.sweep.AbstractBackgroundSweeperIntegrationTest;
+import com.palantir.atlasdb.sweep.AbstractBackgroundSweeperIntegrationTestV2;
 import com.palantir.atlasdb.util.MetricsManagers;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CassandraBackgroundSweeperIntegrationTest extends AbstractBackgroundSweeperIntegrationTest {
-    @ClassRule
+public class CassandraBackgroundSweeperIntegrationTest extends AbstractBackgroundSweeperIntegrationTestV2 {
+    @RegisterExtension
     public static final CassandraResource CASSANDRA =
             new CassandraResource(CassandraBackgroundSweeperIntegrationTest::createKeyValueService);
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolIntegrationTest.java
@@ -42,12 +42,12 @@ import java.util.Set;
 import org.apache.cassandra.thrift.KsDef;
 import org.apache.cassandra.thrift.TokenRange;
 import org.apache.thrift.TException;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CassandraClientPoolIntegrationTest {
-    @ClassRule
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
     private final MetricsManager metricsManager = MetricsManagers.createForTests();
@@ -56,7 +56,7 @@ public class CassandraClientPoolIntegrationTest {
     private Blacklist blacklist;
     private CassandraClientPoolImpl clientPool;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Refreshable<CassandraKeyValueServiceRuntimeConfig> runtimeConfig = CASSANDRA.getRuntimeConfig();
         blacklist = new Blacklist(

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraGetCandidateCellsForSweepingTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraGetCandidateCellsForSweepingTest.java
@@ -21,12 +21,12 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.containers.CassandraResource;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.ImmutableCandidateCellForSweeping;
-import com.palantir.atlasdb.keyvalue.impl.AbstractGetCandidateCellsForSweepingTest;
-import org.junit.ClassRule;
-import org.junit.Test;
+import com.palantir.atlasdb.keyvalue.impl.AbstractGetCandidateCellsForSweepingTestV2;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CassandraGetCandidateCellsForSweepingTest extends AbstractGetCandidateCellsForSweepingTest {
-    @ClassRule
+public class CassandraGetCandidateCellsForSweepingTest extends AbstractGetCandidateCellsForSweepingTestV2 {
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
     public CassandraGetCandidateCellsForSweepingTest() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceAsyncInitializationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceAsyncInitializationTest.java
@@ -19,19 +19,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.atlasdb.containers.UninitializedCassandraResource;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import java.io.IOException;
 import java.time.Duration;
 import org.awaitility.Awaitility;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CassandraKeyValueServiceAsyncInitializationTest {
-    @ClassRule
+    @RegisterExtension
     public static final UninitializedCassandraResource CASSANDRA =
             new UninitializedCassandraResource(CassandraKeyValueServiceAsyncInitializationTest.class);
 
     @Test
-    public void cassandraKvsInitializesAsynchronously() throws IOException, InterruptedException {
+    public void cassandraKvsInitializesAsynchronously() {
         KeyValueService asyncInitializedKvs = CASSANDRA.getAsyncInitializeableKvs();
         assertThat(asyncInitializedKvs.isInitialized()).isFalse();
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceGetRowKeysInRangeTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceGetRowKeysInRangeTest.java
@@ -33,10 +33,10 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CassandraKeyValueServiceGetRowKeysInRangeTest {
     private static final TableReference GET_ROW_KEYS_TABLE = TableReference.createFromFullyQualifiedName("test.rows");
@@ -47,16 +47,16 @@ public class CassandraKeyValueServiceGetRowKeysInRangeTest {
 
     private CassandraKeyValueService kvs;
 
-    @ClassRule
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
-    @Before
+    @BeforeEach
     public void initialize() {
         kvs = CASSANDRA.getDefaultKvs();
         kvs.createTable(GET_ROW_KEYS_TABLE, NO_SWEEP_METADATA);
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         kvs.truncateTable(GET_ROW_KEYS_TABLE);
     }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceMultiCasIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceMultiCasIntegrationTest.java
@@ -17,11 +17,11 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.palantir.atlasdb.containers.CassandraResource;
-import com.palantir.atlasdb.keyvalue.impl.AbstractMultiCasTest;
-import org.junit.ClassRule;
+import com.palantir.atlasdb.keyvalue.impl.AbstractMultiCasTestV2;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CassandraKeyValueServiceMultiCasIntegrationTest extends AbstractMultiCasTest {
-    @ClassRule
+public class CassandraKeyValueServiceMultiCasIntegrationTest extends AbstractMultiCasTestV2 {
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
     public CassandraKeyValueServiceMultiCasIntegrationTest() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceSweepTaskRunnerIntegrationTest.java
@@ -21,14 +21,14 @@ import com.palantir.atlasdb.containers.CassandraResource;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.SweepResults;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
-import com.palantir.atlasdb.sweep.AbstractSweepTaskRunnerTest;
+import com.palantir.atlasdb.sweep.AbstractSweepTaskRunnerTestV2;
 import com.palantir.atlasdb.util.MetricsManagers;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CassandraKeyValueServiceSweepTaskRunnerIntegrationTest extends AbstractSweepTaskRunnerTest {
-    @ClassRule
+public class CassandraKeyValueServiceSweepTaskRunnerIntegrationTest extends AbstractSweepTaskRunnerTestV2 {
+    @RegisterExtension
     public static final CassandraResource CASSANDRA =
             new CassandraResource(CassandraKeyValueServiceSweepTaskRunnerIntegrationTest::createKeyValueService);
 
@@ -53,7 +53,7 @@ public class CassandraKeyValueServiceSweepTaskRunnerIntegrationTest extends Abst
                 MetricsManagers.createForTests(),
                 CASSANDRA.getConfig(),
                 CASSANDRA.getRuntimeConfig(),
-                CassandraTestTools.getMutationProviderWithStartingTimestamp(1_000_000, services));
+                CassandraTestTools.getMutationProviderWithStartingTimestamp(1_000_000, inMemoryTimelockClassExtension));
     }
 
     private void insertMultipleValues(long numInsertions) {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableCreationIntegrationTest.java
@@ -43,9 +43,10 @@ import java.util.stream.IntStream;
 import org.apache.cassandra.thrift.CfDef;
 import org.apache.cassandra.thrift.KsDef;
 import org.apache.thrift.TException;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CassandraKeyValueServiceTableCreationIntegrationTest {
     private static final TableReference GOOD_TABLE = TableReference.createFromFullyQualifiedName("foo.bar");
@@ -54,10 +55,10 @@ public class CassandraKeyValueServiceTableCreationIntegrationTest {
     private static CassandraKeyValueService kvs;
     private static CassandraKeyValueService slowTimeoutKvs;
 
-    @ClassRule
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
-    @BeforeClass
+    @BeforeAll
     public static void initializeKvs() {
         kvs = kvsWithSchemaMutationTimeout(500);
         CASSANDRA.registerKvs(kvs);
@@ -65,7 +66,8 @@ public class CassandraKeyValueServiceTableCreationIntegrationTest {
         CASSANDRA.registerKvs(slowTimeoutKvs);
     }
 
-    @Test(timeout = 10 * 1000)
+    @Test
+    @Timeout(10)
     public void testTableCreationCanOccurAfterError() {
         try {
             kvs.createTable(BAD_TABLE, AtlasDbConstants.GENERIC_TABLE_METADATA);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableManipulationIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceTableManipulationIntegrationTest.java
@@ -31,9 +31,9 @@ import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import java.util.stream.Collectors;
-import org.junit.After;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class CassandraKeyValueServiceTableManipulationIntegrationTest {
     private static final TableReference UPPER_UPPER = TableReference.createFromFullyQualifiedName("TEST.TABLE");
@@ -44,12 +44,12 @@ public class CassandraKeyValueServiceTableManipulationIntegrationTest {
     private static final byte[] SECOND_BYTE_ARRAY = new byte[] {2};
     private static final Cell CELL = Cell.create(BYTE_ARRAY, BYTE_ARRAY);
 
-    private KeyValueService kvs = CASSANDRA.getDefaultKvs();
+    private final KeyValueService kvs = CASSANDRA.getDefaultKvs();
 
-    @ClassRule
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
-    @After
+    @AfterEach
     public void cleanup() {
         kvs.dropTables(kvs.getAllTableNames());
         kvs.truncateTable(AtlasDbConstants.DEFAULT_METADATA_TABLE);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKvsAsyncFallbackMechanismsTests.java
@@ -57,20 +57,20 @@ import com.palantir.refreshable.Refreshable;
 import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import org.junit.After;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CassandraKvsAsyncFallbackMechanismsTests {
     private static final TableReference TEST_TABLE = TableReference.createFromFullyQualifiedName("ns.pt_kvs_test");
     private static final Cell CELL = Cell.create(PtBytes.toBytes("row"), PtBytes.toBytes("column"));
     private static final Map<Cell, Long> TIMESTAMP_BY_CELL = ImmutableMap.of(CELL, 3L);
 
-    @ClassRule
+    @RegisterExtension
     public static final CassandraResource CASSANDRA_RESOURCE = new CassandraResource();
 
     private static final Refreshable<CassandraKeyValueServiceRuntimeConfig> RUNTIME_CONFIG =
@@ -87,7 +87,7 @@ public class CassandraKvsAsyncFallbackMechanismsTests {
     @Mock
     private CassandraAsyncKeyValueServiceFactory factory;
 
-    @After
+    @AfterEach
     public void tearDown() {
         try {
             keyValueService.truncateTables(ImmutableSet.of(TEST_TABLE));

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraNamespaceDeleterIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraNamespaceDeleterIntegrationTest.java
@@ -42,13 +42,13 @@ import org.apache.cassandra.thrift.KsDef;
 import org.apache.cassandra.thrift.NotFoundException;
 import org.apache.thrift.TException;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public final class CassandraNamespaceDeleterIntegrationTest {
 
-    @ClassRule
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
     private final Refreshable<CassandraKeyValueServiceRuntimeConfig> keyValueServiceRuntimeConfig =
@@ -74,7 +74,7 @@ public final class CassandraNamespaceDeleterIntegrationTest {
     private final NamespaceDeleter namespaceDeleterForNamespaceTwo = factory.createNamespaceDeleter(
             keyValueServiceConfigForNamespaceTwo, keyValueServiceRuntimeConfig.map(Optional::of));
 
-    @After
+    @AfterEach
     public void after() throws IOException {
         kvs.close();
         namespaceDeleterForNamespaceOne.deleteAllDataFromNamespace();

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraSweepProgressStoreIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraSweepProgressStoreIntegrationTest.java
@@ -16,11 +16,11 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.palantir.atlasdb.containers.CassandraResource;
-import com.palantir.atlasdb.sweep.progress.AbstractSweepProgressStoreTest;
-import org.junit.ClassRule;
+import com.palantir.atlasdb.sweep.progress.AbstractSweepProgressStoreTestV2;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CassandraSweepProgressStoreIntegrationTest extends AbstractSweepProgressStoreTest {
-    @ClassRule
+public class CassandraSweepProgressStoreIntegrationTest extends AbstractSweepProgressStoreTestV2 {
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
     public CassandraSweepProgressStoreIntegrationTest() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTargetedSweepIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTargetedSweepIntegrationTest.java
@@ -24,13 +24,13 @@ import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence;
-import com.palantir.atlasdb.sweep.AbstractTargetedSweepTest;
+import com.palantir.atlasdb.sweep.AbstractTargetedSweepTestV2;
 import com.palantir.atlasdb.table.description.TableMetadata;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CassandraTargetedSweepIntegrationTest extends AbstractTargetedSweepTest {
-    @ClassRule
+public class CassandraTargetedSweepIntegrationTest extends AbstractTargetedSweepTestV2 {
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
     public CassandraTargetedSweepIntegrationTest() {

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestTools.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTestTools.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import com.palantir.atlasdb.cassandra.CassandraMutationTimestampProvider;
 import com.palantir.atlasdb.cassandra.CassandraMutationTimestampProviders;
 import com.palantir.common.base.Throwables;
-import com.palantir.timelock.paxos.InMemoryTimeLockRule;
+import com.palantir.timelock.paxos.InMemoryTimelockClassExtension;
 import com.palantir.timestamp.ManagedTimestampService;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -57,7 +57,7 @@ public final class CassandraTestTools {
     }
 
     public static CassandraMutationTimestampProvider getMutationProviderWithStartingTimestamp(
-            long timestamp, InMemoryTimeLockRule services) {
+            long timestamp, InMemoryTimelockClassExtension services) {
         ManagedTimestampService timestampService = services.getManagedTimestampService();
         timestampService.fastForwardTimestamp(timestamp);
         return CassandraMutationTimestampProviders.singleLongSupplierBacked(timestampService::getFreshTimestamp);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTimestampIntegrationTest.java
@@ -20,26 +20,24 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.containers.CassandraResource;
-import com.palantir.flake.ShouldRetry;
+import com.palantir.flake.FlakeRetryTest;
 import com.palantir.timestamp.MultipleRunningTimestampServiceError;
 import com.palantir.timestamp.TimestampBoundStore;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ShouldRetry
 public class CassandraTimestampIntegrationTest {
-    @ClassRule
+    @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 
-    private CassandraKeyValueService kv = CASSANDRA.getDefaultKvs();
+    private final CassandraKeyValueService kv = CASSANDRA.getDefaultKvs();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         kv.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
     }
 
-    @Test
+    @FlakeRetryTest
     public void testBounds() {
         TimestampBoundStore ts = CassandraTimestampBoundStore.create(kv);
         long limit = ts.getUpperLimit();
@@ -51,7 +49,7 @@ public class CassandraTimestampIntegrationTest {
         assertThat(ts.getUpperLimit()).isEqualTo(limit + 30);
     }
 
-    @Test
+    @FlakeRetryTest
     public void resilientToMultipleStoreUpperLimitBeforeGet() {
         TimestampBoundStore ts = CassandraTimestampBoundStore.create(kv);
         long limit = ts.getUpperLimit();
@@ -60,7 +58,7 @@ public class CassandraTimestampIntegrationTest {
         assertThat(ts.getUpperLimit()).isEqualTo(limit + 20);
     }
 
-    @Test
+    @FlakeRetryTest
     public void testMultipleThrows() {
         TimestampBoundStore ts = CassandraTimestampBoundStore.create(kv);
         TimestampBoundStore ts2 = CassandraTimestampBoundStore.create(kv);

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/DirectEncodingCassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/DirectEncodingCassandraKeyValueServiceTransactionIntegrationTest.java
@@ -15,16 +15,12 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import com.palantir.atlasdb.containers.CassandraResource;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import java.util.function.UnaryOperator;
 
-public class CassandraConnectionIntegrationTest {
-    @RegisterExtension
-    public static final CassandraResource CASSANDRA = new CassandraResource();
-
-    @Test
-    public void testAuthProvided() {
-        CASSANDRA.getDefaultKvs();
+public class DirectEncodingCassandraKeyValueServiceTransactionIntegrationTest
+        extends AbstractCassandraKeyValueServiceTransactionIntegrationTest {
+    public DirectEncodingCassandraKeyValueServiceTransactionIntegrationTest() {
+        super(UnaryOperator.identity(), TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SyncCassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SyncCassandraKeyValueServiceIntegrationTest.java
@@ -15,16 +15,10 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import com.palantir.atlasdb.containers.CassandraResource;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import java.util.function.UnaryOperator;
 
-public class CassandraConnectionIntegrationTest {
-    @RegisterExtension
-    public static final CassandraResource CASSANDRA = new CassandraResource();
-
-    @Test
-    public void testAuthProvided() {
-        CASSANDRA.getDefaultKvs();
+public class SyncCassandraKeyValueServiceIntegrationTest extends AbstractCassandraKeyValueServiceIntegrationTest {
+    public SyncCassandraKeyValueServiceIntegrationTest() {
+        super(UnaryOperator.identity());
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SyncCassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/SyncCassandraKvsSerializableTransactionTest.java
@@ -15,16 +15,11 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import com.palantir.atlasdb.containers.CassandraResource;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import java.util.function.UnaryOperator;
 
-public class CassandraConnectionIntegrationTest {
-    @RegisterExtension
-    public static final CassandraResource CASSANDRA = new CassandraResource();
-
-    @Test
-    public void testAuthProvided() {
-        CASSANDRA.getDefaultKvs();
+public class SyncCassandraKvsSerializableTransactionTest extends AbstractCassandraKvsSerializableTransactionTest {
+    public SyncCassandraKvsSerializableTransactionTest() {
+        super(UnaryOperator.identity(), TransactionConstants.DIRECT_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TicketsEncodingCassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TicketsEncodingCassandraKeyValueServiceTransactionIntegrationTest.java
@@ -15,16 +15,12 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import com.palantir.atlasdb.containers.CassandraResource;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import com.palantir.atlasdb.transaction.impl.GetAsyncDelegate;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
-public class CassandraConnectionIntegrationTest {
-    @RegisterExtension
-    public static final CassandraResource CASSANDRA = new CassandraResource();
-
-    @Test
-    public void testAuthProvided() {
-        CASSANDRA.getDefaultKvs();
+public class TicketsEncodingCassandraKeyValueServiceTransactionIntegrationTest
+        extends AbstractCassandraKeyValueServiceTransactionIntegrationTest {
+    public TicketsEncodingCassandraKeyValueServiceTransactionIntegrationTest() {
+        super(GetAsyncDelegate::new, TransactionConstants.TICKETS_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
     }
 }

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TwoStageEncodingCassandraKeyValueServiceTransactionIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TwoStageEncodingCassandraKeyValueServiceTransactionIntegrationTest.java
@@ -15,16 +15,12 @@
  */
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import com.palantir.atlasdb.containers.CassandraResource;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import com.palantir.atlasdb.transaction.impl.GetAsyncDelegate;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
 
-public class CassandraConnectionIntegrationTest {
-    @RegisterExtension
-    public static final CassandraResource CASSANDRA = new CassandraResource();
-
-    @Test
-    public void testAuthProvided() {
-        CASSANDRA.getDefaultKvs();
+public class TwoStageEncodingCassandraKeyValueServiceTransactionIntegrationTest
+        extends AbstractCassandraKeyValueServiceTransactionIntegrationTest {
+    public TwoStageEncodingCassandraKeyValueServiceTransactionIntegrationTest() {
+        super(GetAsyncDelegate::new, TransactionConstants.TWO_STAGE_ENCODING_TRANSACTIONS_SCHEMA_VERSION);
     }
 }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraResource.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/CassandraResource.java
@@ -50,16 +50,16 @@ public class CassandraResource implements BeforeAllCallback, AfterAllCallback, K
     }
 
     @Override
-    public void beforeAll(ExtensionContext var1) throws Exception {
-        containers = new ContainersV2(var1.getRequiredTestClass()).with(containerInstance);
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        containers = new ContainersV2(extensionContext.getRequiredTestClass()).with(containerInstance);
         testResourceManager = new TestResourceManagerV2(supplier);
-        containers.beforeAll(var1);
+        containers.beforeAll(extensionContext);
         socksProxy = Containers.getSocksProxy(containerInstance.getServiceName());
     }
 
     @Override
-    public void afterAll(ExtensionContext var1) {
-        testResourceManager.afterAll(var1);
+    public void afterAll(ExtensionContext extensionContext) {
+        testResourceManager.afterAll(extensionContext);
     }
 
     /**

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ContainersV2.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/ContainersV2.java
@@ -90,7 +90,7 @@ public class ContainersV2 implements BeforeAllCallback, AfterAllCallback {
     }
 
     @Override
-    public void beforeAll(ExtensionContext var1) throws IOException, InterruptedException {
+    public void beforeAll(ExtensionContext extensionContext) throws IOException, InterruptedException {
         synchronized (ContainersV2.class) {
             setupShutdownHook();
 
@@ -106,7 +106,7 @@ public class ContainersV2 implements BeforeAllCallback, AfterAllCallback {
     }
 
     @Override
-    public void afterAll(ExtensionContext var1) {
+    public void afterAll(ExtensionContext extensionContext) {
         currentLogCollector.stopExecutor();
     }
 

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/UninitializedCassandraResource.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/UninitializedCassandraResource.java
@@ -26,12 +26,13 @@ import com.palantir.logsafe.Preconditions;
 import java.io.IOException;
 import java.net.Proxy;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-/* TODO(boyoruk): Migrate to JUnit5 */
-public class UninitializedCassandraResource extends ExternalResource {
-    private final CassandraContainer containerInstance = CassandraContainer.throwawayContainer();
-    private final Containers containers;
+public class UninitializedCassandraResource implements BeforeAllCallback, AfterAllCallback {
+    private final CassandraContainerV2 containerInstance = CassandraContainerV2.throwawayContainer();
+    private final ContainersV2 containers;
 
     private KeyValueService kvs;
 
@@ -40,7 +41,7 @@ public class UninitializedCassandraResource extends ExternalResource {
     private Proxy socksProxy;
 
     public UninitializedCassandraResource(Class<?> classToSaveLogsFor) {
-        containers = new Containers(classToSaveLogsFor).with(containerInstance);
+        containers = new ContainersV2(classToSaveLogsFor).with(containerInstance);
     }
 
     public void initialize() {
@@ -53,16 +54,16 @@ public class UninitializedCassandraResource extends ExternalResource {
     }
 
     @Override
-    protected void before() throws Throwable {
-        containers.before();
-        socksProxy = Containers.getSocksProxy(containerInstance.getServiceName());
+    public void beforeAll(ExtensionContext var1) throws IOException, InterruptedException {
+        containers.beforeAll(var1);
+        socksProxy = ContainersV2.getSocksProxy(containerInstance.getServiceName());
         containers.getContainer(containerInstance.getServiceName()).kill();
         containers.getDockerCompose().rm();
         kvs = createKvs();
     }
 
     @Override
-    public void after() {
+    public void afterAll(ExtensionContext var1) {
         if (!initialized.get()) {
             return;
         }

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/UninitializedCassandraResource.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/UninitializedCassandraResource.java
@@ -54,8 +54,8 @@ public class UninitializedCassandraResource implements BeforeAllCallback, AfterA
     }
 
     @Override
-    public void beforeAll(ExtensionContext var1) throws IOException, InterruptedException {
-        containers.beforeAll(var1);
+    public void beforeAll(ExtensionContext extensionContext) throws IOException, InterruptedException {
+        containers.beforeAll(extensionContext);
         socksProxy = ContainersV2.getSocksProxy(containerInstance.getServiceName());
         containers.getContainer(containerInstance.getServiceName()).kill();
         containers.getDockerCompose().rm();
@@ -63,7 +63,7 @@ public class UninitializedCassandraResource implements BeforeAllCallback, AfterA
     }
 
     @Override
-    public void afterAll(ExtensionContext var1) {
+    public void afterAll(ExtensionContext extensionContext) {
         if (!initialized.get()) {
             return;
         }

--- a/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/ete/GradleExtension.java
+++ b/atlasdb-ete-test-utils/src/main/java/com/palantir/atlasdb/ete/GradleExtension.java
@@ -37,7 +37,7 @@ public final class GradleExtension implements BeforeAllCallback {
     }
 
     @Override
-    public void beforeAll(ExtensionContext var1) {
+    public void beforeAll(ExtensionContext extensionContext) {
         if (isRunningOutsideOfGradle()) {
             System.out.println("It looks like you are not running in gradle,"
                     + " performing the required gradle command: " + command); // (authorized)

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TestResourceManagerV2.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TestResourceManagerV2.java
@@ -70,7 +70,7 @@ public class TestResourceManagerV2 implements AfterAllCallback, KvsManager, Tran
     }
 
     @Override
-    public void afterAll(ExtensionContext var1) {
+    public void afterAll(ExtensionContext extensionContext) {
         closeableResources.forEach(resource -> {
             try {
                 resource.close();

--- a/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockClassExtension.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockClassExtension.java
@@ -23,12 +23,12 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 public final class InMemoryTimelockClassExtension extends AbstractInMemoryTimelockExtension
         implements BeforeAllCallback, AfterAllCallback {
     @Override
-    public void beforeAll(ExtensionContext var1) {
+    public void beforeAll(ExtensionContext extensionContext) {
         setup();
     }
 
     @Override
-    public void afterAll(ExtensionContext var1) {
+    public void afterAll(ExtensionContext extensionContext) {
         tearDown();
     }
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockExtension.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockExtension.java
@@ -32,12 +32,12 @@ public final class InMemoryTimelockExtension extends AbstractInMemoryTimelockExt
     }
 
     @Override
-    public void beforeEach(ExtensionContext var1) {
+    public void beforeEach(ExtensionContext extensionContext) {
         setup();
     }
 
     @Override
-    public void afterEach(ExtensionContext var1) {
+    public void afterEach(ExtensionContext extensionContext) {
         tearDown();
     }
 }

--- a/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/TimeLockCorruptionDetectionHelper.java
+++ b/timelock-corruption-detection/src/test/java/com/palantir/timelock/corruption/detection/TimeLockCorruptionDetectionHelper.java
@@ -36,7 +36,7 @@ public final class TimeLockCorruptionDetectionHelper implements BeforeEachCallba
     private final TimeLockCorruptionTestSetup timeLockCorruptionTestSetup = new TimeLockCorruptionTestSetup();
 
     @Override
-    public void beforeEach(ExtensionContext var1) {
+    public void beforeEach(ExtensionContext extensionContext) {
         timeLockCorruptionTestSetup.setup();
     }
 


### PR DESCRIPTION
In [this issue](https://github.com/palantir/atlasdb/issues/6796), we are transitioning our test classes from JUnit4 to JUnit5.

In this pull request, we are upgrading atlasdb-cassandra-integration-tests package completely. For more details, see the comments below.

Note to the review: I highly suggest you to double check if integrations tests under `atlasdb-cassandra-integration-tests` indeed working as they supposed to work. The checks I made are the followings:
- Compare test counts
- Compare runtime durations
- See if standard outputs are somehow similar on CircleCI