### PR TITLE
enable missing atlasdb-multinode-integration-tests

### DIFF
--- a/atlasdb-cassandra-multinode-tests/build.gradle
+++ b/atlasdb-cassandra-multinode-tests/build.gradle
@@ -29,8 +29,17 @@ dependencies {
     testImplementation 'org.assertj:assertj-core'
 
     test {
-        include '**/CassandraSchemaLockTest.class'
-        include '**/OneNodeDownTestSuite.class'
+        exclude "**/LessThanQuorumNodeAvailabilityTest.class"
+        exclude "**/TwoNodesDownGetTest.class"
+        exclude "**/TwoNodesDownMetadataTest.class"
+        exclude "**/TwoNodesDownPutTest.class"
+        exclude "**/TwoNodesDownTableManipulationTest.class"
+        exclude "**/OneNodeDownGetTest.class"
+        exclude "**/OneNodeDownPutTest.class"
+        exclude "**/OneNodeDownMetadataTest.class"
+        exclude "**/OneNodeDownDeleteTest.class"
+        exclude "**/OneNodeDownTableManipulationTest.class"
+        exclude "**/OneNodeDownNodeAvailabilityTest.class"
     }
 
     /* TODO(boyoruk): Upgrade all package to JUnit5. */

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/AbstractDegradedClusterTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/AbstractDegradedClusterTest.java
@@ -58,10 +58,21 @@ public abstract class AbstractDegradedClusterTest {
             new HashMap<>();
 
     private String schemaAtStart;
+    private final boolean withSchemaVersionRecording;
+
+    public AbstractDegradedClusterTest(boolean withSchemaVersionRecording) {
+        this.withSchemaVersionRecording = withSchemaVersionRecording;
+    }
+
+    public AbstractDegradedClusterTest() {
+        this(true);
+    }
 
     @Before
     public void recordSchemaVersion() throws TException {
-        schemaAtStart = getUniqueReachableSchemaVersionOrThrow();
+        if (withSchemaVersionRecording) {
+            schemaAtStart = getUniqueReachableSchemaVersionOrThrow();
+        }
     }
 
     /**
@@ -101,6 +112,9 @@ public abstract class AbstractDegradedClusterTest {
     }
 
     void assertCassandraSchemaChanged() {
+        if (!withSchemaVersionRecording) {
+            throw new IllegalStateException("Cannot assert schema changed without schema version recording");
+        }
         try {
             assertThat(getUniqueReachableSchemaVersionOrThrow()).isNotEqualTo(schemaAtStart);
         } catch (TException e) {
@@ -109,6 +123,9 @@ public abstract class AbstractDegradedClusterTest {
     }
 
     private void assertCassandraSchemaUnchanged() {
+        if (!withSchemaVersionRecording) {
+            throw new IllegalStateException("Cannot assert schema unchanged without schema version recording");
+        }
         try {
             assertThat(getUniqueReachableSchemaVersionOrThrow()).isEqualTo(schemaAtStart);
         } catch (TException e) {

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/AbstractNodeAvailabilityTest.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/AbstractNodeAvailabilityTest.java
@@ -23,6 +23,10 @@ import org.junit.Test;
 
 public abstract class AbstractNodeAvailabilityTest extends AbstractDegradedClusterTest {
 
+    public AbstractNodeAvailabilityTest() {
+        super(false);
+    }
+
     @Override
     void testSetup(CassandraKeyValueService kvs) {
         // noop

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTestSuite.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/OneNodeDownTestSuite.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.containers.ThreeNodeCassandraCluster;
 import java.util.Arrays;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -31,11 +32,14 @@ import org.junit.runners.Suite;
     OneNodeDownTableManipulationTest.class,
     OneNodeDownNodeAvailabilityTest.class
 })
-public final class OneNodeDownTestSuite extends NodesDownTestSetup {
+public final class OneNodeDownTestSuite {
+
+    @ClassRule
+    public static final NodesDownTestSetup setup = new NodesDownTestSetup();
 
     @BeforeClass
     public static void setup() throws Exception {
-        initializeKvsAndDegradeCluster(
+        setup.initializeKvsAndDegradeCluster(
                 Arrays.asList(OneNodeDownTestSuite.class
                         .getAnnotation(Suite.SuiteClasses.class)
                         .value()),

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/ThreeNodesDownTestSuite.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/ThreeNodesDownTestSuite.java
@@ -19,16 +19,19 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.containers.ThreeNodeCassandraCluster;
 import java.util.Arrays;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses(LessThanQuorumNodeAvailabilityTest.class)
-public final class ThreeNodesDownTestSuite extends NodesDownTestSetup {
+public final class ThreeNodesDownTestSuite {
+    @ClassRule
+    public static final NodesDownTestSetup setup = new NodesDownTestSetup();
 
     @BeforeClass
     public static void setup() throws Exception {
-        initializeKvsAndDegradeCluster(
+        setup.initializeKvsAndDegradeCluster(
                 Arrays.asList(ThreeNodesDownTestSuite.class
                         .getAnnotation(Suite.SuiteClasses.class)
                         .value()),

--- a/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/TwoNodesDownTestSuite.java
+++ b/atlasdb-cassandra-multinode-tests/src/test/java/com/palantir/cassandra/multinode/TwoNodesDownTestSuite.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.containers.ThreeNodeCassandraCluster;
 import java.util.Arrays;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -30,11 +31,13 @@ import org.junit.runners.Suite;
     TwoNodesDownPutTest.class,
     TwoNodesDownTableManipulationTest.class
 })
-public final class TwoNodesDownTestSuite extends NodesDownTestSetup {
+public final class TwoNodesDownTestSuite {
+    @ClassRule
+    public static final NodesDownTestSetup setup = new NodesDownTestSetup();
 
     @BeforeClass
     public static void setup() throws Exception {
-        NodesDownTestSetup.initializeKvsAndDegradeCluster(
+        setup.initializeKvsAndDegradeCluster(
                 Arrays.asList(TwoNodesDownTestSuite.class
                         .getAnnotation(Suite.SuiteClasses.class)
                         .value()),

--- a/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
+++ b/atlasdb-container-test-utils/src/main/java/com/palantir/atlasdb/containers/Containers.java
@@ -103,7 +103,7 @@ public class Containers extends ExternalResource {
     }
 
     @Override
-    protected void after() {
+    public void after() {
         currentLogCollector.stopExecutor();
     }
 


### PR DESCRIPTION
In [this issue](https://github.com/palantir/atlasdb/issues/6796), we are transitioning our test classes from JUnit4 to JUnit5.

While upgrading the `atlasdb-multinode-integration-tests`, I noticed that half of the tests were not actually running. With this PR:
- Run the missing tests
- Fix the broken tests (interestingly, these tests have never run since they were implemented.)