### PR TITLE
Trigger antithesis experiment on baseline profile once a week 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,8 +164,7 @@ workflows:
       - trigger-antithesis-simulation
     triggers:
       - schedule:
-          # TODO(lmeireles): Temporarily setting this to every day 10am to test. Should change to once a week.
-          cron: "0 10 * * *"
+          cron: "0 10 * * 1" # Every Monday 10am
           filters:
             branches:
               only: develop

--- a/scripts/circle-ci/trigger-antithesis-simulation.sh
+++ b/scripts/circle-ci/trigger-antithesis-simulation.sh
@@ -5,7 +5,6 @@ if [[ -z "${ANTITHESIS_WEBHOOK_PASSWORD}" ]]; then
   exit 1
 fi
 
-# TODO(lmeireles): should update webhook locator to palantir_atlasdb__baseline__latest when we confirm test works.
-WEBHOOK_LOCATOR="palantir_atlasdb__smoketest__latest"
+WEBHOOK_LOCATOR="palantir_atlasdb__baseline__latest"
 echo "Triggering simulation on Antithesis via the ${WEBHOOK_LOCATOR} webhook."
 curl -v -u "palantir:${ANTITHESIS_WEBHOOK_PASSWORD}" -X POST https://palantir.antithesis.com/api/v1/launch_experiment/${WEBHOOK_LOCATOR}


### PR DESCRIPTION
## General
**Before this PR**:
We were running Antithesis simulations with the smoketest configuration everyday to verify out integration works.

We've verified that we're able to trigger those successfully: https://app.circleci.com/pipelines/github/palantir/atlasdb/15266/workflows/8c48f2af-88b7-4755-9f3b-a752bfdde2ec/jobs/77273

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
We now trigger the Antithesis experiment on the baseline profile, instead of smoketest profile. CI scheduled was updated to run 10am on Mondays instead of 10am every day.
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
