### PR TITLE
TimeLockMigrationEteTest junit5

### DIFF
--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'io.dropwizard:dropwizard-jersey'
     implementation 'javax.ws.rs:javax.ws.rs-api'
     implementation 'org.apache.commons:commons-text'
+
     implementation project(':atlasdb-api')
     implementation project(':atlasdb-client')
     implementation project(':atlasdb-client-protobufs')
@@ -45,14 +46,16 @@ dependencies {
     testImplementation 'com.palantir.conjure.java.api:ssl-config'
     testImplementation 'com.palantir.conjure.java.api:test-utils'
     testImplementation 'com.palantir.conjure.java.runtime:keystores'
+    testImplementation 'com.palantir.docker.compose:docker-compose-rule-core'
     testImplementation 'com.palantir.docker.compose:docker-compose-rule-junit4'
     testImplementation 'com.palantir.docker.proxy:docker-proxy-rule-junit4'
+    testImplementation 'com.palantir.docker.compose:docker-compose-junit-jupiter'
+    testImplementation 'com.palantir.docker.proxy:docker-proxy-junit-jupiter'
     testImplementation 'com.palantir.safe-logging:preconditions'
     testImplementation 'com.palantir.safe-logging:safe-logging'
     testImplementation 'commons-io:commons-io'
     testImplementation 'joda-time:joda-time'
     testImplementation 'org.slf4j:slf4j-api'
-    testImplementation 'com.palantir.docker.compose:docker-compose-rule-core'
     testImplementation 'io.dropwizard:dropwizard-testing'
     testImplementation 'org.assertj:assertj-core'
     testImplementation project(':atlasdb-api')
@@ -68,20 +71,22 @@ dependencies {
     testImplementation project(':lock-api-objects')
     testImplementation project(':timestamp-api')
     testImplementation project(':timestamp-impl')
+
     testImplementation ('com.palantir.cassandra:cassandra-thrift') {
         exclude group: 'commons-logging'
         exclude module: 'junit'
         exclude group: 'org.apache.httpcomponents'
     }
 
-    runtimeOnly project(':atlasdb-dbkvs')
     runtimeOnly project(':atlasdb-cassandra')
+    runtimeOnly project(':atlasdb-dbkvs')
 
     annotationProcessor 'org.immutables:value'
     annotationProcessor project(':atlasdb-processors')
+    testAnnotationProcessor 'org.immutables:value'
+
     compileOnly 'org.immutables:value::annotations'
     compileOnly project(':atlasdb-processors')
-    testAnnotationProcessor 'org.immutables:value'
     testCompileOnly 'org.immutables:value::annotations'
 
     /* TODO(boyoruk): Migrate to JUnit5 */
@@ -196,6 +201,10 @@ test {
         excludeTestsMatching 'com.palantir.atlasdb.ete.suites.SingleClientWithEmbeddedAndPostgresTestSuite'
         excludeTestsMatching 'com.palantir.atlasdb.ete.suites.SingleClientWithEmbeddedAndThreeNodeCassandraTestSuite'
     }
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
 }
 
 distribution {

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/standalone/TimeLockMigrationEteTest.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/standalone/TimeLockMigrationEteTest.java
@@ -18,10 +18,10 @@ package com.palantir.atlasdb.ete.standalone;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.google.common.util.concurrent.Uninterruptibles;
-import com.palantir.atlasdb.ete.Gradle;
-import com.palantir.atlasdb.ete.utilities.DockerClientOrchestrationRule;
-import com.palantir.atlasdb.ete.utilities.DockerClientOrchestrationRule.DockerClientConfiguration;
-import com.palantir.atlasdb.ete.utilities.ImmutableDockerClientConfiguration;
+import com.palantir.atlasdb.ete.GradleExtension;
+import com.palantir.atlasdb.ete.utilities.DockerClientOrchestrationExtension;
+import com.palantir.atlasdb.ete.utilities.DockerClientOrchestrationExtension.DockerClientConfigurationV2;
+import com.palantir.atlasdb.ete.utilities.ImmutableDockerClientConfigurationV2;
 import com.palantir.atlasdb.http.AtlasDbHttpClients;
 import com.palantir.atlasdb.http.TestProxyUtils;
 import com.palantir.atlasdb.todo.ImmutableTodo;
@@ -33,36 +33,45 @@ import com.palantir.conjure.java.config.ssl.TrustContext;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.timestamp.TimestampService;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import org.assertj.core.api.JUnitSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.awaitility.Awaitility;
 import org.immutables.value.Value;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 // We don't use EteSetup because we need much finer-grained control of the orchestration here, compared to the other
 // ETE tests where the general idea is "set up all the containers, and fire".
+@ExtendWith(SoftAssertionsExtension.class)
 public class TimeLockMigrationEteTest {
-    private static final Gradle GRADLE_PREPARE_TASK = Gradle.ensureTaskHasRun(":atlasdb-ete-tests:prepareForEteTests");
-    private static final Gradle DOCKER_TASK = Gradle.ensureTaskHasRun(":timelock-server-distribution:dockerTag");
+
+    @RegisterExtension
+    public static final GradleExtension GRADLE_PREPARE_TASK =
+            GradleExtension.ensureTaskHasRun(":atlasdb-ete-tests:prepareForEteTests");
+
+    @RegisterExtension
+    public static final GradleExtension DOCKER_TASK =
+            GradleExtension.ensureTaskHasRun(":timelock-server-distribution:dockerTag");
 
     private static final TimeLockMigrationTestCase TEST_CASE = TimeLockMigrationTestCase.CASSANDRA_PAXOS;
     private static final TimeLockMigrationTestContext TEST_CONTEXT;
 
     static {
         File embeddedConfig;
-        DockerClientConfiguration dockerClientConfiguration;
+        DockerClientConfigurationV2 dockerClientConfiguration;
         switch (TEST_CASE) {
             case CASSANDRA_PAXOS:
                 embeddedConfig = new File("docker/conf/atlasdb-ete.no-leader.cassandra.yml");
-                dockerClientConfiguration = ImmutableDockerClientConfiguration.builder()
+                dockerClientConfiguration = ImmutableDockerClientConfigurationV2.builder()
                         .initialConfigFile(embeddedConfig)
                         .dockerComposeYmlFile(new File("docker-compose.timelock-migration.cassandra.yml"))
                         .databaseServiceName("cassandra")
@@ -75,7 +84,7 @@ public class TimeLockMigrationEteTest {
                 break;
             case POSTGRES_DB_TIMELOCK:
                 embeddedConfig = new File("docker/conf/atlasdb-ete.no-leader.dbkvs.yml");
-                dockerClientConfiguration = ImmutableDockerClientConfiguration.builder()
+                dockerClientConfiguration = ImmutableDockerClientConfigurationV2.builder()
                         .initialConfigFile(embeddedConfig)
                         .dockerComposeYmlFile(new File("docker-compose.timelock-migration.dbkvs.yml"))
                         .databaseServiceName("postgres")
@@ -93,11 +102,22 @@ public class TimeLockMigrationEteTest {
 
     // Docker Engine daemon only has limited access to the filesystem, if the user is using Docker-Machine
     // Thus ensure the temporary folder is a subdirectory of the user's home directory
-    private static final TemporaryFolder TEMPORARY_FOLDER =
-            new TemporaryFolder(new File(System.getProperty("user.home")));
+    private static final File TEMPORARY_FOLDER;
 
-    private static final DockerClientOrchestrationRule CLIENT_ORCHESTRATION_RULE =
-            new DockerClientOrchestrationRule(TEST_CONTEXT.dockerClientConfiguration(), TEMPORARY_FOLDER);
+    static {
+        try {
+            TEMPORARY_FOLDER = Files.createTempDirectory(
+                            new File(System.getProperty("user.home")).toPath(), "TimeLockMigrationEteTest")
+                    .toFile();
+            TEMPORARY_FOLDER.deleteOnExit();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @RegisterExtension
+    public static final DockerClientOrchestrationExtension CLIENT_ORCHESTRATION_EXTENSION =
+            new DockerClientOrchestrationExtension(TEST_CONTEXT.dockerClientConfiguration(), TEMPORARY_FOLDER);
 
     private static final SslConfiguration SSL_CONFIGURATION =
             SslConfiguration.of(Paths.get("var/security/trustStore.jks"));
@@ -114,18 +134,12 @@ public class TimeLockMigrationEteTest {
     private static final int TIMELOCK_PORT = 8421;
     private static final String TEST_CLIENT = "atlasete";
 
-    @ClassRule
-    public static final RuleChain RULE_CHAIN = RuleChain.outerRule(GRADLE_PREPARE_TASK)
-            .around(DOCKER_TASK)
-            .around(TEMPORARY_FOLDER)
-            .around(CLIENT_ORCHESTRATION_RULE);
+    @InjectSoftAssertions
+    private SoftAssertions softAssertions;
 
-    @Rule
-    public final JUnitSoftAssertions softAssertions = new JUnitSoftAssertions();
-
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
-        CLIENT_ORCHESTRATION_RULE.updateProcessLivenessScript();
+        CLIENT_ORCHESTRATION_EXTENSION.updateProcessLivenessScript();
         waitUntil(serversAreReady());
     }
 
@@ -165,18 +179,18 @@ public class TimeLockMigrationEteTest {
         assertCanNeitherReadNorWrite();
 
         // Do this explicitly to avoid mountains of log spam
-        CLIENT_ORCHESTRATION_RULE.stopAtlasClient();
+        CLIENT_ORCHESTRATION_EXTENSION.stopAtlasClient();
     }
 
     private void upgradeAtlasClientToTimelock() {
-        CLIENT_ORCHESTRATION_RULE.updateClientConfig(TEST_CONTEXT.eteConfigWithTimeLock());
-        CLIENT_ORCHESTRATION_RULE.restartAtlasClient();
+        CLIENT_ORCHESTRATION_EXTENSION.updateClientConfig(TEST_CONTEXT.eteConfigWithTimeLock());
+        CLIENT_ORCHESTRATION_EXTENSION.restartAtlasClient();
         waitUntil(serversAreReady());
     }
 
     private void downgradeAtlasClientFromTimelockWithoutMigration() {
-        CLIENT_ORCHESTRATION_RULE.updateClientConfig(TEST_CONTEXT.eteConfigWithEmbedded());
-        CLIENT_ORCHESTRATION_RULE.restartAtlasClient();
+        CLIENT_ORCHESTRATION_EXTENSION.updateClientConfig(TEST_CONTEXT.eteConfigWithEmbedded());
+        CLIENT_ORCHESTRATION_EXTENSION.restartAtlasClient();
         if (TEST_CASE == TimeLockMigrationTestCase.CASSANDRA_PAXOS) {
             // Doesn't work for Postgres because of extreme volume of logs produced in this way
             waitForTransactionManagerCreationError();
@@ -234,7 +248,7 @@ public class TimeLockMigrationEteTest {
     // Note that this check is a bit hacky, as it depends on finding a particular log message
     private static Callable<Boolean> logsContainTransactionManagerCreationFailure() {
         return () -> {
-            String serverLogs = CLIENT_ORCHESTRATION_RULE.getClientLogs();
+            String serverLogs = CLIENT_ORCHESTRATION_EXTENSION.getClientLogs();
             return serverLogs.contains("IllegalArgumentException trying to convert the stored value to a long.");
         };
     }
@@ -263,7 +277,7 @@ public class TimeLockMigrationEteTest {
 
     @Value.Immutable
     interface TimeLockMigrationTestContext {
-        DockerClientConfiguration dockerClientConfiguration();
+        DockerClientConfigurationV2 dockerClientConfiguration();
 
         File eteConfigWithEmbedded();
 
@@ -272,6 +286,6 @@ public class TimeLockMigrationEteTest {
 
     private enum TimeLockMigrationTestCase {
         CASSANDRA_PAXOS,
-        POSTGRES_DB_TIMELOCK;
+        POSTGRES_DB_TIMELOCK
     }
 }

--- a/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/utilities/DockerClientOrchestrationExtension.java
+++ b/atlasdb-ete-tests/src/test/java/com/palantir/atlasdb/ete/utilities/DockerClientOrchestrationExtension.java
@@ -1,0 +1,180 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.atlasdb.ete.utilities;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.containers.CassandraEnvironment;
+import com.palantir.atlasdb.ete.standalone.TimeLockMigrationEteTest;
+import com.palantir.docker.compose.DockerComposeExtension;
+import com.palantir.docker.compose.connection.DockerMachine;
+import com.palantir.docker.compose.connection.waiting.ClusterHealthCheck;
+import com.palantir.docker.compose.connection.waiting.ClusterWait;
+import com.palantir.docker.compose.connection.waiting.HealthChecks;
+import com.palantir.docker.compose.execution.DockerComposeExecOption;
+import com.palantir.docker.compose.execution.DockerExecutionException;
+import com.palantir.docker.compose.execution.ImmutableDockerComposeExecArgument;
+import com.palantir.docker.compose.logging.LogDirectory;
+import com.palantir.docker.proxy.DockerProxyExtension;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.test.utils.SubdirectoryCreator;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.immutables.value.Value;
+import org.joda.time.Duration;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class DockerClientOrchestrationExtension implements BeforeAllCallback, AfterAllCallback {
+    private static final SafeLogger log = SafeLoggerFactory.get(DockerClientOrchestrationExtension.class);
+
+    private static final String CONTAINER = "ete1";
+    private static final Duration WAIT_TIMEOUT = Duration.standardMinutes(5);
+    private static final int MAX_EXEC_TRIES = 10;
+
+    private final DockerClientConfigurationV2 clientConfiguration;
+    private final File temporaryFolder;
+
+    private DockerComposeExtension dockerComposeExtension;
+    private DockerProxyExtension dockerProxyExtension;
+    private File configFile;
+
+    public DockerClientOrchestrationExtension(
+            DockerClientConfigurationV2 dockerClientConfiguration, File temporaryFolder) {
+        this.clientConfiguration = dockerClientConfiguration;
+        this.temporaryFolder = temporaryFolder;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        try {
+            configFile = SubdirectoryCreator.createAndGetFile(temporaryFolder, "atlasdb-ete.yml");
+            configFile.deleteOnExit();
+            updateClientConfig(clientConfiguration.initialConfigFile());
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+
+        DockerMachine dockerMachine = createDockerMachine();
+        dockerComposeExtension = DockerComposeExtension.builder()
+                .machine(dockerMachine)
+                .file(clientConfiguration.dockerComposeYmlFile().toString())
+                .waitingForService(clientConfiguration.databaseServiceName(), HealthChecks.toHaveAllPortsOpen())
+                .saveLogsTo(LogDirectory.circleAwareLogDirectory(TimeLockMigrationEteTest.class.getSimpleName()))
+                .addClusterWait(new ClusterWait(ClusterHealthCheck.nativeHealthChecks(), WAIT_TIMEOUT))
+                .build();
+        dockerProxyExtension = DockerProxyExtension.fromProjectName(
+                dockerComposeExtension.projectName(), TimeLockMigrationEteTest.class);
+
+        dockerComposeExtension.beforeAll(extensionContext);
+        dockerProxyExtension.beforeAll(extensionContext);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        dockerProxyExtension.afterAll(extensionContext);
+        dockerComposeExtension.afterAll(extensionContext);
+    }
+
+    public void updateProcessLivenessScript() {
+        // Go-Java-Launcher's functionality for seeing if a process is running is not correct with respect to busybox.
+        // See also https://github.com/palantir/sls-packaging/issues/185
+        dockerExecOnClient("sed", "-i", "s/ps $PID > \\/dev\\/null;/kill -0 $PID/", "service/bin/init.sh");
+    }
+
+    public void updateClientConfig(File file) {
+        try {
+            FileUtils.writeStringToFile(configFile, FileUtils.readFileToString(file));
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    public void restartAtlasClient() {
+        runInitShWithVerb("restart");
+    }
+
+    public void stopAtlasClient() {
+        runInitShWithVerb("stop");
+    }
+
+    public String getClientLogs() {
+        return dockerExecOnClient("cat", "var/log/startup.log");
+    }
+
+    private void runInitShWithVerb(String verb) {
+        // Need nohup - otherwise our process is a child of our shell, and will be killed when we're done.
+        dockerExecOnClient("bash", "-c", "nohup service/bin/init.sh " + verb);
+    }
+
+    private DockerMachine createDockerMachine() {
+        return DockerMachine.localMachine().withEnvironment(getEnvironment()).build();
+    }
+
+    private Map<String, String> getEnvironment() {
+        return ImmutableMap.<String, String>builder()
+                .putAll(CassandraEnvironment.get())
+                .put("CONFIG_FILE_MOUNTPOINT", temporaryFolder.getAbsolutePath())
+                .buildOrThrow();
+    }
+
+    private String dockerExecOnClient(String... arguments) {
+        for (int i = 1; i <= MAX_EXEC_TRIES; i++) {
+            try {
+                log.info(
+                        "Attempting docker-exec with arguments: {}",
+                        UnsafeArg.of("arguments", Arrays.asList(arguments)));
+                return dockerComposeExtension.exec(
+                        DockerComposeExecOption.noOptions(),
+                        CONTAINER,
+                        ImmutableDockerComposeExecArgument.arguments(arguments));
+            } catch (InterruptedException | IOException e) {
+                throw Throwables.propagate(e);
+            } catch (DockerExecutionException e) {
+                if (i != MAX_EXEC_TRIES) {
+                    // I have seen very odd flakes where exec terminates with exit code 129
+                    // i.e. they are interrupted with the hangup signal.
+                    log.warn(
+                            "Encountered error in docker-exec, retrying (attempt {} of {})",
+                            SafeArg.of("attempt", i),
+                            SafeArg.of("maxAttempts", MAX_EXEC_TRIES),
+                            e);
+                } else {
+                    log.error("Made {} attempts, and now giving up", SafeArg.of("maxAttempts", MAX_EXEC_TRIES), e);
+                    throw e;
+                }
+            }
+        }
+        throw new IllegalStateException(
+                String.format("Unexpected state after %s unsuccessful attempts in docker-exec", MAX_EXEC_TRIES));
+    }
+
+    @Value.Immutable
+    public interface DockerClientConfigurationV2 {
+        File dockerComposeYmlFile();
+
+        File initialConfigFile();
+
+        String databaseServiceName();
+    }
+}


### PR DESCRIPTION
In [this issue](https://github.com/palantir/atlasdb/issues/6796), we are transitioning our test classes from JUnit4 to JUnit5.

In this pull request, we are upgrading atlasdb-ete-tests package for `TimeLockMigrationEteTest`. For more details, see the comments below.