### PR TITLE
Clarify and add tests for ColumnRangeSelections.createPrefixRange

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelections.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelections.java
@@ -26,6 +26,10 @@ public final class ColumnRangeSelections implements Serializable {
         // Utility class
     }
 
+    /**
+     * Returns a {@link BatchColumnRangeSelection} that can be used with {@link KeyValueService#getRowsColumnRange(TableReference, Iterable, BatchColumnRangeSelection, long)} or
+     * to return the columns that have values beginning with the provided prefix.
+     */
     public static BatchColumnRangeSelection createPrefixRange(byte[] prefix, int batchSize) {
         byte[] startCol =
                 Preconditions.checkNotNull(prefix, "prefix cannot be null").clone();

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelections.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/ColumnRangeSelections.java
@@ -27,7 +27,7 @@ public final class ColumnRangeSelections implements Serializable {
     }
 
     /**
-     * Returns a {@link BatchColumnRangeSelection} that can be used with {@link KeyValueService#getRowsColumnRange(TableReference, Iterable, BatchColumnRangeSelection, long)} or
+     * Returns a {@link BatchColumnRangeSelection} that can be used with {@link KeyValueService#getRowsColumnRange(TableReference, Iterable, BatchColumnRangeSelection, long)}
      * to return the columns that have values beginning with the provided prefix.
      */
     public static BatchColumnRangeSelection createPrefixRange(byte[] prefix, int batchSize) {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequests.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/RangeRequests.java
@@ -56,6 +56,7 @@ public final class RangeRequests {
      * This will return the row name that will include exactly all prefix matches if passed to
      * {@link KeyValueService#getRange(TableReference, RangeRequest, long)}.
      * <p>
+     *
      * @param rowName must be non-null
      */
     public static byte[] createEndNameForPrefixScan(@Nonnull byte[] rowName) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/RangeRequestsTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/RangeRequestsTest.java
@@ -114,6 +114,8 @@ public class RangeRequestsTest {
     public void endNameForPrefixScanOfSingleByteArraysIncrementsTheByte() {
         assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {0})).isEqualTo(new byte[] {1});
         assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {42})).isEqualTo(new byte[] {43});
+
+        // Note: We treat bytes as unsigned, so 127 (0x7f) is followed by -128 (0x80).
         assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {127})).isEqualTo(new byte[] {-128});
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/RangeRequestsTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/RangeRequestsTest.java
@@ -104,6 +104,42 @@ public class RangeRequestsTest {
         assertThat(RangeRequests.isExactlyEmptyRange(BYTES_2, BYTES_2)).isTrue();
     }
 
+    @Test
+    public void endNameForPrefixScanOfEmptyByteArrayIsEmpty() {
+        assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {})).isEmpty();
+    }
+
+    @Test
+    public void endNameForPrefixScanOfSingleByteArraysIncrementsTheByte() {
+        assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {0})).isEqualTo(new byte[] {1});
+        assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {42})).isEqualTo(new byte[] {43});
+        assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {127})).isEqualTo(new byte[] {-128});
+    }
+
+    @Test
+    public void endNameForPrefixScanOfMultiByteArraysIncrementsTheLeastSignificantByte() {
+        assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {0, 1, 2}))
+                .isEqualTo(new byte[] {0, 1, 3});
+        assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {9, 8, 88}))
+                .isEqualTo(new byte[] {9, 8, 89});
+    }
+
+    @Test
+    public void endNameForPrefixScanOfArrayOfMaximalValuedBytesIsEmpty() {
+        assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {(byte) 0xff}))
+                .isEmpty();
+        assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {(byte) 0xff, (byte) 0xff, (byte) 0xff}))
+                .isEmpty();
+    }
+
+    @Test
+    public void endNameForPrefixScanOfArrayEndingInMaximalValuedBytesIncrementsAndCollapses() {
+        assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {2, 3, (byte) 0xff}))
+                .isEqualTo(new byte[] {2, 4});
+        assertThat(RangeRequests.createEndNameForPrefixScan(new byte[] {2, 3, (byte) 0xff, (byte) 0xff}))
+                .isEqualTo(new byte[] {2, 4});
+    }
+
     private byte[] generateRandomWithFreqLogLen() {
         long randomLong = random.nextLong();
         // lg(n) distribution of len


### PR DESCRIPTION
## General
**Before this PR**:
`ColumnRangeSelections.createPrefixRange(byte[])` is undocumented, which could potentially mislead users to interpret it as returning the range `[input, +inf)` as opposed to the range `[input, succ(input))`.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`ColumnRangeSelections.createPrefixRange(byte[])` is documented.
==COMMIT_MSG==

**Priority**: P3

**Concerns / possible downsides (what feedback would you like?)**: None in particular

**Is documentation needed?**: None other than what's in the PR

## Compatibility
No production changes were intended in this PR.

## Testing and Correctness
No production changes were intended in this PR. Tests were added for RangeRequests.endNameForPrefixScan which is the most "interesting" part of the logic for ColumnRangeSelections.createPrefixRange.

## Execution
No production changes were intended in this PR.

## Scale
No production changes were intended in this PR.

## Development Process
**Where should we start reviewing?**: RangeRequestsTest probably to get a feel for what the prefix things look like

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
