### PR TITLE
New timelock clients also log the endpoint name

### DIFF
--- a/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/AbstractInMemoryTimelockExtension.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/AbstractInMemoryTimelockExtension.java
@@ -157,7 +157,7 @@ public abstract class AbstractInMemoryTimelockExtension implements TimeLockServi
 
         RedirectRetryTargeter redirectRetryTargeter = timeLockAgent.redirectRetryTargeter();
         ConjureTimelockService conjureTimelockService = ConjureTimelockResource.jersey(
-                redirectRetryTargeter, (_namespace, _context) -> delegate.getTimelockService());
+                redirectRetryTargeter, (_namespace, _context, _endpointName) -> delegate.getTimelockService());
         namespacedConjureTimelockService = new NamespacedConjureTimelockServiceImpl(conjureTimelockService, client);
         lockLeaseService = LockLeaseService.create(
                 namespacedConjureTimelockService,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockServices.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/InMemoryTimelockServices.java
@@ -161,7 +161,7 @@ public final class InMemoryTimelockServices extends ExternalResource implements 
 
         RedirectRetryTargeter redirectRetryTargeter = timeLockAgent.redirectRetryTargeter();
         ConjureTimelockService conjureTimelockService = ConjureTimelockResource.jersey(
-                redirectRetryTargeter, (_namespace, _context) -> delegate.getTimelockService());
+                redirectRetryTargeter, (_namespace, _context, _endpointName) -> delegate.getTimelockService());
         namespacedConjureTimelockService = new NamespacedConjureTimelockServiceImpl(conjureTimelockService, client);
         lockLeaseService = LockLeaseService.create(
                 namespacedConjureTimelockService,

--- a/changelog/@unreleased/pr-6875.v2.yml
+++ b/changelog/@unreleased/pr-6875.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: New timelock clients also log the endpoint name
+  links:
+  - https://github.com/palantir/atlasdb/pull/6875

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -34,6 +34,7 @@ import com.palantir.atlasdb.timelock.ConjureTimelockResource;
 import com.palantir.atlasdb.timelock.TimeLockServices;
 import com.palantir.atlasdb.timelock.TimelockNamespaces;
 import com.palantir.atlasdb.timelock.TooManyRequestsExceptionMapper;
+import com.palantir.atlasdb.timelock.TriFunction;
 import com.palantir.atlasdb.timelock.adjudicate.FeedbackHandler;
 import com.palantir.atlasdb.timelock.adjudicate.HealthStatusReport;
 import com.palantir.atlasdb.timelock.adjudicate.LeaderElectionMetricAggregator;
@@ -90,7 +91,6 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -318,10 +318,12 @@ public class TimeLockAgent {
         registerManagementResource();
         healthCheck = paxosResources.leadershipComponents().healthCheck(namespaces::getActiveClients);
 
-        BiFunction<String, Optional<String>, LockService> lockServiceGetter =
-                (namespace, userAgent) -> namespaces.get(namespace, userAgent).getLockService();
-        BiFunction<String, Optional<String>, AsyncTimelockService> asyncTimelockServiceGetter =
-                (namespace, userAgent) -> namespaces.get(namespace, userAgent).getTimelockService();
+        TriFunction<String, Optional<String>, String, LockService> lockServiceGetter =
+                (namespace, userAgent, endpointName) ->
+                        namespaces.get(namespace, userAgent, endpointName).getLockService();
+        TriFunction<String, Optional<String>, String, AsyncTimelockService> asyncTimelockServiceGetter =
+                (namespace, userAgent, endpointName) ->
+                        namespaces.get(namespace, userAgent, endpointName).getTimelockService();
 
         if (undertowRegistrar.isPresent()) {
             Consumer<UndertowService> presentUndertowRegistrar = undertowRegistrar.get();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/JerseyAsyncTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/JerseyAsyncTimelockResource.java
@@ -192,7 +192,10 @@ public class JerseyAsyncTimelockResource {
     @Path("do-not-use-without-explicit-atlasdb-authorisation/lock-diagnostic-config")
     public Optional<LockDiagnosticInfo> getEnhancedLockDiagnosticInfo(
             @PathParam("namespace") String namespace, Set<UUID> requestIds) {
-        return namespaces.get(namespace, Optional.empty()).getLockLog().getAndLogLockDiagnosticInfo(requestIds);
+        return namespaces
+                .get(namespace, Optional.empty(), "JerseyAsyncTimelock#getEnhancedLockDiagnosticInfo")
+                .getLockLog()
+                .getAndLogLockDiagnosticInfo(requestIds);
     }
 
     private void addJerseyCallback(ListenableFuture<?> result, AsyncResponse response) {
@@ -213,6 +216,8 @@ public class JerseyAsyncTimelockResource {
     }
 
     private AsyncTimelockService getAsyncTimelockService(String namespace) {
-        return namespaces.get(namespace, Optional.empty()).getTimelockService();
+        return namespaces
+                .get(namespace, Optional.empty(), "JerseyAsyncTimelock#generic")
+                .getTimelockService();
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/LockV1Resource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/LockV1Resource.java
@@ -70,7 +70,8 @@ public class LockV1Resource {
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent)
             throws InterruptedException {
-        return Optional.ofNullable(getLockService(namespace, userAgent).lockWithFullLockResponse(client, request));
+        return Optional.ofNullable(getLockService(namespace, userAgent, "LockV1#lockWithFullLockResponse")
+                .lockWithFullLockResponse(client, request));
     }
 
     @POST
@@ -105,7 +106,7 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).unlock(token);
+        return getLockService(namespace, userAgent, "LockV1#unlock").unlock(token);
     }
 
     @POST
@@ -121,7 +122,7 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).unlockSimple(token);
+        return getLockService(namespace, userAgent, "LockV1#unlockSimple").unlockSimple(token);
     }
 
     @POST
@@ -137,7 +138,7 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).unlockAndFreeze(token);
+        return getLockService(namespace, userAgent, "LockV1#unlockAndFreeze").unlockAndFreeze(token);
     }
 
     @POST
@@ -153,7 +154,7 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).getTokens(client);
+        return getLockService(namespace, userAgent, "LockV1#getTokens").getTokens(client);
     }
 
     @POST
@@ -185,7 +186,7 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).refreshTokens(tokens);
+        return getLockService(namespace, userAgent, "LockV1#refreshTokens").refreshTokens(tokens);
     }
 
     @POST
@@ -203,7 +204,8 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return Optional.ofNullable(getLockService(namespace, userAgent).refreshGrant(grant));
+        return Optional.ofNullable(
+                getLockService(namespace, userAgent, "LockV1#refreshGrant").refreshGrant(grant));
     }
 
     @POST
@@ -221,7 +223,8 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return Optional.ofNullable(getLockService(namespace, userAgent).refreshGrant(grantId));
+        return Optional.ofNullable(
+                getLockService(namespace, userAgent, "LockV1#refreshGrantId").refreshGrant(grantId));
     }
 
     @POST
@@ -237,7 +240,7 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).convertToGrant(token);
+        return getLockService(namespace, userAgent, "LockV1#convertToGrant").convertToGrant(token);
     }
 
     @POST
@@ -254,7 +257,7 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).useGrant(client, grant);
+        return getLockService(namespace, userAgent, "LockV1#useGrant").useGrant(client, grant);
     }
 
     @POST
@@ -287,7 +290,7 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).useGrant(client, grantId);
+        return getLockService(namespace, userAgent, "LockV1#useGrant").useGrant(client, grantId);
     }
 
     @POST
@@ -321,7 +324,8 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return Optional.ofNullable(getLockService(namespace, userAgent).getMinLockedInVersionId());
+        return Optional.ofNullable(getLockService(namespace, userAgent, "LockV1#getMinLockedInVersionId")
+                .getMinLockedInVersionId());
     }
 
     @POST
@@ -336,7 +340,8 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return Optional.ofNullable(getLockService(namespace, userAgent).getMinLockedInVersionId(client));
+        return Optional.ofNullable(getLockService(namespace, userAgent, "LockV1#getMinLockedInVersionIdForClient")
+                .getMinLockedInVersionId(client));
     }
 
     @POST
@@ -365,7 +370,8 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).getLockServerOptions();
+        return getLockService(namespace, userAgent, "LockV1#getLockServerOptions")
+                .getLockServerOptions();
     }
 
     @POST
@@ -380,7 +386,7 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).currentTimeMillis();
+        return getLockService(namespace, userAgent, "LockV1#currentTimeMillis").currentTimeMillis();
     }
 
     @POST
@@ -395,7 +401,7 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        getLockService(namespace, userAgent).logCurrentState();
+        getLockService(namespace, userAgent, "LockV1#logCurrentState").logCurrentState();
     }
 
     // Remote lock service
@@ -415,7 +421,8 @@ public class LockV1Resource {
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent)
             throws InterruptedException {
-        return Optional.ofNullable(getLockService(namespace, userAgent).lock(client, request));
+        return Optional.ofNullable(
+                getLockService(namespace, userAgent, "LockV1#lock").lock(client, request));
     }
 
     @POST
@@ -450,7 +457,8 @@ public class LockV1Resource {
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent)
             throws InterruptedException {
-        return Optional.ofNullable(getLockService(namespace, userAgent).lockAndGetHeldLocks(client, request));
+        return Optional.ofNullable(getLockService(namespace, userAgent, "LockV1#lockAndGetHeldLocks")
+                .lockAndGetHeldLocks(client, request));
     }
 
     @POST
@@ -482,7 +490,7 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).unlock(token);
+        return getLockService(namespace, userAgent, "LockV1#unlock").unlock(token);
     }
 
     @POST
@@ -498,7 +506,8 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).refreshLockRefreshTokens(tokens);
+        return getLockService(namespace, userAgent, "LockV1#refreshLockRefreshTokens")
+                .refreshLockRefreshTokens(tokens);
     }
 
     @POST
@@ -516,7 +525,8 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return Optional.ofNullable(getLockService(namespace, userAgent).getMinLockedInVersionId(client));
+        return Optional.ofNullable(getLockService(namespace, userAgent, "LockV1#getMinLockedInVersionId")
+                .getMinLockedInVersionId(client));
     }
 
     @POST
@@ -549,10 +559,10 @@ public class LockV1Resource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getLockService(namespace, userAgent).getLockState(lock);
+        return getLockService(namespace, userAgent, "LockV1#getLockState").getLockState(lock);
     }
 
-    private LockService getLockService(String namespace, Optional<String> userAgent) {
-        return namespaces.get(namespace, userAgent).getLockService();
+    private LockService getLockService(String namespace, Optional<String> userAgent, String endpointName) {
+        return namespaces.get(namespace, userAgent, endpointName).getLockService();
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
@@ -86,11 +86,12 @@ public final class TimelockNamespaces {
      * Should be best-effort to give a UserAgent - it's possible with Undertow interfaces but not
      * server-side Jersey interfaces (which are just used in tests)
      */
-    public TimeLockServices get(String namespace, Optional<String> userAgent) {
+    public TimeLockServices get(String namespace, Optional<String> userAgent, String endpointName) {
         return services.computeIfAbsent(namespace, _namespace -> {
             log.info(
                     "Creating new timelock client",
                     SafeArg.of("namespace", namespace),
+                    SafeArg.of("endpointName", endpointName),
                     SafeArg.of("userAgent", userAgent));
             return createNewClient(namespace);
         });

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimestampManagementResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimestampManagementResource.java
@@ -72,7 +72,8 @@ public class TimestampManagementResource {
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
         long timestampToUse = currentTimestamp.orElse(SENTINEL_TIMESTAMP);
-        getTimestampManagementService(namespace, userAgent).fastForwardTimestamp(timestampToUse);
+        getTimestampManagementService(namespace, userAgent, "TimestampManagement#fastForwardTimestamp")
+                .fastForwardTimestamp(timestampToUse);
     }
 
     @GET
@@ -86,11 +87,13 @@ public class TimestampManagementResource {
     public String ping(
             @Safe @PathParam("namespace") @Handle.PathParam String namespace,
             @Safe @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER) Optional<String> userAgent) {
-        return getTimestampManagementService(namespace, userAgent).ping();
+        return getTimestampManagementService(namespace, userAgent, "TimestampManagement#ping")
+                .ping();
     }
 
-    private TimestampManagementService getTimestampManagementService(String namespace, Optional<String> userAgent) {
-        return namespaces.get(namespace, userAgent).getTimestampManagementService();
+    private TimestampManagementService getTimestampManagementService(
+            String namespace, Optional<String> userAgent, String endpointName) {
+        return namespaces.get(namespace, userAgent, endpointName).getTimestampManagementService();
     }
 
     enum TextPlainSerializer implements SerializerFactory<String> {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimestampResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimestampResource.java
@@ -48,7 +48,8 @@ public final class TimestampResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getTimestampService(namespace, userAgent).getFreshTimestamp();
+        return getTimestampService(namespace, userAgent, "Timestamp#getFreshTimestamp")
+                .getFreshTimestamp();
     }
 
     @POST // This has to be POST because we can't allow caching.
@@ -62,10 +63,11 @@ public final class TimestampResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getTimestampService(namespace, userAgent).getFreshTimestamps(numTimestampsRequested);
+        return getTimestampService(namespace, userAgent, "Timestamp#getFreshTimestamps")
+                .getFreshTimestamps(numTimestampsRequested);
     }
 
-    private TimestampService getTimestampService(String namespace, Optional<String> userAgent) {
-        return namespaces.get(namespace, userAgent).getTimestampService();
+    private TimestampService getTimestampService(String namespace, Optional<String> userAgent, String endpointName) {
+        return namespaces.get(namespace, userAgent, endpointName).getTimestampService();
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TriFunction.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TriFunction.java
@@ -1,0 +1,23 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+@FunctionalInterface
+public interface TriFunction<A, B, C, R> {
+
+    R apply(A a, B b, C c);
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/UndertowAsyncTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/UndertowAsyncTimelockResource.java
@@ -57,7 +57,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).getFreshTimestampAsync();
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#getFreshTimestamp")
+                .getFreshTimestampAsync();
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/fresh-timestamps")
@@ -68,7 +69,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).getFreshTimestampsAsync(numTimestampsRequested);
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#getFreshTimestamps")
+                .getFreshTimestampsAsync(numTimestampsRequested);
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/lock-immutable-timestamp")
@@ -79,7 +81,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).lockImmutableTimestamp(request);
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#lockImmutableTimestamp")
+                .lockImmutableTimestamp(request);
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/start-atlasdb-transaction")
@@ -90,7 +93,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).deprecatedStartTransaction(request);
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#deprecatedStartTransactionV1")
+                .deprecatedStartTransaction(request);
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/start-identified-atlasdb-transaction")
@@ -101,7 +105,7 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent)
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#deprecatedStartTransactionV2")
                 .startTransaction(request)
                 .toStartTransactionResponse();
     }
@@ -114,7 +118,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).startTransaction(request);
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#deprecatedStartTransactionV3")
+                .startTransaction(request);
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/start-atlasdb-transaction-v4")
@@ -125,7 +130,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).startTransactionsAsync(request);
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#startTransactions")
+                .startTransactionsAsync(request);
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/immutable-timestamp")
@@ -135,7 +141,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).getImmutableTimestamp();
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#getImmutableTimestamp")
+                .getImmutableTimestamp();
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/lock")
@@ -146,7 +153,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).deprecatedLock(request);
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#deprecatedLock")
+                .deprecatedLock(request);
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/lock-v2")
@@ -157,7 +165,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).lock(request);
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#lock")
+                .lock(request);
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/await-locks")
@@ -168,7 +177,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).waitForLocks(request);
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#waitForLocks")
+                .waitForLocks(request);
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/refresh-locks")
@@ -179,7 +189,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).deprecatedRefreshLockLeases(tokens);
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#deprecatedRefreshLockLeases")
+                .deprecatedRefreshLockLeases(tokens);
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/refresh-locks-v2")
@@ -190,7 +201,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).refreshLockLeases(tokens);
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#refreshLockLeases")
+                .refreshLockLeases(tokens);
     }
 
     @Handle(method = HttpMethod.GET, path = "/{namespace}/timelock/leader-time")
@@ -200,7 +212,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).leaderTime();
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#getLeaderTime")
+                .leaderTime();
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/unlock")
@@ -211,7 +224,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).unlock(tokens);
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#unlock")
+                .unlock(tokens);
     }
 
     @Handle(method = HttpMethod.POST, path = "/{namespace}/timelock/current-time-millis")
@@ -221,7 +235,8 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return getAsyncTimelockService(namespace, userAgent).currentTimeMillis();
+        return getAsyncTimelockService(namespace, userAgent, "UndertowAsyncTimelock#currentTimeMillis")
+                .currentTimeMillis();
     }
 
     // TODO(jkong): Remove this once PDS-95791 is resolved.
@@ -236,10 +251,14 @@ public final class UndertowAsyncTimelockResource {
                     @HeaderParam(TimelockNamespaces.USER_AGENT_HEADER)
                     @Handle.Header(TimelockNamespaces.USER_AGENT_HEADER)
                     Optional<String> userAgent) {
-        return namespaces.get(namespace, userAgent).getLockLog().getAndLogLockDiagnosticInfo(requestIds);
+        return namespaces
+                .get(namespace, userAgent, "UndertowAsyncTimelock#getEnhancedLockDiagnosticInfo")
+                .getLockLog()
+                .getAndLogLockDiagnosticInfo(requestIds);
     }
 
-    private AsyncTimelockService getAsyncTimelockService(String namespace, Optional<String> userAgent) {
-        return namespaces.get(namespace, userAgent).getTimelockService();
+    private AsyncTimelockService getAsyncTimelockService(
+            String namespace, Optional<String> userAgent, String endpointName) {
+        return namespaces.get(namespace, userAgent, endpointName).getTimelockService();
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/NamespacedConsensus.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/NamespacedConsensus.java
@@ -29,7 +29,7 @@ public class NamespacedConsensus {
      * @param namespace namespace for which consensus has to be achieved
      */
     public static void achieveConsensusForNamespace(TimelockNamespaces timelockNamespaces, String namespace) {
-        TimeLockServices timeLockServices = timelockNamespaces.get(namespace, Optional.empty());
+        TimeLockServices timeLockServices = timelockNamespaces.get(namespace, Optional.empty(), "NamespacedConsensus");
         long timestamp = timeLockServices.getTimelockService().getFreshTimestamp() + 1000000L;
         timeLockServices.getTimestampManagementService().fastForwardTimestamp(timestamp);
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
@@ -144,7 +144,7 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
             AuthHeader authHeader, String namespace, long currentTimestamp, @Nullable RequestContext context) {
         return handleExceptions(() -> {
             timelockNamespaces
-                    .get(namespace, TimelockNamespaces.toUserAgent(context))
+                    .get(namespace, TimelockNamespaces.toUserAgent(context), "TimeLockManagement#fastForwardTimestamp")
                     .getTimestampManagementService()
                     .fastForwardTimestamp(currentTimestamp);
             return Futures.immediateFuture(null);

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/ConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/ConjureTimelockResourceTest.java
@@ -92,8 +92,8 @@ public class ConjureTimelockResourceTest {
 
     @BeforeEach
     public void before() {
-        resource = new ConjureTimelockResource(TARGETER, (_namespace, _userAgent) -> timelockService);
-        service = ConjureTimelockResource.jersey(TARGETER, (_namespace, _userAgent) -> timelockService);
+        resource = new ConjureTimelockResource(TARGETER, (_namespace, _userAgent, _endpointName) -> timelockService);
+        service = ConjureTimelockResource.jersey(TARGETER, (_namespace, _userAgent, _endpointName) -> timelockService);
     }
 
     @Test

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimelockNamespacesTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/TimelockNamespacesTest.java
@@ -73,15 +73,15 @@ public class TimelockNamespacesTest {
         prepareServiceFactoryAndMaxNumberOfClientsSupplierInvocations();
         when(serviceFactory.apply(CLIENT_A)).thenReturn(servicesA);
         when(serviceFactory.apply(CLIENT_B)).thenReturn(servicesB);
-        assertThat(namespaces.get(CLIENT_A, USER_AGENT)).isEqualTo(servicesA);
-        assertThat(namespaces.get(CLIENT_B, USER_AGENT)).isEqualTo(servicesB);
+        assertThat(namespaces.get(CLIENT_A, USER_AGENT, "test")).isEqualTo(servicesA);
+        assertThat(namespaces.get(CLIENT_B, USER_AGENT, "test")).isEqualTo(servicesB);
     }
 
     @Test
     public void servicesAreOnlyCreatedOncePerClient() {
         prepareServiceFactoryAndMaxNumberOfClientsSupplierInvocations();
-        namespaces.get(CLIENT_A, USER_AGENT);
-        namespaces.get(CLIENT_A, USER_AGENT);
+        namespaces.get(CLIENT_A, USER_AGENT, "test");
+        namespaces.get(CLIENT_A, USER_AGENT, "test");
         verify(serviceFactory, times(1)).apply(any());
     }
 
@@ -90,7 +90,8 @@ public class TimelockNamespacesTest {
         prepareServiceFactoryAndMaxNumberOfClientsSupplierInvocations();
         createMaximumNumberOfClients();
 
-        assertThatThrownBy(() -> namespaces.get(uniqueClient(), USER_AGENT)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> namespaces.get(uniqueClient(), USER_AGENT, "test"))
+                .isInstanceOf(IllegalStateException.class);
 
         verify(serviceFactory, times(DEFAULT_MAX_NUMBER_OF_CLIENTS)).apply(any());
         verifyNoMoreInteractions(serviceFactory);
@@ -107,7 +108,7 @@ public class TimelockNamespacesTest {
     public void onClientCreationIncreaseNumberOfClients() {
         prepareServiceFactoryAndMaxNumberOfClientsSupplierInvocations();
         assertThat(namespaces.getNumberOfActiveClients()).isEqualTo(0);
-        namespaces.get(uniqueClient(), USER_AGENT);
+        namespaces.get(uniqueClient(), USER_AGENT, "test");
         assertThat(namespaces.getNumberOfActiveClients()).isEqualTo(1);
     }
 
@@ -118,7 +119,7 @@ public class TimelockNamespacesTest {
 
         when(maxNumberOfClientsSupplier.get()).thenReturn(DEFAULT_MAX_NUMBER_OF_CLIENTS + 1);
 
-        namespaces.get(uniqueClient(), USER_AGENT);
+        namespaces.get(uniqueClient(), USER_AGENT, "test");
     }
 
     @Test
@@ -127,12 +128,12 @@ public class TimelockNamespacesTest {
         assertNumberOfActiveClientsIs(0);
         assertMaxClientsIs(DEFAULT_MAX_NUMBER_OF_CLIENTS);
 
-        namespaces.get(uniqueClient(), USER_AGENT);
+        namespaces.get(uniqueClient(), USER_AGENT, "test");
 
         assertNumberOfActiveClientsIs(1);
         assertMaxClientsIs(DEFAULT_MAX_NUMBER_OF_CLIENTS);
 
-        namespaces.get(uniqueClient(), USER_AGENT);
+        namespaces.get(uniqueClient(), USER_AGENT, "test");
 
         assertNumberOfActiveClientsIs(2);
         assertMaxClientsIs(DEFAULT_MAX_NUMBER_OF_CLIENTS);
@@ -173,11 +174,11 @@ public class TimelockNamespacesTest {
                 .thenReturn(mock(TimeLockServices.class));
 
         String client = uniqueClient();
-        TimeLockServices services = namespaces.get(client, USER_AGENT);
+        TimeLockServices services = namespaces.get(client, USER_AGENT, "test");
         namespaces.invalidateResourcesForClient(client);
         verify(services).close();
 
-        TimeLockServices newServices = namespaces.get(client, USER_AGENT);
+        TimeLockServices newServices = namespaces.get(client, USER_AGENT, "test");
         assertThat(newServices).as("should have gotten a new set of delegates").isNotEqualTo(services);
 
         namespaces.invalidateResourcesForClient(client);
@@ -197,7 +198,7 @@ public class TimelockNamespacesTest {
 
     private void createMaximumNumberOfClients() {
         for (int i = 0; i < DEFAULT_MAX_NUMBER_OF_CLIENTS; i++) {
-            namespaces.get(uniqueClient(), USER_AGENT);
+            namespaces.get(uniqueClient(), USER_AGENT, "test");
         }
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResourceTest.java
@@ -90,7 +90,7 @@ public class MultiClientConjureTimelockResourceTest {
     @BeforeEach
     public void before() {
         resource = new MultiClientConjureTimelockResource(
-                TARGETER, (namespace, _context) -> getServiceForClient(namespace));
+                TARGETER, (namespace, _context, _endpointName) -> getServiceForClient(namespace));
     }
 
     @Test


### PR DESCRIPTION
## General
**Before this PR**:
When timelock creates a new timelock client (per restart), we logged the userAgent that initiated the request. However, if there was no user agent, we were still left with no useful information about what service is querying the timelock namespace.

**After this PR**:
==COMMIT_MSG==
New timelock clients also log the endpoint name
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: None

**Is documentation needed?**: No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: Safe

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: Safe

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Safe

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: Safe

**Does this PR need a schema migration?** Safe

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: No assumptions

**What was existing testing like? What have you done to improve it?**: Just unit tests

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Logging

**Has the safety of all log arguments been decided correctly?**: Yes

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: View logging for TimelockNamespaces

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Just move forward

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: Yes

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: N/A

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: N/A

## Development Process
**Where should we start reviewing?**: TimelockNamespaces.java

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
