### PR TITLE
Boy/junit5 cleanup3

### DIFF
--- a/atlasdb-perf/build.gradle
+++ b/atlasdb-perf/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'com.google.guava:guava'
     implementation 'com.google.protobuf:protobuf-java'
     implementation 'com.palantir.docker.compose:docker-compose-rule-core'
-    implementation 'com.palantir.docker.compose:docker-compose-rule-junit4'
+    implementation 'com.palantir.docker.compose:docker-compose-junit-jupiter'
     implementation 'com.palantir.refreshable:refreshable'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.safe-logging:safe-logging'

--- a/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/DockerizedDatabase.java
+++ b/atlasdb-perf/src/main/java/com/palantir/atlasdb/performance/backend/DockerizedDatabase.java
@@ -15,8 +15,7 @@
  */
 package com.palantir.atlasdb.performance.backend;
 
-import com.palantir.docker.compose.DockerComposeRule;
-import com.palantir.docker.compose.configuration.ShutdownStrategy;
+import com.palantir.docker.compose.DockerComposeExtension;
 import com.palantir.docker.compose.connection.DockerPort;
 import com.palantir.docker.compose.connection.waiting.HealthCheck;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
@@ -35,11 +34,10 @@ public final class DockerizedDatabase implements Closeable {
     private static final String DOCKER_LOGS_DIR = "container-logs";
 
     public static DockerizedDatabase start(KeyValueServiceInstrumentation type) {
-        DockerComposeRule docker = DockerComposeRule.builder()
+        DockerComposeExtension docker = DockerComposeExtension.builder()
                 .file(getDockerComposeFileAbsolutePath(type.getDockerComposeResourceFileName()))
                 .waitingForHostNetworkedPort(type.getKeyValueServicePort(), toBeOpen())
                 .saveLogsTo(DOCKER_LOGS_DIR)
-                .shutdownStrategy(ShutdownStrategy.AGGRESSIVE_WITH_NETWORK_CLEANUP)
                 .build();
         InetSocketAddress addr = connect(docker, type.getKeyValueServicePort());
         return new DockerizedDatabase(docker, new DockerizedDatabaseUri(type, addr));
@@ -67,7 +65,7 @@ public final class DockerizedDatabase implements Closeable {
         return port -> SuccessOrFailure.fromBoolean(port.isListeningNow(), "" + "" + port + " was not open");
     }
 
-    private static InetSocketAddress connect(DockerComposeRule docker, int dbPort) {
+    private static InetSocketAddress connect(DockerComposeExtension docker, int dbPort) {
         try {
             if (docker == null) {
                 throw new SafeIllegalStateException("Docker compose rule cannot be run, is null.");
@@ -82,10 +80,10 @@ public final class DockerizedDatabase implements Closeable {
         }
     }
 
-    private final DockerComposeRule docker;
+    private final DockerComposeExtension docker;
     private final DockerizedDatabaseUri uri;
 
-    private DockerizedDatabase(DockerComposeRule docker, DockerizedDatabaseUri uri) {
+    private DockerizedDatabase(DockerComposeExtension docker, DockerizedDatabaseUri uri) {
         this.docker = docker;
         this.uri = uri;
     }


### PR DESCRIPTION
In [this issue](https://github.com/palantir/atlasdb/issues/6796), we are transitioning our test classes from JUnit4 to JUnit5.

In this pull request, we are cleaning leftover implementations, mainly by removing V1s and renaming V2s. This PR is for package `atlasdb-perf`

It works as expected locally.
