### PR TITLE
feat(cli): Add logger to distribution

### DIFF
--- a/atlasdb-cli-distribution/build.gradle
+++ b/atlasdb-cli-distribution/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   runtimeOnly project(':atlasdb-cli')
   runtimeOnly project(':atlasdb-cassandra')
   runtimeOnly project(':atlasdb-dbkvs')
+  runtimeOnly 'ch.qos.logback:logback-classic'
 }
 
 distribution {


### PR DESCRIPTION
## General
**Before this PR**:
https://github.com/palantir/atlasdb/pull/6742/files#diff-bf4ee2c3b702465b964f3fd7cee2ec01bd40a07228344ae2ccf336b20bdef4b2L15 removed the logger dependency in the CLI. This resulted in the following when running the cli:
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```
which made it really hard to see what went wrong during the internal migration. At the time, I patched it quickly (see #6842 ) so we were unblocked - this PR aims to merge it properly.
**After this PR**:
With the logger, you now get logs:
```
15:46:54.284 [main] ERROR com.palantir.atlasdb.cli.AtlasCli - Fatal exception thrown during cli command execution.  Exiting.
com.palantir.logsafe.exceptions.SafeRuntimeException: 
        at com.palantir.atlasdb.cli.command.KvsMigrationCommand.lambda$rethrowIoExceptionAsUnchecked$5(KvsMigrationCommand.java:270)
        at java.base/java.util.Optional.map(Optional.java:265)
        at com.palantir.atlasdb.cli.command.KvsMigrationCommand.loadFromFile(KvsMigrationCommand.java:261)
        at com.palantir.atlasdb.cli.command.KvsMigrationCommand.connectFromServices(KvsMigrationCommand.java:206)
        at com.palantir.atlasdb.cli.command.KvsMigrationCommand.call(KvsMigrationCommand.java:158)
        at com.palantir.atlasdb.cli.command.KvsMigrationCommand.call(KvsMigrationCommand.java:49)
        at com.palantir.atlasdb.cli.AtlasCli.main(AtlasCli.java:60)
Caused by: java.io.FileNotFoundException: <redacted> (No such file or directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:219)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
        at com.fasterxml.jackson.dataformat.yaml.YAMLFactory.createParser(YAMLFactory.java:393)
        at com.fasterxml.jackson.dataformat.yaml.YAMLFactory.createParser(YAMLFactory.java:15)
        at com.fasterxml.jackson.databind.ObjectMapper.readTree(ObjectMapper.java:3252)
        at com.palantir.atlasdb.config.AtlasDbConfigs.load(AtlasDbConfigs.java:62)
        at com.palantir.atlasdb.cli.command.KvsMigrationCommand.lambda$loadFromFile$4(KvsMigrationCommand.java:261)
        at com.palantir.atlasdb.cli.command.KvsMigrationCommand.lambda$rethrowIoExceptionAsUnchecked$5(KvsMigrationCommand.java:268)
        ... 6 common frames omitted
```

as exoected
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: p3

**Concerns / possible downsides (what feedback would you like?)**:
None

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
