### PR TITLE
[Antithesis] re-add runtimeOnly dependency on atlasdb-cassandra 

### DIFF
--- a/atlasdb-workload-server-distribution/build.gradle
+++ b/atlasdb-workload-server-distribution/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(':atlasdb-workload-server')
     implementation project(':atlasdb-workload-server-api')
     implementation project(':atlasdb-config')
+    runtimeOnly project(':atlasdb-cassandra')
 
     compileOnly 'org.immutables:value::annotations'
     annotationProcessor 'org.immutables:value'


### PR DESCRIPTION
https://github.com/palantir/atlasdb/pull/6742/files#diff-bf4ee2c3b702465b964f3fd7cee2ec01bd40a07228344ae2ccf336b20bdef4b2L15 removed the atlasdb-cassandra dependency in workload-server-distribution, which is breaking antithesis.
