### PR TITLE
[Antithesis] Fix false positives in SummaryRowsWorkflow

### DIFF
--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
@@ -60,7 +60,8 @@ public final class TransientRowsWorkflows {
 
     private static final SecureRandom SECURE_RANDOM = DefaultNativeSamplingSecureRandomFactory.INSTANCE.create();
 
-    private TransientRowsWorkflows() {}
+    private TransientRowsWorkflows() {
+    }
 
     public static Workflow create(
             InteractiveTransactionStore store,
@@ -166,7 +167,7 @@ public final class TransientRowsWorkflows {
                 .orElseThrow(() -> new SafeIllegalStateException(
                         "Expected to find a read of the summary row", SafeArg.of("actions", actions)));
         WitnessedSingleCellReadTransactionAction normalRowRead = readTransactionActions.stream()
-                .filter(action -> action.cell().key() != SUMMARY_ROW)
+                .filter(action -> action.cell().key().equals(summaryRowRead.cell().column()))
                 .findAny()
                 .orElseThrow(() -> new SafeIllegalStateException(
                         "Expected to find a read of a corresponding normal row", SafeArg.of("actions", actions)));

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
@@ -60,8 +60,7 @@ public final class TransientRowsWorkflows {
 
     private static final SecureRandom SECURE_RANDOM = DefaultNativeSamplingSecureRandomFactory.INSTANCE.create();
 
-    private TransientRowsWorkflows() {
-    }
+    private TransientRowsWorkflows() {}
 
     public static Workflow create(
             InteractiveTransactionStore store,
@@ -167,7 +166,8 @@ public final class TransientRowsWorkflows {
                 .orElseThrow(() -> new SafeIllegalStateException(
                         "Expected to find a read of the summary row", SafeArg.of("actions", actions)));
         WitnessedSingleCellReadTransactionAction normalRowRead = readTransactionActions.stream()
-                .filter(action -> action.cell().key().equals(summaryRowRead.cell().column()))
+                .filter(action ->
+                        action.cell().key().equals(summaryRowRead.cell().column()))
                 .findAny()
                 .orElseThrow(() -> new SafeIllegalStateException(
                         "Expected to find a read of a corresponding normal row", SafeArg.of("actions", actions)));


### PR DESCRIPTION
## General
**Before this PR**: The summary rows workflow did a `findAny()` on _non-summary row reads_ in an attempt to find the primary table read corresponding to the summary row; however, we actually do another read earlier in the transaction (so that we only delete if present) that might accidentally be selected for comparison, leading to false positives.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The summary rows workflow finds the corresponding cell when attempting to validate that a non-summary row exists (or doesn't exist).
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: None in particular

**Is documentation needed?**: No

## Compatibility
This PR only affects Antithesis testing code.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing in particular

**What was existing testing like? What have you done to improve it?**: Annoyingly, given the original behaviour was nondeterministic, I wasn't able to easily reproduce the problem and thus did not write a test. There are existing tests, though they don't test against the specific findAny failure mode.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: We don't see any more false positives of comparing (-1, x) and (y, 1) for x != y.

**Has the safety of all log arguments been decided correctly?**: N/A

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: We still see false positives comparing (-1, x) and (y, 1) for x != y.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: N/A

## Scale
This PR only affects Antithesis testing code.

## Development Process
**Where should we start reviewing?**: The one file

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
