### PR TITLE
[Antithesis] Run workloads in a random order + allow running of just one workload

### DIFF
--- a/atlasdb-workload-server-distribution/build.gradle
+++ b/atlasdb-workload-server-distribution/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'com.palantir.conjure.java.api:service-config'
     implementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
     implementation 'com.palantir.refreshable:refreshable'
+    implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.tritium:tritium-registry'
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.guava:guava'

--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
@@ -189,12 +189,18 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
                 workflowsAndInvariantsToRun = workflowsAndInvariants;
                 break;
             default:
-                throw new SafeIllegalStateException("Unexpected run mode",
-                        SafeArg.of("runMode", configuration.install().workflowExecutionConfig().runMode()));
+                throw new SafeIllegalStateException(
+                        "Unexpected run mode",
+                        SafeArg.of(
+                                "runMode",
+                                configuration
+                                        .install()
+                                        .workflowExecutionConfig()
+                                        .runMode()));
         }
 
         new AntithesisWorkflowValidatorRunner(new DefaultWorkflowRunner(
-                MoreExecutors.listeningDecorator(antithesisWorkflowRunnerExecutorService)))
+                        MoreExecutors.listeningDecorator(antithesisWorkflowRunnerExecutorService)))
                 .run(workflowsAndInvariantsToRun);
 
         log.info("antithesis: terminate");

--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
@@ -189,12 +189,12 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
                 workflowsAndInvariantsToRun = workflowsAndInvariants;
                 break;
             default:
-                throw new SafeIllegalStateException("Unexpected value: "
-                        + configuration.install().workflowExecutionConfig().runMode());
+                throw new SafeIllegalStateException("Unexpected run mode",
+                        SafeArg.of("runMode", configuration.install().workflowExecutionConfig().runMode()));
         }
 
         new AntithesisWorkflowValidatorRunner(new DefaultWorkflowRunner(
-                        MoreExecutors.listeningDecorator(antithesisWorkflowRunnerExecutorService)))
+                MoreExecutors.listeningDecorator(antithesisWorkflowRunnerExecutorService)))
                 .run(workflowsAndInvariantsToRun);
 
         log.info("antithesis: terminate");

--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/config/WorkflowExecutionConfiguration.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/config/WorkflowExecutionConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.config;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@JsonDeserialize(as = ImmutableWorkflowExecutionConfiguration.class)
+@JsonSerialize(as = ImmutableWorkflowExecutionConfiguration.class)
+@Value.Immutable
+public interface WorkflowExecutionConfiguration {
+    RunMode runMode();
+
+    enum RunMode {
+        ONE,
+        ALL;
+    }
+}

--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/config/WorkloadServerInstallConfiguration.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/config/WorkloadServerInstallConfiguration.java
@@ -53,5 +53,7 @@ public interface WorkloadServerInstallConfiguration {
 
     WriteOnceDeleteOnceWorkflowConfiguration writeOnceDeleteOnceConfig();
 
+    WorkflowExecutionConfiguration workflowExecutionConfig();
+
     boolean exitAfterRunning();
 }

--- a/atlasdb-workload-server-distribution/src/test/resources/workload-server.yml
+++ b/atlasdb-workload-server-distribution/src/test/resources/workload-server.yml
@@ -54,4 +54,6 @@ install:
       isolationLevel: SERIALIZABLE
     iterationCount: 100
     type: write-once-delete-once
+  workflowExecutionConfig:
+    runMode: ALL
   exitAfterRunning: false

--- a/atlasdb-workload-server-distribution/src/test/resources/workload-server.yml
+++ b/atlasdb-workload-server-distribution/src/test/resources/workload-server.yml
@@ -55,5 +55,5 @@ install:
     iterationCount: 100
     type: write-once-delete-once
   workflowExecutionConfig:
-    runMode: ALL
+    runMode: ONE
   exitAfterRunning: false

--- a/atlasdb-workload-server-distribution/var/conf/workload-server.yml
+++ b/atlasdb-workload-server-distribution/var/conf/workload-server.yml
@@ -56,5 +56,5 @@ install:
     iterationCount: 100
     type: write-once-delete-once
   workflowExecutionConfig:
-    runMode: ALL
+    runMode: ONE
   exitAfterRunning: true

--- a/atlasdb-workload-server-distribution/var/conf/workload-server.yml
+++ b/atlasdb-workload-server-distribution/var/conf/workload-server.yml
@@ -55,4 +55,6 @@ install:
       isolationLevel: SERIALIZABLE
     iterationCount: 100
     type: write-once-delete-once
+  workflowExecutionConfig:
+    runMode: ALL
   exitAfterRunning: true


### PR DESCRIPTION
## General
**Before this PR**:
The workload server runs the workloads in the prescribed order, beginning with the SingleRowTwoCells and ending with WriteOnceDeleteOnce.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The workload server can be configured to have an `executionConfig` with a `runMode` of either `ALL` or `ONE`. The `ALL` mode runs all workflows in a random order (that pokes out to the system random number generation); the `ONE` mode runs one workflow (that also is selected by random number generation).
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: Is the `ONE` mode useful in this form, or do we need to also let the user specify _which one_?

**Is documentation needed?**: No

## Compatibility
Antithesis workload server change.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That relying on the random number generator to pick a workflow is sufficient for our purposes.

**What was existing testing like? What have you done to improve it?**: Nothing much.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Workflows visibly run in a random order; when ONE is set, only one runs.

**Has the safety of all log arguments been decided correctly?**: N/A

**Will this change significantly affect our spending on metrics or logs?**: No.

**How would I tell that this PR does not work in production? (monitors, etc.)**: Workflows always run in the same order and we have run this enough times that we are satisfied (though once is already statistically significant given there are 10 workflows or so?)

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: N/A

## Scale
Antithesis workload server change.

## Development Process
**Where should we start reviewing?**: WorkloadServerLauncher

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
