### PR TITLE
Supporting pre-commit conditions that can use the mutation map to verify things

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
@@ -48,7 +48,7 @@ public interface PreCommitCondition {
     /**
      * Checks that the condition is valid at the given timestamp and writes, otherwise throws a
      * {@link TransactionFailedException}. If the condition is not valid, the transaction will not be committed.
-     * This will _only_ be called in write transactions once #commit() has been called. In all other cases,
+     * This will _only_ be called in write transactions once {@link SnapshotTransaction#commit()} has been called. In all other cases,
      * {@link #throwIfConditionInvalid(long)} will be called instead.
      *
      * This API should not be implemented by users of AtlasDB. It is only intended for internal use, and may be

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
@@ -15,6 +15,11 @@
  */
 package com.palantir.atlasdb.transaction.api;
 
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import java.util.Map;
+import java.util.concurrent.ConcurrentNavigableMap;
+
 /**
  * General condition that is checked before a transaction commits for validity. All conditions associated with a
  * transaction must be true for that transaction to commit successfully. If a given condition is valid at commit
@@ -40,6 +45,16 @@ public interface PreCommitCondition {
      */
     void throwIfConditionInvalid(long timestamp);
 
+    /**
+     * Checks that the condition is valid at the given timestamp and writes, otherwise throws a
+     * {@link TransactionFailedException}. If the condition is not valid, the transaction will not be committed.
+     * This will _only_ be called in write transactions once #commit() has been called. In all other cases,
+     * {@link #throwIfConditionInvalid(long)} will be called instead.
+     */
+    default void throwIfConditionInvalid(
+            Map<TableReference, ConcurrentNavigableMap<Cell, byte[]>> mutations, long timestamp) {
+        throwIfConditionInvalid(timestamp);
+    }
     /**
      * Cleans up any state managed by this condition, e.g. a lock that should be held for the lifetime of the
      * transaction. Conditions last the lifetime of a particular transaction and will be cleaned up on each retry.

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
@@ -48,8 +48,8 @@ public interface PreCommitCondition {
     /**
      * Checks that the condition is valid at the given timestamp and writes, otherwise throws a
      * {@link TransactionFailedException}. If the condition is not valid, the transaction will not be committed.
-     * This will _only_ be called in write transactions once {@link SnapshotTransaction#commit()} has been called. In all other cases,
-     * {@link #throwIfConditionInvalid(long)} will be called instead.
+     * This will _only_ be called in write transactions once {@link SnapshotTransaction#commit()} has been called.
+     * In all other cases, {@link #throwIfConditionInvalid(long)} will be called instead.
      *
      * This API should not be implemented by users of AtlasDB. It is only intended for internal use, and may be
      * removed or changed at any time.
@@ -58,6 +58,7 @@ public interface PreCommitCondition {
     default void throwIfConditionInvalid(Map<TableReference, ? extends Map<Cell, byte[]>> mutations, long timestamp) {
         throwIfConditionInvalid(timestamp);
     }
+
     /**
      * Cleans up any state managed by this condition, e.g. a lock that should be held for the lifetime of the
      * transaction. Conditions last the lifetime of a particular transaction and will be cleaned up on each retry.

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.transaction.api;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import java.util.Map;
-import java.util.concurrent.ConcurrentNavigableMap;
 
 /**
  * General condition that is checked before a transaction commits for validity. All conditions associated with a
@@ -51,8 +50,7 @@ public interface PreCommitCondition {
      * This will _only_ be called in write transactions once #commit() has been called. In all other cases,
      * {@link #throwIfConditionInvalid(long)} will be called instead.
      */
-    default void throwIfConditionInvalid(
-            Map<TableReference, ConcurrentNavigableMap<Cell, byte[]>> mutations, long timestamp) {
+    default void throwIfConditionInvalid(Map<TableReference, ? extends Map<Cell, byte[]>> mutations, long timestamp) {
         throwIfConditionInvalid(timestamp);
     }
     /**

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/PreCommitCondition.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.transaction.api;
 
+import com.google.common.annotations.Beta;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import java.util.Map;
@@ -49,7 +50,11 @@ public interface PreCommitCondition {
      * {@link TransactionFailedException}. If the condition is not valid, the transaction will not be committed.
      * This will _only_ be called in write transactions once #commit() has been called. In all other cases,
      * {@link #throwIfConditionInvalid(long)} will be called instead.
+     *
+     * This API should not be implemented by users of AtlasDB. It is only intended for internal use, and may be
+     * removed or changed at any time.
      */
+    @Beta
     default void throwIfConditionInvalid(Map<TableReference, ? extends Map<Cell, byte[]>> mutations, long timestamp) {
         throwIfConditionInvalid(timestamp);
     }

--- a/changelog/@unreleased/pr-6926.v2.yml
+++ b/changelog/@unreleased/pr-6926.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: PreCommitConditions may now implement a check that relies on the mutation
+    map that AtlasDB will commit. This check will only be called on a transaction
+    that has writes and only once commit has been called.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6926

--- a/changelog/@unreleased/pr-6926.v2.yml
+++ b/changelog/@unreleased/pr-6926.v2.yml
@@ -1,7 +1,0 @@
-type: improvement
-improvement:
-  description: PreCommitConditions may now implement a check that relies on the mutation
-    map that AtlasDB will commit. This check will only be called on a transaction
-    that has writes and only once commit has been called.
-  links:
-  - https://github.com/palantir/atlasdb/pull/6926


### PR DESCRIPTION
## General
**Before this PR**:
We cannot extract the writes in a pre-commit condition. As a result, it's nigh impossible for us to verify some internal invariants in AtlasDB proxy as part of an investigation.
**After this PR**:
==COMMIT_MSG==
PreCommitConditions may now implement a check that relies on the mutation map that AtlasDB will commit. This check will only be called on a transaction that has writes and only once commit has been called.
==COMMIT_MSG==

**Priority**:
P1 
**Concerns / possible downsides (what feedback would you like?)**:
Do we want to inform users that they shouldn't use this outside of the specific use case we have internally? 

**Is documentation needed?**:
Javadoc added
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
**What was existing testing like? What have you done to improve it?**:
Added tests for the behaviour we're expecting!
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
No change should be observed
**Has the safety of all log arguments been decided correctly?**:
No
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:
SnapshotTransaction
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
