### PR TITLE
Expose a worker pool interface

### DIFF
--- a/atlasdb-autobatch/build.gradle
+++ b/atlasdb-autobatch/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.tracing:tracing'
     implementation 'io.dropwizard.metrics:metrics-core'
+    implementation 'org.jetbrains:annotations'
     implementation project(':commons-executors')
 
     testImplementation 'com.google.errorprone:error_prone_annotations'

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/Autobatchers.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/Autobatchers.java
@@ -95,8 +95,9 @@ public final class Autobatchers {
      * @return builder where the autobatcher can be further customised
      */
     public static <I, O> AutobatcherBuilder<I, O> independent(Consumer<List<BatchElement<I, O>>> batchFunction) {
-        return new AutobatcherBuilder<>(parameters -> new IndependentBatchingEventHandler<>(
-                maybeWrapWithTimeout(batchFunction, parameters), parameters.batchSize()));
+        return new AutobatcherBuilder<>(
+                parameters -> IndependentBatchingEventHandler.createWithSequentialBatchProcessing(
+                        maybeWrapWithTimeout(batchFunction, parameters), parameters.batchSize()));
     }
 
     private static <I, O> Consumer<List<BatchElement<I, O>>> maybeWrapWithTimeout(

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/IndependentBatchingEventHandler.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/IndependentBatchingEventHandler.java
@@ -16,38 +16,62 @@
 
 package com.palantir.atlasdb.autobatch;
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+import org.jetbrains.annotations.VisibleForTesting;
 
 final class IndependentBatchingEventHandler<T, R> implements AutobatcherEventHandler<T, R> {
     private final Consumer<List<BatchElement<T, R>>> batchFunction;
     private final List<BatchElement<T, R>> pending;
+    private final WorkerPool pool;
 
-    IndependentBatchingEventHandler(Consumer<List<BatchElement<T, R>>> batchFunction, int bufferSize) {
+    @VisibleForTesting
+    IndependentBatchingEventHandler(Consumer<List<BatchElement<T, R>>> batchFunction, int bufferSize, WorkerPool pool) {
         this.batchFunction = batchFunction;
         this.pending = new ArrayList<>(bufferSize);
+        this.pool = pool;
+    }
+
+    static <T, R> AutobatcherEventHandler<T, R> createWithSequentialBatchProcessing(
+            Consumer<List<BatchElement<T, R>>> batchFunction, int bufferSize) {
+        return new IndependentBatchingEventHandler<>(batchFunction, bufferSize, NoOpWorkerPool.INSTANCE);
     }
 
     @Override
     public void onEvent(BatchElement<T, R> event, long sequence, boolean endOfBatch) {
         pending.add(event);
         if (endOfBatch) {
-            flush();
+            processBatch();
+            pending.clear();
         }
     }
 
-    private void flush() {
-        pending.forEach(element -> element.result().running());
-        try {
-            batchFunction.accept(Collections.unmodifiableList(pending));
-        } catch (Throwable t) {
-            pending.forEach(p -> p.result().setException(t));
+    private void processBatch() {
+        boolean flushWasSubmitted =
+                pool.tryRun(() -> ImmutableList.copyOf(pending), batchCopy -> flush(batchFunction, batchCopy));
+
+        if (flushWasSubmitted) {
+            return;
         }
-        pending.clear();
+
+        List<BatchElement<T, R>> batchView = Collections.unmodifiableList(pending);
+        flush(batchFunction, batchView);
+    }
+
+    private static <T, R> void flush(Consumer<List<BatchElement<T, R>>> batchFunction, List<BatchElement<T, R>> batch) {
+        batch.forEach(element -> element.result().running());
+        try {
+            batchFunction.accept(batch);
+        } catch (Throwable t) {
+            batch.forEach(p -> p.result().setException(t));
+        }
     }
 
     @Override
-    public void close() {}
+    public void close() {
+        pool.close();
+    }
 }

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/NoOpWorkerPool.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/NoOpWorkerPool.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.autobatch;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+enum NoOpWorkerPool implements WorkerPool {
+    INSTANCE;
+
+    @Override
+    public <T> boolean tryRun(Supplier<T> supplier, Consumer<T> task) {
+        return false;
+    }
+
+    @Override
+    public List<Runnable> close() {
+        return List.of();
+    }
+}

--- a/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/WorkerPool.java
+++ b/atlasdb-autobatch/src/main/java/com/palantir/atlasdb/autobatch/WorkerPool.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.autobatch;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+interface WorkerPool {
+    /**
+     * Synchronously triggers supplier when a permit is available, and then runs task with the result.
+     * Returns true when the task was submitted, and false otherwise.
+     */
+    <T> boolean tryRun(Supplier<T> supplier, Consumer<T> task);
+
+    /**
+     * Close any resources held by this worker pool.
+     * Returns tasks that have not commenced execution.
+     */
+    List<Runnable> close();
+}

--- a/atlasdb-autobatch/src/test/java/com/palantir/atlasdb/autobatch/NoOpWorkerPoolTest.java
+++ b/atlasdb-autobatch/src/test/java/com/palantir/atlasdb/autobatch/NoOpWorkerPoolTest.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.autobatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+public final class NoOpWorkerPoolTest {
+    private final WorkerPool workerPool = NoOpWorkerPool.INSTANCE;
+
+    @Test
+    public void noOpWorkerPoolCloseReturnsEmpty() {
+        assertThat(workerPool.close()).isEmpty();
+    }
+
+    @Test
+    public void noOpWorkerPoolTryRunReturnsFalse() {
+        assertThat(workerPool.tryRun(() -> 1, $ -> {})).isFalse();
+    }
+
+    @Test
+    public void noOpWorkerPoolDoesNotRunTask() {
+        AtomicBoolean taskWasRun = new AtomicBoolean(false);
+        workerPool.tryRun(() -> 1, $ -> taskWasRun.set(true));
+        assertThat(taskWasRun).isFalse();
+    }
+
+    @Test
+    public void noOpWorkPoolDoesNotConsumeSupplier() {
+        AtomicBoolean supplierWasConsumed = new AtomicBoolean(false);
+        workerPool.tryRun(
+                () -> {
+                    supplierWasConsumed.set(true);
+                    return 1;
+                },
+                $ -> {});
+        assertThat(supplierWasConsumed).isFalse();
+    }
+}

--- a/atlasdb-autobatch/src/test/java/com/palantir/atlasdb/autobatch/SequentialIndependentBatchingEventHandlerTest.java
+++ b/atlasdb-autobatch/src/test/java/com/palantir/atlasdb/autobatch/SequentialIndependentBatchingEventHandlerTest.java
@@ -1,0 +1,159 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.autobatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.base.Ticker;
+import com.google.common.collect.ImmutableList;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public final class SequentialIndependentBatchingEventHandlerTest {
+    private static final long IGNORED_SEQUENCE = 0L;
+
+    // hand-rolling a stub because using Mockito for a consumer of a list
+    // yields counter-intuitive behaviour, as Mockito will capture the list
+    // reference whose contents may be mutated by the handler
+    private final StubbedBatchFunction batchFunction = new StubbedBatchFunction();
+
+    private final AutobatcherEventHandler<String, String> handler =
+            IndependentBatchingEventHandler.createWithSequentialBatchProcessing(batchFunction, 16);
+
+    @Test
+    public void handlerCloseClosesPool() throws Exception {
+        WorkerPool pool = mock(WorkerPool.class);
+        AutobatcherEventHandler<String, String> handler = new IndependentBatchingEventHandler<>(s -> {}, 1, pool);
+        handler.close();
+        verify(pool).close();
+    }
+
+    @Test
+    public void handlerDoesNotInvokeBatchingFunctionIfEndOfBatchIsNotSignalled() throws Exception {
+        try (handler) {
+            handler.onEvent(createBatchElement("element1"), IGNORED_SEQUENCE, false);
+            handler.onEvent(createBatchElement("element2"), IGNORED_SEQUENCE, false);
+        }
+        batchFunction.assertNoBatchWasProcessed();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 5})
+    public void handlerInvokesBatchingFunctionOnEndOfBatch(int batchCount) throws Exception {
+        List<BatchElement<String, String>> batch = createBatch(batchCount);
+        try (handler) {
+            submitBatch(handler, batch);
+        }
+        batchFunction.assertOnlyBatchWasProcessed(batch);
+    }
+
+    @Test
+    public void handlerDoesNotRemoveDuplicateElements() throws Exception {
+        List<BatchElement<String, String>> batch =
+                List.of(createBatchElement("element"), createBatchElement("element"));
+        try (handler) {
+            submitBatch(handler, batch);
+        }
+        batchFunction.assertOnlyBatchWasProcessed(batch);
+    }
+
+    @Test
+    public void handlerInvokesBatchingFunctionForEachBatchInSequentialOrder() throws Exception {
+        List<BatchElement<String, String>> batch1 = createBatch(2);
+        List<BatchElement<String, String>> batch2 = createBatch(3);
+        List<BatchElement<String, String>> batch3 = createBatch(1);
+        List<BatchElement<String, String>> batch4 = createBatch(4);
+
+        try (handler) {
+            submitBatch(handler, batch1);
+            submitBatch(handler, batch2);
+            submitBatch(handler, batch3);
+            submitBatch(handler, batch4);
+        }
+
+        batchFunction.assertOnlyBatchesWereProcessedInOrder(List.of(batch1, batch2, batch3, batch4));
+    }
+
+    private static void submitBatch(
+            AutobatcherEventHandler<String, String> handler, List<BatchElement<String, String>> batch) {
+        for (int i = 0; i < batch.size(); i++) {
+            try {
+                handler.onEvent(batch.get(i), IGNORED_SEQUENCE, i == batch.size() - 1);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static List<BatchElement<String, String>> createBatch(int batchSize) {
+        String batchId = UUID.randomUUID().toString();
+        return IntStream.range(0, batchSize)
+                .mapToObj(i -> createBatchElement(batchId + "-element" + i))
+                .collect(Collectors.toList());
+    }
+
+    private static BatchElement<String, String> createBatchElement(String input) {
+        return BatchElement.of(
+                input,
+                new DisruptorAutobatcher.DisruptorFuture<>(
+                        Ticker.systemTicker(),
+                        AutobatcherTelemetryComponents.create("test", new DefaultTaggedMetricRegistry())));
+    }
+
+    private static final class StubbedBatchFunction implements Consumer<List<BatchElement<String, String>>> {
+        private final List<List<BatchElement<String, String>>> processedBatches =
+                Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public void accept(List<BatchElement<String, String>> batch) {
+            List<BatchElement<String, String>> copy = ImmutableList.copyOf(batch);
+            processedBatches.add(copy);
+        }
+
+        void assertOnlyBatchWasProcessed(List<BatchElement<String, String>> batch) {
+            synchronized (processedBatches) {
+                assertThat(processedBatches).containsOnly(batch);
+            }
+        }
+
+        void assertOnlyBatchesWereProcessedInOrder(List<List<BatchElement<String, String>>> batches) {
+            synchronized (processedBatches) {
+                assertThat(processedBatches).containsExactlyElementsOf(batches);
+            }
+        }
+
+        void assertNoBatchWasProcessed() {
+            synchronized (processedBatches) {
+                assertThat(processedBatches).isEmpty();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:

**After this PR**:
Introduced WorkerPool interface for submitting tasks and wired it in a no-op way to IndependentBatchingEventHandler, added some missing test coverage. This will allow for usage of a real worker pool later to multiplex the event handler.

**Priority**:
P2
**Concerns / possible downsides (what feedback would you like?)**:
Tests do not check that the sequential handler does not go and spin some async stuff. This is hard to check for, though it is simple to check in code review that it is not the case. Open to ideas here.
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
Improved coverage
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
No-op, nothing changes
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No-op
**How would I tell that this PR does not work in production? (monitors, etc.)**:
No-op, quite complicated, any bug here would be subtle and can cause all types of badness in different places on multiple downstream consumers
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Recall and rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
