### PR TITLE
[Antithesis] Fill in missing execution config to configuration with TimeLock and Cassandra

### DIFF
--- a/atlasdb-workload-server-distribution/var/conf/workload-server.timelock.cassandra.yml
+++ b/atlasdb-workload-server-distribution/var/conf/workload-server.timelock.cassandra.yml
@@ -91,4 +91,6 @@ install:
       isolationLevel: SERIALIZABLE
     iterationCount: 100
     type: write-once-delete-once
+  workflowExecutionConfig:
+    runMode: ONE
   exitAfterRunning: true

--- a/changelog/@unreleased/pr-6930.v2.yml
+++ b/changelog/@unreleased/pr-6930.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'The workload server now has runMode: ONE specified by default.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/6930


### PR DESCRIPTION
## General
**Before this PR**: The workload server was missing some configuration, because the path to create the server in prod and test is different (!!)

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The workload server now has runMode: ONE specified by default.
==COMMIT_MSG==

**Priority**: dev P0

**Concerns / possible downsides (what feedback would you like?)**:
The point marked (!!) is still true

**Is documentation needed?**: No

## Compatibility
Antithesis workload server change

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing in particular

**What was existing testing like? What have you done to improve it?**: This is unfortunately still not ideal

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Containers start

**Has the safety of all log arguments been decided correctly?**: N/A

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: Containers still fail

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Yeah, rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
Antithesis workload server change

## Development Process
**Where should we start reviewing?**: Is small

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: It's a +2

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
