### PR TITLE
Avoid reflection when rethrowing exceptions

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionRetryStrategy.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionRetryStrategy.java
@@ -29,7 +29,6 @@ import com.github.rholder.retry.WaitStrategy;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
 import com.palantir.atlasdb.transaction.api.TransactionFailedException;
-import com.palantir.common.base.Throwables;
 import com.palantir.exception.NotInitializedException;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
@@ -86,10 +85,7 @@ public final class TransactionRetryStrategy {
         try {
             return retryer.call(task::run);
         } catch (RetryException e) {
-            Throwable wrapped = Throwables.rewrap(
-                    String.format("Failing after %d tries.", e.getNumberOfFailedAttempts()),
-                    e.getLastFailedAttempt().getExceptionCause());
-            throw throwTaskException(wrapped);
+            throw throwTaskException(e.getLastFailedAttempt().getExceptionCause());
         } catch (ExecutionException e) {
             throw throwTaskException(e.getCause());
         }

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionRetryStrategyTest.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionRetryStrategyTest.java
@@ -101,10 +101,7 @@ public class TransactionRetryStrategyTest {
                 .thenThrow(new TransactionFailedRetriableException("first"))
                 .thenThrow(second)
                 .thenReturn("success");
-        assertThatExceptionOfType(TransactionFailedRetriableException.class)
-                .isThrownBy(this::runExponential)
-                .withMessage("Failing after 2 tries.")
-                .withCause(second);
+        assertThatThrownBy(this::runExponential).isSameAs(second);
         assertThat(blockStrategy.numRetries).isEqualTo(1);
     }
 
@@ -112,21 +109,21 @@ public class TransactionRetryStrategyTest {
     public void doesNotRetryOnNonRetriableTransactionFailedException() throws Exception {
         TransactionFailedNonRetriableException failure = new TransactionFailedNonRetriableException("");
         when(task.run()).thenThrow(failure).thenReturn("success");
-        assertThatThrownBy(this::runExponential).isEqualTo(failure);
+        assertThatThrownBy(this::runExponential).isSameAs(failure);
     }
 
     @Test
     public void rethrowsExceptions() throws Exception {
         Exception exception = new Exception("rethrown");
         when(task.run()).thenThrow(exception);
-        assertThatThrownBy(this::runExponential).isEqualTo(exception);
+        assertThatThrownBy(this::runExponential).isSameAs(exception);
     }
 
     @Test
     public void rethrowsErrors() throws Exception {
         AssertionError error = new AssertionError();
         when(task.run()).thenThrow(error);
-        assertThatThrownBy(this::runExponential).isEqualTo(error);
+        assertThatThrownBy(this::runExponential).isSameAs(error);
     }
 
     @Test

--- a/atlasdb-commons/src/main/java/com/palantir/common/proxy/InterruptibleProxy.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/proxy/InterruptibleProxy.java
@@ -76,7 +76,7 @@ public final class InterruptibleProxy implements DelegatingInvocationHandler {
         try {
             return future.get();
         } catch (ExecutionException e) {
-            throw Throwables.rewrap(e.getCause());
+            throw e.getCause();
         } catch (InterruptedException e) {
             throw new PalantirInterruptedException(e);
         } finally {

--- a/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogImpl.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/PaxosStateLogImpl.java
@@ -292,7 +292,7 @@ public class PaxosStateLogImpl<V extends Persistable & Versionable> implements P
                         UnsafeArg.of("full path", file.getAbsolutePath()),
                         SafeArg.of("file name", file.getName()),
                         e);
-                throw Throwables.rewrap(e);
+                throw e;
             } finally {
                 IOUtils.closeQuietly(fileIn);
             }

--- a/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
+++ b/leader-election-impl/src/main/java/com/palantir/paxos/SingleLeaderPinger.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.RateLimiter;
-import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.CheckedRejectedExecutionException;
 import com.palantir.common.concurrent.CheckedRejectionExecutorService;
 import com.palantir.common.concurrent.MultiplexingCompletionService;
@@ -287,21 +286,12 @@ public final class SingleLeaderPinger implements LeaderPinger {
             return;
         }
 
-        IllegalStateException exception =
-                new SafeIllegalStateException("There is a fatal problem with the leadership election configuration! "
-                        + "This is probably caused by invalid pref files setting up the cluster "
-                        + "(e.g. for lock server look at lock.prefs, leader.prefs, and lock_client.prefs)."
-                        + "If the preferences are specified with a host port pair list and localhost index "
-                        + "then make sure that the localhost index is correct (e.g. actually the localhost).");
-
         if (cachedService != pingedService) {
-            log.error("Remote potential leaders are claiming to be each other!", exception);
-            throw Throwables.rewrap(exception);
+            throw new SafeIllegalStateException("Remote potential leaders are claiming to be each other!");
         }
 
         if (pingedServiceUuid.equals(localUuid)) {
-            log.error("Remote potential leader is claiming to be you!", exception);
-            throw Throwables.rewrap(exception);
+            throw new SafeIllegalStateException("Remote potential leader is claiming to be you!");
         }
     }
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuid.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/GetSuspectedLeaderWithUuid.java
@@ -27,10 +27,9 @@ import com.google.common.collect.Sets;
 import com.palantir.atlasdb.autobatch.BatchElement;
 import com.palantir.atlasdb.autobatch.DisruptorAutobatcher.DisruptorFuture;
 import com.palantir.atlasdb.timelock.paxos.PaxosQuorumCheckingCoalescingFunction.PaxosContainer;
-import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.CheckedRejectionExecutorService;
 import com.palantir.common.streams.KeyedStream;
-import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.paxos.LeaderPingerContext;
@@ -143,21 +142,12 @@ class GetSuspectedLeaderWithUuid implements Consumer<List<BatchElement<UUID, Opt
             return;
         }
 
-        IllegalStateException exception =
-                new SafeIllegalStateException("There is a fatal problem with the leadership election configuration! "
-                        + "This is probably caused by invalid pref files setting up the cluster "
-                        + "(e.g. for lock server look at lock.prefs, leader.prefs, and lock_client.prefs)."
-                        + "If the preferences are specified with a host port pair list and localhost index "
-                        + "then make sure that the localhost index is correct (e.g. actually the localhost).");
-
         if (cachedService != pingedService) {
-            log.error("Remote potential leaders are claiming to be each other!", exception);
-            throw Throwables.rewrap(exception);
+            throw new SafeIllegalArgumentException("Remote potential leaders are claiming to be each other!");
         }
 
         if (pingedServiceUuid.equals(localUuid)) {
-            log.error("Remote potential leader is claiming to be you!", exception);
-            throw Throwables.rewrap(exception);
+            throw new SafeIllegalArgumentException("Remote potential leader is claiming to be you!");
         }
     }
 }


### PR DESCRIPTION
`Throwables.rewrap` uses reflection to try an reconstruct an exception of the same type with a different message.