### PR TITLE
DO NOT MERGE: Showcasing how we catch antithesis workload server image break on CI

### DIFF
--- a/atlasdb-workload-server-distribution/var/conf/workload-server.timelock.cassandra.yml
+++ b/atlasdb-workload-server-distribution/var/conf/workload-server.timelock.cassandra.yml
@@ -91,6 +91,4 @@ install:
       isolationLevel: SERIALIZABLE
     iterationCount: 100
     type: write-once-delete-once
-  workflowExecutionConfig:
-    runMode: ONE
   exitAfterRunning: true

--- a/atlasdb-workload-server-distribution/var/conf/workload-server.yml
+++ b/atlasdb-workload-server-distribution/var/conf/workload-server.yml
@@ -55,6 +55,4 @@ install:
       isolationLevel: SERIALIZABLE
     iterationCount: 100
     type: write-once-delete-once
-  workflowExecutionConfig:
-    runMode: ONE
   exitAfterRunning: true


### PR DESCRIPTION
DO NOT MERGE:

This PR is just to showcase how we can now detect on CI (suite 14) if our antithesis workload server image fails to complete successfully.