### PR TITLE
[Antithesis] Fix race condition in transient rows workflow

### DIFF
--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
@@ -61,8 +61,7 @@ public final class TransientRowsWorkflows {
 
     private static final SecureRandom SECURE_RANDOM = DefaultNativeSamplingSecureRandomFactory.INSTANCE.create();
 
-    private TransientRowsWorkflows() {
-    }
+    private TransientRowsWorkflows() {}
 
     public static Workflow create(
             InteractiveTransactionStore store,
@@ -97,7 +96,8 @@ public final class TransientRowsWorkflows {
         protected Optional<WitnessedTransaction> run(InteractiveTransactionStore store, Integer taskIndex) {
             if (taskIndex % configuration.validateEveryNIterations() == 0) {
                 // This is cheeky, as we are not including our reads in our transaction history!
-                List<CrossCellInconsistency> violations = findInconsistencyInIndexStateDuringWorkflow(configuration, store);
+                List<CrossCellInconsistency> violations =
+                        findInconsistencyInIndexStateDuringWorkflow(configuration, store);
 
                 if (!violations.isEmpty()) {
                     recordFailure(violations);
@@ -208,7 +208,10 @@ public final class TransientRowsWorkflows {
     }
 
     private static void checkSummaryConsistencyForIndex(
-            List<CrossCellInconsistency> violations, BiFunction<String, WorkloadCell, Optional<Integer>> reader, String tableName, Integer index) {
+            List<CrossCellInconsistency> violations,
+            BiFunction<String, WorkloadCell, Optional<Integer>> reader,
+            String tableName,
+            Integer index) {
         WorkloadCell primaryCell = ImmutableWorkloadCell.of(index, COLUMN);
         Optional<Integer> valueFromPrimaryRow = reader.apply(tableName, primaryCell);
         WorkloadCell summaryCell = ImmutableWorkloadCell.of(SUMMARY_ROW, index);

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -60,7 +61,8 @@ public final class TransientRowsWorkflows {
 
     private static final SecureRandom SECURE_RANDOM = DefaultNativeSamplingSecureRandomFactory.INSTANCE.create();
 
-    private TransientRowsWorkflows() {}
+    private TransientRowsWorkflows() {
+    }
 
     public static Workflow create(
             InteractiveTransactionStore store,
@@ -95,7 +97,7 @@ public final class TransientRowsWorkflows {
         protected Optional<WitnessedTransaction> run(InteractiveTransactionStore store, Integer taskIndex) {
             if (taskIndex % configuration.validateEveryNIterations() == 0) {
                 // This is cheeky, as we are not including our reads in our transaction history!
-                List<CrossCellInconsistency> violations = findInconsistencyInFinalIndexState(configuration, store);
+                List<CrossCellInconsistency> violations = findInconsistencyInIndexStateDuringWorkflow(configuration, store);
 
                 if (!violations.isEmpty()) {
                     recordFailure(violations);
@@ -184,22 +186,33 @@ public final class TransientRowsWorkflows {
         }
     }
 
+    private static List<CrossCellInconsistency> findInconsistencyInIndexStateDuringWorkflow(
+            TransientRowsWorkflowConfiguration configuration, InteractiveTransactionStore store) {
+        List<CrossCellInconsistency> violations = new ArrayList<>();
+        String tableName = configuration.tableConfiguration().tableName();
+        Set<Integer> taskIndices =
+                IntStream.range(0, configuration.iterationCount()).boxed().collect(Collectors.toSet());
+        taskIndices.forEach(index ->
+                store.readWrite(txn -> checkSummaryConsistencyForIndex(violations, txn::read, tableName, index)));
+        return violations;
+    }
+
     private static List<CrossCellInconsistency> findInconsistencyInFinalIndexState(
             TransientRowsWorkflowConfiguration configuration, ReadableTransactionStore store) {
         List<CrossCellInconsistency> violations = new ArrayList<>();
         String tableName = configuration.tableConfiguration().tableName();
         Set<Integer> taskIndices =
                 IntStream.range(0, configuration.iterationCount()).boxed().collect(Collectors.toSet());
-        taskIndices.forEach(index -> checkSummaryConsistencyForIndex(violations, store, tableName, index));
+        taskIndices.forEach(index -> checkSummaryConsistencyForIndex(violations, store::get, tableName, index));
         return violations;
     }
 
     private static void checkSummaryConsistencyForIndex(
-            List<CrossCellInconsistency> violations, ReadableTransactionStore store, String tableName, Integer index) {
+            List<CrossCellInconsistency> violations, BiFunction<String, WorkloadCell, Optional<Integer>> reader, String tableName, Integer index) {
         WorkloadCell primaryCell = ImmutableWorkloadCell.of(index, COLUMN);
-        Optional<Integer> valueFromPrimaryRow = store.get(tableName, primaryCell);
+        Optional<Integer> valueFromPrimaryRow = reader.apply(tableName, primaryCell);
         WorkloadCell summaryCell = ImmutableWorkloadCell.of(SUMMARY_ROW, index);
-        Optional<Integer> valueFromSummaryRow = store.get(tableName, summaryCell);
+        Optional<Integer> valueFromSummaryRow = reader.apply(tableName, summaryCell);
         if (valueFromSummaryRow.isPresent() ^ valueFromPrimaryRow.isPresent()) {
             violations.add(CrossCellInconsistency.builder()
                     .putInconsistentValues(TableAndWorkloadCell.of(tableName, primaryCell), valueFromPrimaryRow)

--- a/changelog/@unreleased/pr-6934.v2.yml
+++ b/changelog/@unreleased/pr-6934.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Mid-workflow validation of the transaction history in the TransientRowsWorkflow
+    is now transactional.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6934


### PR DESCRIPTION
## General
**Before this PR**: The mid-workflow validation of our transaction history has a race condition, if certain dice are rolled very precisely:

- task 0 must start validating the index state
- pick some index number: we read the summary row and find that that index doesn't exist
- while this is happening, another task writes the main value to that index
- and then we read it and it's there!

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Mid-workflow validation of the transaction history in the TransientRowsWorkflow is now transactional.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: None in particular

**Is documentation needed?**: No

## Compatibility
Antithesis workflow server change

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing in particular

**What was existing testing like? What have you done to improve it?**: Very hard to add testing for this specific condition

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: We don't see this class of violations again

**Has the safety of all log arguments been decided correctly?**: N/A

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: We still see this kind of violation and can show it relates to this

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
Antithesis workload server change

## Development Process
**Where should we start reviewing?**: small

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: No

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
