### PR TITLE
fix 17

### DIFF
--- a/atlasdb-workload-server-distribution/Dockerfile
+++ b/atlasdb-workload-server-distribution/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-debian
+FROM azul/zulu-openjdk:17-latest
 MAINTAINER AtlasDB Team
 
 ENV DOCKERIZE_VERSION v0.2.0


### PR DESCRIPTION
While upgrading to JDK 17, I missed updating one of the Docker files. Thanks to the new test added by @LucasIME, we noticed this issue. Upgrading to the JDK 17 image fixes the problem.