### PR TITLE
Add conjure-undertow annotations to (Batch)PingableLeader

### DIFF
--- a/leader-election-api/build.gradle
+++ b/leader-election-api/build.gradle
@@ -4,10 +4,14 @@ libsDirName = file('build/artifacts')
 
 dependencies {
   api project(":atlasdb-commons")
+  api 'com.palantir.conjure.java:conjure-undertow-annotations'
+
   implementation project(":leader-election-api-protobufs")
-  implementation 'org.apache.commons:commons-lang3'
-  implementation 'javax.ws.rs:javax.ws.rs-api'
   implementation 'com.fasterxml.jackson.core:jackson-annotations'
+  implementation 'com.palantir.conjure.java:conjure-undertow-lib'
+  implementation 'org.apache.commons:commons-lang3'
+  implementation 'io.undertow:undertow-core'
+  implementation 'javax.ws.rs:javax.ws.rs-api'
 
   implementation 'com.palantir.sls.versions:sls-versions'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
@@ -18,6 +22,7 @@ dependencies {
   implementation 'com.palantir.safe-logging:safe-logging'
   implementation project(':commons-annotations')
 
+  annotationProcessor 'com.palantir.conjure.java:conjure-undertow-processor'
   annotationProcessor 'org.immutables:value'
   compileOnly 'org.immutables:value::annotations'
 }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -24,6 +24,7 @@ import com.palantir.conjure.java.api.config.service.UserAgent;
 import com.palantir.conjure.java.config.ssl.SslSocketFactories;
 import com.palantir.conjure.java.config.ssl.TrustContext;
 import com.palantir.leader.PingableLeader;
+import com.palantir.leader.PingableLeaderEndpoints;
 import com.palantir.paxos.CoalescingPaxosLatestRoundVerifier;
 import com.palantir.paxos.PaxosAcceptorNetworkClient;
 import com.palantir.paxos.PaxosLatestRoundVerifierImpl;
@@ -111,10 +112,14 @@ public final class PaxosResourcesFactory {
                 .latestRoundVerifierFactory(latestRoundVerifierFactory)
                 .build();
 
+        BatchPingableLeaderResource batchPingableLeader =
+                new BatchPingableLeaderResource(install.nodeUuid(), factory.components());
+
         return resourcesBuilder
                 .leadershipContextFactory(factory)
                 .putLeadershipBatchComponents(PaxosUseCase.LEADER_FOR_EACH_CLIENT, factory.components())
-                .addAdhocResources(new BatchPingableLeaderResource(install.nodeUuid(), factory.components()))
+                .addAdhocResources(batchPingableLeader)
+                .addUndertowServices(BatchPingableLeaderEndpoints.of(batchPingableLeader))
                 .timeLockCorruptionComponents(timeLockCorruptionComponents(install.sqliteDataSource(), remoteClients))
                 .build();
     }
@@ -155,15 +160,22 @@ public final class PaxosResourcesFactory {
         LeaderAcceptorResource leaderAcceptorResource =
                 new LeaderAcceptorResource(factory.components().acceptor(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT));
 
+        BatchPingableLeaderResource batchPingableLeader =
+                new BatchPingableLeaderResource(install.nodeUuid(), factory.components());
+
+        PingableLeader pingableLeader = factory.components().pingableLeader(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT);
+
         return resourcesBuilder
                 .leadershipContextFactory(factory)
                 .putLeadershipBatchComponents(PaxosUseCase.LEADER_FOR_ALL_CLIENTS, factory.components())
-                .addAdhocResources(new BatchPingableLeaderResource(install.nodeUuid(), factory.components()))
+                .addAdhocResources(batchPingableLeader)
                 .addAdhocResources(
                         leaderAcceptorResource,
                         new LeaderLearnerResource(factory.components().learner(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT)),
-                        factory.components().pingableLeader(PaxosUseCase.PSEUDO_LEADERSHIP_CLIENT))
+                        pingableLeader)
                 .addUndertowServices(LeaderAcceptorResourceEndpoints.of(leaderAcceptorResource))
+                .addUndertowServices(BatchPingableLeaderEndpoints.of(batchPingableLeader))
+                .addUndertowServices(PingableLeaderEndpoints.of(pingableLeader))
                 .timeLockCorruptionComponents(timeLockCorruptionComponents(install.sqliteDataSource(), remoteClients))
                 .build();
     }

--- a/timelock-api/build.gradle
+++ b/timelock-api/build.gradle
@@ -9,6 +9,8 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.google.errorprone:error_prone_annotations'
+    implementation 'com.google.guava:guava'
 
     testImplementation project(':atlasdb-api')
     testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeader.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/BatchPingableLeader.java
@@ -16,7 +16,10 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
+import com.palantir.conjure.java.undertow.annotations.Handle;
+import com.palantir.conjure.java.undertow.annotations.HttpMethod;
 import com.palantir.leader.PingableLeader;
+import com.palantir.logsafe.Safe;
 import com.palantir.paxos.Client;
 import java.util.Set;
 import java.util.UUID;
@@ -46,7 +49,13 @@ public interface BatchPingableLeader {
     @Path("ping")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    Set<Client> ping(Set<Client> clients);
+    @Handle(
+            method = HttpMethod.POST,
+            path = "/" + PaxosTimeLockConstants.INTERNAL_NAMESPACE
+                    + "/" + PaxosTimeLockConstants.MULTI_LEADER_PAXOS_NAMESPACE
+                    + "/" + PaxosTimeLockConstants.BATCH_INTERNAL_NAMESPACE
+                    + "/leader/ping")
+    Set<Client> ping(@Safe @Handle.Body Set<Client> clients);
 
     /**
      * Re-exported version of {@link PingableLeader#getUUID}. Returns unique leadership identifier for the remote
@@ -58,5 +67,11 @@ public interface BatchPingableLeader {
     @GET
     @Path("uuid")
     @Produces(MediaType.APPLICATION_JSON)
+    @Handle(
+            method = HttpMethod.GET,
+            path = "/" + PaxosTimeLockConstants.INTERNAL_NAMESPACE
+                    + "/" + PaxosTimeLockConstants.MULTI_LEADER_PAXOS_NAMESPACE
+                    + "/" + PaxosTimeLockConstants.BATCH_INTERNAL_NAMESPACE
+                    + "/leader/uuid")
     UUID uuid();
 }


### PR DESCRIPTION
## General
**Before this PR**:
PingableLeader and BatchPingableLeader are mounted as Jersey resources only in TimeLockAgent. 
**After this PR**:
PingableLeader and BatchPingableLeader can be mounted as Jersey resources only or Jersey and Undertow resources in TimeLockAgent.
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P2
**Concerns / possible downsides (what feedback would you like?)**:
I have checked the APIs return the same output for a selection of path params / arguments on IL. I am blocking the PR on a smoke test in our internal testing environment.

PaxosResourcesFactory/TimeLockAgent interaction will need to be refactored. Currently, we mount things both on Jersey and Undertow (both in test setups and prod setups). We should move towards separating the two and conditionally mount the resource (if an undertow registrar is present, do not mount jersey components). This is a FLUP for when we migrate all resources.
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
Yes
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
Server testing uses Dropwizard, this is a larger effort which we should do once we fully move to Undertow.
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
TimeLock wrapper is live, goes through leader elections and does not emit 500s.
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
TimeLock wrapper emits 500s, is not able to go through leader election successfully, sees bad performance.
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Recall and rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No, it might even be beneficial for perf 
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:
PaxosResourcesFactory.java
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
