### PR TITLE
feature: Allow configurable table mapper caching

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/TableMappingCacheConfiguration.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/TableMappingCacheConfiguration.java
@@ -20,12 +20,15 @@ import java.util.function.Predicate;
 import org.immutables.value.Value;
 
 /**
- * Indicates how the table mapping cache should be configured. This is to account for tables that no longer
+ * Indicates how the table mapping cache should be configured. This is to account for dynamic tables, for which caching
+ * table mapping lookups may be unsafe.
  */
 @Value.Immutable(singleton = true)
 public interface TableMappingCacheConfiguration {
     /**
-     * A predicate indicating whether tables should be cached.
+     * A predicate indicating whether the table mapping for these *fully qualified* table names should be cached.
+     * Users with dynamic tables that may be deleted and re-created should treat these tables as non-cacheable, so that
+     * the latest table mapping will be loaded from the database on each pertinent query.
      */
     @Value.Default
     default Predicate<TableReference> cacheableTablePredicate() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/TableMappingCacheConfiguration.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/TableMappingCacheConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.api;
+
+import java.util.function.Predicate;
+import org.immutables.value.Value;
+
+/**
+ * Indicates how the table mapping cache should be configured. This is to account for tables that no longer
+ */
+@Value.Immutable(singleton = true)
+public interface TableMappingCacheConfiguration {
+    /**
+     * A predicate indicating whether tables should be cached.
+     */
+    @Value.Default
+    default Predicate<TableReference> cacheableTablePredicate() {
+        return table -> true;
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
@@ -30,11 +30,13 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.TableMappingService;
 import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ImmutableTableMappingCacheConfiguration;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableMappingCacheConfiguration;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.ptobject.EncodingUtils;
@@ -46,18 +48,18 @@ import com.palantir.atlasdb.table.description.ValueType;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.exception.TableMappingNotFoundException;
 import com.palantir.logsafe.Preconditions;
-import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.Validate;
 
@@ -76,11 +78,17 @@ public class KvTableMappingService implements TableMappingService {
     private final LongSupplier uniqueLongSupplier;
     private final Pattern namespaceValidation;
     private final Set<TableReference> unmappedTables = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Predicate<TableReference> cacheableTablePredicate;
 
-    protected KvTableMappingService(KeyValueService kvs, LongSupplier uniqueLongSupplier, Pattern namespaceValidation) {
+    protected KvTableMappingService(
+            KeyValueService kvs,
+            LongSupplier uniqueLongSupplier,
+            Pattern namespaceValidation,
+            Predicate<TableReference> cacheableTablePredicate) {
         this.kvs = Preconditions.checkNotNull(kvs, "kvs must not be null");
         this.uniqueLongSupplier = Preconditions.checkNotNull(uniqueLongSupplier, "uniqueLongSupplier must not be null");
         this.namespaceValidation = namespaceValidation;
+        this.cacheableTablePredicate = cacheableTablePredicate;
     }
 
     public static KvTableMappingService create(KeyValueService kvs, LongSupplier uniqueLongSupplier) {
@@ -89,8 +97,18 @@ public class KvTableMappingService implements TableMappingService {
 
     public static KvTableMappingService createWithCustomNamespaceValidation(
             KeyValueService kvs, LongSupplier uniqueLongSupplier, Pattern namespaceValidation) {
+        return createWithCustomNamespaceValidation(
+                kvs, uniqueLongSupplier, namespaceValidation, ImmutableTableMappingCacheConfiguration.of());
+    }
+
+    public static KvTableMappingService createWithCustomNamespaceValidation(
+            KeyValueService kvs,
+            LongSupplier uniqueLongSupplier,
+            Pattern namespaceValidation,
+            TableMappingCacheConfiguration cacheConfiguration) {
         createNamespaceTable(kvs);
-        KvTableMappingService ret = new KvTableMappingService(kvs, uniqueLongSupplier, namespaceValidation);
+        KvTableMappingService ret = new KvTableMappingService(
+                kvs, uniqueLongSupplier, namespaceValidation, cacheConfiguration.cacheableTablePredicate());
         ret.updateTableMap();
         return ret;
     }
@@ -186,7 +204,21 @@ public class KvTableMappingService implements TableMappingService {
     }
 
     private TableReference getMappedTableRef(TableReference tableRef) throws TableMappingNotFoundException {
+        if (!cacheableTablePredicate.test(tableRef)) {
+            Map<Cell, Value> entryForTable = kvs.get(
+                    AtlasDbConstants.NAMESPACE_TABLE, ImmutableMap.of(getKeyCellForTable(tableRef), Long.MAX_VALUE));
+            return Optional.ofNullable(entryForTable.get(getKeyCellForTable(tableRef)))
+                    .map(row -> TableReference.createWithEmptyNamespace(PtBytes.toString(row.getContents())))
+                    .orElseThrow(() -> new TableMappingNotFoundException(
+                            "Unable to resolve mapping for table reference " + tableRef));
+        } else {
+            return getMappedTableRefThroughCache(tableRef);
+        }
+    }
+
+    private TableReference getMappedTableRefThroughCache(TableReference tableRef) throws TableMappingNotFoundException {
         TableReference candidate = tableMap.get().get(tableRef);
+
         if (candidate == null) {
             updateTableMap();
             candidate = tableMap.get().get(tableRef);
@@ -252,12 +284,6 @@ public class KvTableMappingService implements TableMappingService {
     }
 
     protected BiMap<TableReference, TableReference> readTableMap() {
-        // TODO (jkong) Remove after PDS-117310 is resolved.
-        if (log.isTraceEnabled()) {
-            log.trace(
-                    "Attempting to read the table mapping from the namespace table.",
-                    new SafeRuntimeException("I exist to show you the stack trace"));
-        }
         BiMap<TableReference, TableReference> ret = HashBiMap.create();
         try (ClosableIterator<RowResult<Value>> range = rangeScanNamespaceTable()) {
             while (range.hasNext()) {
@@ -268,13 +294,6 @@ public class KvTableMappingService implements TableMappingService {
                 TableReference ref = getTableRefFromBytes(row.getRowName());
                 ret.put(ref, TableReference.createWithEmptyNamespace(shortName));
             }
-        }
-        // TODO (jkong) Remove after PDS-117310 is resolved.
-        if (log.isTraceEnabled()) {
-            log.trace(
-                    "Successfully read {} entries from the namespace table, to refresh the table map.",
-                    SafeArg.of("entriesRead", ret.size()),
-                    new SafeRuntimeException("I exist to show you the stack trace"));
         }
         return ret;
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
@@ -201,15 +201,15 @@ public class KvTableMappingService implements TableMappingService {
     }
 
     private TableReference getMappedTableRef(TableReference tableRef) throws TableMappingNotFoundException {
-        if (!cacheableTablePredicate.test(tableRef)) {
+        if (cacheableTablePredicate.test(tableRef)) {
+            return getMappedTableRefThroughCache(tableRef);
+        } else {
             Map<Cell, Value> entryForTable = kvs.get(
                     AtlasDbConstants.NAMESPACE_TABLE, ImmutableMap.of(getKeyCellForTable(tableRef), Long.MAX_VALUE));
             return Optional.ofNullable(entryForTable.get(getKeyCellForTable(tableRef)))
                     .map(row -> TableReference.createWithEmptyNamespace(PtBytes.toString(row.getContents())))
                     .orElseThrow(() -> new TableMappingNotFoundException(
                             "Unable to resolve mapping for table reference " + tableRef));
-        } else {
-            return getMappedTableRefThroughCache(tableRef);
         }
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingServiceTest.java
@@ -256,12 +256,13 @@ public class KvTableMappingServiceTest {
 
     @Test
     public void loadingTableNamesIntoCacheAppliesAcrossDistinctCacheableTables() throws TableMappingNotFoundException {
-        tableMapping.addTable(FQ_TABLE2);
-        tableMapping.addTable(FQ_TABLE3);
-
+        // This ordering looks strange but is intentional: we need to add the new tables before calling get
+        TableReference mappedTableTwo = tableMapping.addTable(FQ_TABLE2);
+        TableReference mappedTableThree = tableMapping.addTable(FQ_TABLE3);
         TableReference mappedTableOne = tableMapping.getMappedTableName(FQ_TABLE);
-        TableReference mappedTableTwo = tableMapping.getMappedTableName(FQ_TABLE2);
-        TableReference mappedTableThree = tableMapping.getMappedTableName(FQ_TABLE3);
+
+        assertThat(tableMapping.getMappedTableName(FQ_TABLE2)).isEqualTo(mappedTableTwo);
+        assertThat(tableMapping.getMappedTableName(FQ_TABLE3)).isEqualTo(mappedTableThree);
 
         assertThat(ImmutableSet.of(mappedTableOne, mappedTableTwo, mappedTableThree))
                 .as("mapped tables should all be different")

--- a/changelog/@unreleased/pr-6946.v2.yml
+++ b/changelog/@unreleased/pr-6946.v2.yml
@@ -1,0 +1,8 @@
+type: feature
+feature:
+  description: Users are able to provide a predicate indicating the fully qualified
+    table names for which the table mapping cache will be allowed to operate. This
+    should unblock workflows for users which delete and re-create tables, who can
+    elect to not cache said tables in the table mapper.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6946


### PR DESCRIPTION
## General
**Before this PR**:
`TableMappingService` is used to deal with name length limits in various databases: instead of creating a database identifier that is the fully qualified table name (`FQTN`) which may be too long, we instead convert `FQTN` to a number `K` and store `_n_K` as the short name of that table. 

When formulating queries we need to perform mappings between `FQTN` and short names. We generally cache this mapping, and for a majority of AtlasDB clients this is fine, because a table once assigned stays assigned. In the event tables are dropped, while the mapping might be stale in that it could still point to a table that _used_ to exist, we'll still correctly get some exception from the database.

However, clients which delete and re-create tables may run into issues: although a table might have been deleted and re-created on a different service node, the table mapper on an existing service node might be completely or partially unaware of this, leading to problems as said existing service node is unable to use the new table even though it was properly created.

An important consideration to be aware of going into this PR is that performance on the **non-dynamic tables** code path is paramount: this covers the majority of users, and their performance must not be (significantly) affected by this change.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Users are able to provide a predicate indicating the fully qualified table names for which the table mapping cache will be allowed to operate. This should unblock workflows for users which delete and re-create tables, who can elect to not cache said tables in the table mapper.
==COMMIT_MSG==

**Priority**: P1.

**Concerns / possible downsides (what feedback would you like?)**:
- As mentioned, it is essential that performance on non-dynamic tables code paths is preserved. I believe this to be the case. Consider that the forward Get path does a singular get as opposed to any kind of range scan or cache invalidation; for backwards Get, we already can't cache negative lookups and reload the map in that case; the main change is that if we think the mapping exists and the table is cacheable we treat that as OK, while if the table is not cacheable we subsequently reload the map.

**Is documentation needed?**: Probably not.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes - during the overlap period blue nodes will still be vulnerable to the race condition of deleting and recreating tables but that's fine.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No.

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That this will suffice, but the team operating the product using this feature will be able to confirm or deny that.

**What was existing testing like? What have you done to improve it?**: I added a number of tests for KvTableMappingService.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Dynamic table workflows proceed smoothly

**Has the safety of all log arguments been decided correctly?**: No Args were added. Exception messages could have unsafe content, but are not safe-loggable anyway so will be treated as unsafe.

**Will this change significantly affect our spending on metrics or logs?**: No.

**How would I tell that this PR does not work in production? (monitors, etc.)**: Dynamic table workflows still run into table-mapping race conditions.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback.

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: There is a row range scan for the table mapping table if users frequently invoke the reverse mapping `generateMapToFullTableNames`, but we don't get to avoid this I think.

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: If the team operating the product using this feature finds that this results in too large of a performance regression, we can re-evaluate.

## Development Process
**Where should we start reviewing?**: TableMappingCacheConfiguration

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
