### PR TITLE
fix: Forward timestamp on Antithesis workload server to use txn3

### DIFF
--- a/atlasdb-workload-server-antithesis/src/test/java/AntithesisDockerTest.java
+++ b/atlasdb-workload-server-antithesis/src/test/java/AntithesisDockerTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -52,28 +53,37 @@ public class AntithesisDockerTest {
 
         String successMessage = "Finished running desired workflows successfully";
         String failureMessage = "Workflow will now exit.";
+        AtomicReference<String> logs = new AtomicReference<>("");
 
-        Awaitility.await()
-                .atMost(Duration.ofMinutes(5))
-                .pollInterval(Duration.ofSeconds(10))
-                .until(() -> {
-                    OutputStream logStream = new ByteArrayOutputStream();
-                    dockerComposeExtension
-                            .dockerComposeExecutable()
-                            .execute("logs", "workload-server")
-                            .getInputStream()
-                            .transferTo(logStream);
+        try {
+            Awaitility.await()
+                    .atMost(Duration.ofMinutes(5))
+                    .pollInterval(Duration.ofSeconds(10))
+                    .until(() -> {
+                        OutputStream logStream = new ByteArrayOutputStream();
+                        dockerComposeExtension
+                                .dockerComposeExecutable()
+                                .execute("logs", "workload-server")
+                                .getInputStream()
+                                .transferTo(logStream);
 
-                    String logs = logStream.toString();
+                        String logsSoFar = logStream.toString();
+                        logs.set(logsSoFar);
 
-                    if (logs.contains(successMessage)) {
-                        hasRunSuccessfully.set(true);
-                        return true;
-                    }
+                        if (logsSoFar.contains(successMessage)) {
+                            hasRunSuccessfully.set(true);
+                            return true;
+                        }
 
-                    return logs.contains(failureMessage);
-                });
+                        return logsSoFar.contains(failureMessage);
+                    });
+        } catch (Exception e) {
+            hasRunSuccessfully.set(false);
+        }
 
+        // This can be inferred from hasRunSuccessfully, but explicitly recheck here so logs readily available to be
+        // consumed when this test fails.
+        assertThat(logs.get()).contains(successMessage);
         assertThat(hasRunSuccessfully.get()).isTrue();
     }
 }

--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
@@ -201,6 +201,7 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
                 configuration.install().writeOnceDeleteOnceConfig();
 
         waitForTransactionStoreFactoryToBeInitialized(transactionStoreFactory);
+        transactionStoreFactory.fastForwardTimestampToSupportTransactions3();
 
         return new ArrayList<>(List.of(
                 createSingleRowTwoCellsWorkflowValidator(

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreFactory.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStoreFactory.java
@@ -59,6 +59,13 @@ public final class AtlasDbTransactionStoreFactory implements TransactionStoreFac
         return transactionManager.isInitialized();
     }
 
+    public void fastForwardTimestampToSupportTransactions3() {
+        long currentTimestamp = transactionManager.getTimestampService().getFreshTimestamp();
+        long guaranteedTransaction3Timestamp = currentTimestamp + 10_000_000;
+
+        transactionManager.getTimestampManagementService().fastForwardTimestamp(guaranteedTransaction3Timestamp);
+    }
+
     @Override
     public InteractiveTransactionStore create(Map<String, IsolationLevel> tables, Set<IndexTable> indexes) {
         return AtlasDbTransactionStore.create(transactionManager, toAtlasTables(tables, indexes));

--- a/changelog/@unreleased/pr-6951.v2.yml
+++ b/changelog/@unreleased/pr-6951.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Now we properly fast forward the timestamps only once the transaction
+    manager has been successfully initialized on antithesis workload server
+  links:
+  - https://github.com/palantir/atlasdb/pull/6951


### PR DESCRIPTION
## General
**Before this PR**:
Previously we had attempted this on [this PR](https://github.com/palantir/atlasdb/pull/6921), but we were trying to fast forward the timestamp before the transaction manager was initialized.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Now we properly fast forward the timestamps only once the transaction manager has been successfully initialized on antithesis workload server
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
