### PR TITLE
Mounting NamespaceTakeoverResource (conjure-defined API) on Undertow as well

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/NamespaceTakeoverComponent.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/NamespaceTakeoverComponent.java
@@ -1,0 +1,69 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.paxos;
+
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.StopStrategies;
+import com.github.rholder.retry.WaitStrategies;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.paxos.Client;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+final class NamespaceTakeoverComponent {
+    private static final SafeLogger log = SafeLoggerFactory.get(NamespaceTakeoverComponent.class);
+    private static final Duration RANDOM_WAIT_BEFORE_BACKOFF = Duration.ofMillis(500);
+
+    private final LeadershipComponents leadershipComponents;
+    private final Retryer<Boolean> takeoverRetryer;
+
+    NamespaceTakeoverComponent(LeadershipComponents leadershipComponents) {
+        this.leadershipComponents = leadershipComponents;
+        this.takeoverRetryer = new Retryer<>(
+                StopStrategies.stopAfterAttempt(5),
+                WaitStrategies.randomWait(RANDOM_WAIT_BEFORE_BACKOFF.toMillis(), TimeUnit.MILLISECONDS),
+                attempt -> !attempt.hasResult() || !attempt.getResult());
+    }
+
+    boolean takeover(String namespace) {
+        try {
+            return takeoverRetryer.call(() -> nonRetriedTakeover(namespace));
+        } catch (ExecutionException e) {
+            log.info("request failed, should not reach here", e);
+            return false;
+        } catch (RetryException e) {
+            log.info("failed repeatedly", SafeArg.of("numberOfAttempts", e.getNumberOfFailedAttempts()), e);
+            return false;
+        }
+    }
+
+    Set<String> takeoverNamespaces(Set<String> namespaces) {
+        return namespaces.stream()
+                .filter(namespace -> leadershipComponents.requestHostileTakeover(Client.of(namespace)))
+                .collect(Collectors.toSet());
+    }
+
+    private boolean nonRetriedTakeover(String namespace) {
+        return leadershipComponents.requestHostileTakeover(Client.of(namespace));
+    }
+}

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/NamespaceTakeoverService.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/NamespaceTakeoverService.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,27 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
-import com.palantir.atlasdb.timelock.paxos.api.NamespaceLeadershipTakeoverService;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.atlasdb.timelock.paxos.api.UndertowNamespaceLeadershipTakeoverService;
 import com.palantir.tokens.auth.AuthHeader;
 import java.util.Set;
 
-final class NamespaceTakeoverResource implements NamespaceLeadershipTakeoverService {
+final class NamespaceTakeoverService implements UndertowNamespaceLeadershipTakeoverService {
+
     private final NamespaceTakeoverComponent delegate;
 
-    NamespaceTakeoverResource(NamespaceTakeoverComponent delegate) {
+    NamespaceTakeoverService(NamespaceTakeoverComponent delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public boolean takeover(AuthHeader _authHeader, String namespace) {
-        return delegate.takeover(namespace);
+    public ListenableFuture<Boolean> takeover(AuthHeader _authHeader, String namespace) {
+        return Futures.immediateFuture(delegate.takeover(namespace));
     }
 
     @Override
-    public Set<String> takeoverNamespaces(AuthHeader _authHeader, Set<String> namespaces) {
-        return delegate.takeoverNamespaces(namespaces);
+    public ListenableFuture<Set<String>> takeoverNamespaces(AuthHeader _authHeader, Set<String> namespaces) {
+        return Futures.immediateFuture(delegate.takeoverNamespaces(namespaces));
     }
 }

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/PaxosResourcesFactory.java
@@ -119,7 +119,7 @@ public final class PaxosResourcesFactory {
                 .leadershipContextFactory(factory)
                 .putLeadershipBatchComponents(PaxosUseCase.LEADER_FOR_EACH_CLIENT, factory.components())
                 .addAdhocResources(batchPingableLeader)
-                .addUndertowServices(BatchPingableLeaderEndpoints.of(batchPingableLeader))
+                .addAdhocUndertowServices(BatchPingableLeaderEndpoints.of(batchPingableLeader))
                 .timeLockCorruptionComponents(timeLockCorruptionComponents(install.sqliteDataSource(), remoteClients))
                 .build();
     }
@@ -175,10 +175,10 @@ public final class PaxosResourcesFactory {
                 .addAdhocResources(pingableLeader)
                 .addAdhocResources(leaderAcceptorResource)
                 .addAdhocResources(leaderLearnerResource)
-                .addUndertowServices(BatchPingableLeaderEndpoints.of(batchPingableLeader))
-                .addUndertowServices(PingableLeaderEndpoints.of(pingableLeader))
-                .addUndertowServices(LeaderAcceptorResourceEndpoints.of(leaderAcceptorResource))
-                .addUndertowServices(LeaderLearnerResourceEndpoints.of(leaderLearnerResource))
+                .addAdhocUndertowServices(BatchPingableLeaderEndpoints.of(batchPingableLeader))
+                .addAdhocUndertowServices(PingableLeaderEndpoints.of(pingableLeader))
+                .addAdhocUndertowServices(LeaderAcceptorResourceEndpoints.of(leaderAcceptorResource))
+                .addAdhocUndertowServices(LeaderLearnerResourceEndpoints.of(leaderLearnerResource))
                 .timeLockCorruptionComponents(timeLockCorruptionComponents(install.sqliteDataSource(), remoteClients))
                 .build();
     }


### PR DESCRIPTION
## General
**Before this PR**:
NamespaceTakeoverResource is a conjure-defined service implemented and registered as a Jersey resource only
**After this PR**:
NamespaceTakeoverResource is a conjure-defined service implemented and registered as a Jersey resource and Undertow service

==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P2
**Concerns / possible downsides (what feedback would you like?)**:
See my self-review on the code
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
Similar comment as previous PRs relating to failure cases
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
NA
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
No
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
TimeLock startups and we see no 500s, this PR should really be a no-op given this is unused.
**Has the safety of all log arguments been decided correctly?**:
Yes
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
timelock does not startup if things aren't wired correctly, or we see 500s
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Recall and rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
