### PR TITLE
[JUnit5] Postgres ETE tests flup 

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbTimestampStoreInvalidatorCreationTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbTimestampStoreInvalidatorCreationTest.java
@@ -42,11 +42,15 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+// This test class invalidates the default timestamp bound store that is used by other test classes. Since the other
+// test classes rely on the default timestamp bound store being valid, this test class must be executed last.
 @ExtendWith(DbKvsPostgresExtension.class)
+@Order(Integer.MAX_VALUE)
 public class DbTimestampStoreInvalidatorCreationTest {
     private final MetricsManager metrics = MetricsManagers.createForTests();
 

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresEmbeddedDbTimestampBoundStoreTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresEmbeddedDbTimestampBoundStoreTest.java
@@ -21,13 +21,9 @@ import com.palantir.atlasdb.keyvalue.dbkvs.timestamp.InDbTimestampBoundStore;
 import com.palantir.atlasdb.timestamp.AbstractDbTimestampBoundStoreTest;
 import com.palantir.timestamp.TimestampBoundStore;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(DbKvsPostgresExtension.class)
-/* TODO(boyoruk): Investigate why this is needed. If this class does not run first, then some of its methods fail.
- * Although this solution works, we should find the root cause. */
-@Order(1)
 public class PostgresEmbeddedDbTimestampBoundStoreTest extends AbstractDbTimestampBoundStoreTest {
 
     private ConnectionManagerAwareDbKvs kvs;

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresMultiSeriesDbTimestampBoundStoreTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/PostgresMultiSeriesDbTimestampBoundStoreTest.java
@@ -24,14 +24,10 @@ import com.palantir.atlasdb.keyvalue.dbkvs.timestamp.InDbTimestampBoundStore;
 import com.palantir.atlasdb.timestamp.AbstractDbTimestampBoundStoreTest;
 import com.palantir.timestamp.TimestampBoundStore;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(DbKvsPostgresExtension.class)
-/* TODO(boyoruk): Investigate why this is needed. If this class does not run first, then some of its methods fail.
- * Although this solution works, we should find the root cause. */
-@Order(1)
 public class PostgresMultiSeriesDbTimestampBoundStoreTest extends AbstractDbTimestampBoundStoreTest {
 
     private static final TimestampSeries DEFAULT_SERIES = TimestampSeries.of("defaultSeries");


### PR DESCRIPTION
My leftover work from junit5 project. I found out that there is a test class that invalidates default timestamp bound store, which is used by other test classes. If DbTimestampStoreInvalidatorCreationTest runs first, then other fails. For that reason , I changed DbTimestampStoreInvalidatorCreationTest to be run last.