### PR TITLE
Do not use javax UriBuilder in PaxosRemotingUtils

### DIFF
--- a/timelock-agent/build.gradle
+++ b/timelock-agent/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     implementation 'io.dropwizard.metrics:metrics-core'
     implementation 'io.undertow:undertow-core'
     implementation 'javax.ws.rs:javax.ws.rs-api'
-    implementation 'org.apache.httpcomponents.core5:httpcore5'
     implementation 'org.jdbi:jdbi3-core'
     implementation 'org.jdbi:jdbi3-sqlobject'
 

--- a/timelock-agent/build.gradle
+++ b/timelock-agent/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'io.dropwizard.metrics:metrics-core'
     implementation 'io.undertow:undertow-core'
     implementation 'javax.ws.rs:javax.ws.rs-api'
+    implementation 'org.apache.httpcomponents.core5:httpcore5'
     implementation 'org.jdbi:jdbi3-core'
     implementation 'org.jdbi:jdbi3-sqlobject'
 

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosRemotingUtils.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosRemotingUtils.java
@@ -19,14 +19,12 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.timelock.config.ClusterConfiguration;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.apache.hc.core5.net.URIBuilder;
 
 public final class PaxosRemotingUtils {
     private PaxosRemotingUtils() {
@@ -66,8 +64,8 @@ public final class PaxosRemotingUtils {
 
     public static URL convertAddressToUrl(ClusterConfiguration cluster, String address) {
         try {
-            return new URIBuilder(addProtocol(cluster, address)).build().toURL();
-        } catch (MalformedURLException | URISyntaxException e) {
+            return new URL(addProtocol(cluster, address));
+        } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
     }

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosRemotingUtils.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/PaxosRemotingUtils.java
@@ -19,13 +19,14 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.timelock.config.ClusterConfiguration;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javax.ws.rs.core.UriBuilder;
+import org.apache.hc.core5.net.URIBuilder;
 
 public final class PaxosRemotingUtils {
     private PaxosRemotingUtils() {
@@ -65,8 +66,8 @@ public final class PaxosRemotingUtils {
 
     public static URL convertAddressToUrl(ClusterConfiguration cluster, String address) {
         try {
-            return UriBuilder.fromPath(addProtocol(cluster, address)).build().toURL();
-        } catch (MalformedURLException e) {
+            return new URIBuilder(addProtocol(cluster, address)).build().toURL();
+        } catch (MalformedURLException | URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
## General
**Before this PR**:
Usage of UriBuilder blocks the Jakarta migration (see internal migration runbook for suggested change). I also ran into the failure in practice locally and in CI.
**After this PR**:
Use java.net.URL::new instead of javax UriBuilder in PaxosRemotingUtils 
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P2
**Concerns / possible downsides (what feedback would you like?)**:
The semantics aren't exactly the same. UriBuilder supports wildcards in the jax-rs style. As far as I can see, we do not rely on those and only use the common functionality. Usage is also contained only in taking static URIs (from ClusterConfiguration from Conjure Java's PartialServiceConfiguration#uris). There should be no interpolation needed.
**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
Usage is as described in the concerns section
**What was existing testing like? What have you done to improve it?**:
There is testing for PaxosRemotingUtils
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
TimeLock starts up successfully and TimeLock serves requests through the leader and nodes can talk to one another
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
TimeLock does not start up, or network communications between nodes fail
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Recall and rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
N/A
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
