### PR TITLE
Fix flakiness on poisoningMultipleTimesIsAllowed test

### DIFF
--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java
@@ -29,7 +29,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.timestamp.InDbTimestampBoundStore;
 import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
 import com.palantir.timestamp.TimestampBoundStore;
 import java.time.Duration;
-import java.util.UUID;
+import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,11 +50,25 @@ public class DbKvsPostgresInvalidationRunnerTest {
     @BeforeEach
     public void setUp() {
         kvs.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
-        String prefix = UUID.randomUUID().toString().substring(0, 4);
+        String prefix = randomAlphanumericPrefix(4);
         invalidationRunner =
                 new InvalidationRunner(kvs.getConnectionManager(), AtlasDbConstants.TIMESTAMP_TABLE, prefix);
         invalidationRunner.createTableIfDoesNotExist();
         store = getStoreWithPrefix(prefix);
+    }
+
+    private static String randomAlphanumericPrefix(long size) {
+        String alphabet = "abcdefghijklmnopqrstuvwxyz";
+        Random random = new Random();
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for (int i = 0; i < size; i++) {
+            int randomIndex = random.nextInt(alphabet.length());
+            char randomCharacter = alphabet.charAt(randomIndex);
+            stringBuilder.append(randomCharacter);
+        }
+
+        return stringBuilder.toString();
     }
 
     @Test

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.keyvalue.dbkvs.timestamp.InDbTimestampBoundStore;
 import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
 import com.palantir.timestamp.TimestampBoundStore;
 import java.time.Duration;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +43,7 @@ public class DbKvsPostgresInvalidationRunnerTest {
     public static final TestResourceManager TRM = new TestResourceManager(DbKvsPostgresExtension::createKvs);
 
     private final ConnectionManagerAwareDbKvs kvs = (ConnectionManagerAwareDbKvs) TRM.getDefaultKvs();
-    private final TimestampBoundStore store = getStore();
+    private TimestampBoundStore store;
     private final InvalidationRunner invalidationRunner = new InvalidationRunner(
             kvs.getConnectionManager(),
             AtlasDbConstants.TIMESTAMP_TABLE,
@@ -53,6 +54,7 @@ public class DbKvsPostgresInvalidationRunnerTest {
     public void setUp() {
         kvs.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
         invalidationRunner.createTableIfDoesNotExist();
+        store = getStoreWithPrefix(UUID.randomUUID().toString());
     }
 
     @Test
@@ -98,11 +100,8 @@ public class DbKvsPostgresInvalidationRunnerTest {
         assertBoundNotReadableAfterBeingPoisoned();
     }
 
-    public TimestampBoundStore getStore() {
-        return InDbTimestampBoundStore.create(
-                kvs.getConnectionManager(),
-                AtlasDbConstants.TIMESTAMP_TABLE,
-                DbKvsPostgresExtension.getKvsConfig().ddl().tablePrefix());
+    public TimestampBoundStore getStoreWithPrefix(String prefix) {
+        return InDbTimestampBoundStore.create(kvs.getConnectionManager(), AtlasDbConstants.TIMESTAMP_TABLE, prefix);
     }
 
     private void assertBoundNotReadableAfterBeingPoisoned() {

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java
@@ -54,7 +54,7 @@ public class DbKvsPostgresInvalidationRunnerTest {
     public void setUp() {
         kvs.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
         invalidationRunner.createTableIfDoesNotExist();
-        store = getStoreWithPrefix(UUID.randomUUID().toString());
+        store = getStoreWithPrefix(UUID.randomUUID().toString().substring(0, 8));
     }
 
     @Test

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java
@@ -44,17 +44,17 @@ public class DbKvsPostgresInvalidationRunnerTest {
 
     private final ConnectionManagerAwareDbKvs kvs = (ConnectionManagerAwareDbKvs) TRM.getDefaultKvs();
     private TimestampBoundStore store;
-    private final InvalidationRunner invalidationRunner = new InvalidationRunner(
-            kvs.getConnectionManager(),
-            AtlasDbConstants.TIMESTAMP_TABLE,
-            DbKvsPostgresExtension.getKvsConfig().ddl().tablePrefix());
+    private InvalidationRunner invalidationRunner;
     private static final long TIMESTAMP_1 = 12000;
 
     @BeforeEach
     public void setUp() {
         kvs.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
+        String prefix = UUID.randomUUID().toString().substring(0, 4);
+        invalidationRunner =
+                new InvalidationRunner(kvs.getConnectionManager(), AtlasDbConstants.TIMESTAMP_TABLE, prefix);
         invalidationRunner.createTableIfDoesNotExist();
-        store = getStoreWithPrefix(UUID.randomUUID().toString().substring(0, 8));
+        store = getStoreWithPrefix(prefix);
     }
 
     @Test

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java
@@ -51,26 +51,13 @@ public class DbKvsPostgresInvalidationRunnerTest {
 
     @BeforeEach
     public void setUp() {
-        kvs.dropTable(AtlasDbConstants.TIMESTAMP_TABLE);
-        String prefix = nextUniquePrefix(prefixCounter);
+        long nextPrefixCount = prefixCounter.incrementAndGet();
+        String prefix = "n" + nextPrefixCount;
+
         invalidationRunner =
                 new InvalidationRunner(kvs.getConnectionManager(), AtlasDbConstants.TIMESTAMP_TABLE, prefix);
         invalidationRunner.createTableIfDoesNotExist();
         store = getStoreWithPrefix(prefix);
-    }
-
-    // 0 -> "a", 1 -> "b", ..., 25 -> "z", 26 -> "aa", 27 -> "ab", ...
-    private static String nextUniquePrefix(AtomicInteger counter) {
-        int nextValue = counter.getAndIncrement();
-
-        StringBuilder result = new StringBuilder();
-        while (nextValue >= 0) {
-            int remainder = nextValue % 26;
-            result.insert(0, (char) ('a' + remainder));
-            nextValue = (nextValue / 26) - 1;
-        }
-
-        return result.toString();
     }
 
     @Test


### PR DESCRIPTION
## General
**Before this PR**:
poisoningMultipleTimesIsAllowed test was flaky [(example)](https://app.circleci.com/pipelines/github/palantir/atlasdb/16208/workflows/cc89ac33-da84-47c4-ac9d-e925fc0e8d63/jobs/88986/tests)

The reason why it happened is due to a race condition between [InDbTimestampBoundStore.getUpperLimit](https://github.com/palantir/atlasdb/blob/51bb54bc4e38429165286e774e583b092f1df610/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java#L198-L208) and [InDbTimestampBoundStre.storeUpperLimit](https://github.com/palantir/atlasdb/blob/51bb54bc4e38429165286e774e583b092f1df610/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java#L211-L221).

`getUpperLimit` operates by setting the limit to 10_000 if one doesn't yet exists, or simply returning the existing limit if one is found.

`storeUpperLimit` always either updates the existing limit or create a new one if one doesn't exist.

~~Both methods are synchronized, but they can run in parallel with each other. As in, no 2 `storeUpperLimit` or 2 `getUpperLimit` can execute at the same time, but you can have 1 `storeUpperLimit` and 1 `getUpperLimit` running at the same time.~~ (This was just me not know how synchronized works lol). But the race below can still happen since we have different store objects for each test, and they won't be synchronized against each other since they're different objects.

So the case for the race we're fixing here is as follows:

1. [poisonsEmptyTableAndReturnsStoredBound](https://github.com/palantir/atlasdb/blob/51bb54bc4e38429165286e774e583b092f1df610/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java#L66) test starts and calls `getUpperLimit`
2. Since initially there is no limit present, `getUpperLimit` doesn't return [here](https://github.com/palantir/atlasdb/blob/51bb54bc4e38429165286e774e583b092f1df610/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java#L201) and instead proceeds
3. [poisoningMultipleTimesIsAllowed](https://github.com/palantir/atlasdb/blob/51bb54bc4e38429165286e774e583b092f1df610/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java#L80)  starts running and calls `store.storeUpperLimit(12000)`
4. Due to a race, poisoningMultipleTimesIsAllowed.storeUpperLimit write persists before the poisonsEmptyTableAndReturnsStoredBound.getUpperLimit is allowed to proceed with its write. (In memory expected limit = 12000, DB limit = 12000)
5. poisonsEmptyTableAndReturnsStoredBound.getUpperLimit continues executing [here](https://github.com/palantir/atlasdb/blob/51bb54bc4e38429165286e774e583b092f1df610/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java#L205) and persists the default limit of 10_000). (In memory expected limit = 12000, DB limit = 10000)
6. `poisoningMultipleTimesIsAllowed` test continues and calls  [store.getUpperLimit](https://github.com/palantir/atlasdb/blob/51bb54bc4e38429165286e774e583b092f1df610/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresInvalidationRunnerTest.java#L81), but it crashes [here](https://github.com/palantir/atlasdb/blob/51bb54bc4e38429165286e774e583b092f1df610/atlasdb-dbkvs/src/main/java/com/palantir/atlasdb/keyvalue/dbkvs/timestamp/InDbTimestampBoundStore.java#L156-L162) due to expected in memory limit not matching the one that exists in the database.


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
We now namespace each tests, creating a different table prefix for each of them so they don't clash with each other.
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
