### PR TITLE
fix: Forcibly conclude transactions in antithesis workload server before performing durable write invariant validation

### DIFF
--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/store/ReadableTransactionStore.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/store/ReadableTransactionStore.java
@@ -30,7 +30,11 @@ public interface ReadableTransactionStore {
     Optional<Integer> get(String table, WorkloadCell cell);
 
     /**
-     * Checks whether the transaction with the provided startTimestamp has committed.
+     * Attempts to retrieve the state of the transaction starting at the provided timestamp; if the transaction is
+     * still pending (neither committed nor aborted), attempts to abort the transaction. It is guaranteed that when
+     * this method returns normally, the transaction will have concluded (whether committed or aborted).
+     *
+     * @return true if the transaction was committed, false otherwise
      */
-    boolean isCommitted(long startTimestamp);
+    boolean isCommittedForcingTransactionConclusion(long startTimestamp);
 }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionConcluder.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionConcluder.java
@@ -41,7 +41,7 @@ public final class AtlasDbTransactionConcluder {
         }
 
         for (int retry = 0; retry < MAX_RETRIES; retry++) {
-            if (attemptToForceTransactionConclusion(startTimestamp)) {
+            if (tryAbortTransaction(startTimestamp)) {
                 return TransactionStatus.aborted();
             } else {
                 transactionStatus = transactionService.getV2(startTimestamp);
@@ -57,12 +57,11 @@ public final class AtlasDbTransactionConcluder {
     }
 
     // Returns true iff we successfully aborted the transaction at this start timestamp
-    private boolean attemptToForceTransactionConclusion(long startTimestamp) {
+    private boolean tryAbortTransaction(long startTimestamp) {
         try {
             transactionService.putUnlessExists(startTimestamp, TransactionConstants.FAILED_COMMIT_TS);
             return true;
         } catch (KeyAlreadyExistsException keyAlreadyExistsException) {
-            // Transaction was already concluded, but we should perform another get
             return false;
         }
     }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionConcluder.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionConcluder.java
@@ -1,0 +1,73 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.store;
+
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.atlasdb.transaction.service.TransactionStatus;
+import com.palantir.atlasdb.transaction.service.TransactionStatus.Aborted;
+import com.palantir.atlasdb.transaction.service.TransactionStatus.Committed;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+
+public final class AtlasDbTransactionConcluder {
+    private static final int MAX_RETRIES = 5;
+
+    private final TransactionService transactionService;
+
+    public AtlasDbTransactionConcluder(TransactionService transactionService) {
+        this.transactionService = transactionService;
+    }
+
+    public TransactionStatus forceTransactionConclusion(long startTimestamp) {
+        TransactionStatus transactionStatus = transactionService.getV2(startTimestamp);
+        if (isConclusiveTransactionStatus(transactionStatus)) {
+            return transactionStatus;
+        }
+
+        for (int retry = 0; retry < MAX_RETRIES; retry++) {
+            if (attemptToForceTransactionConclusion(startTimestamp)) {
+                return TransactionStatus.aborted();
+            } else {
+                transactionStatus = transactionService.getV2(startTimestamp);
+                if (isConclusiveTransactionStatus(transactionStatus)) {
+                    return transactionStatus;
+                }
+                // Otherwise try again: this can happen if we race with e.g. a Transactions4 start
+            }
+        }
+
+        throw new SafeIllegalStateException(
+                "Failed to force transaction conclusion", SafeArg.of("retries", MAX_RETRIES));
+    }
+
+    // Returns true iff we successfully aborted the transaction at this start timestamp
+    private boolean attemptToForceTransactionConclusion(long startTimestamp) {
+        try {
+            transactionService.putUnlessExists(startTimestamp, TransactionConstants.FAILED_COMMIT_TS);
+            return true;
+        } catch (KeyAlreadyExistsException keyAlreadyExistsException) {
+            // Transaction was already concluded, but we should perform another get
+            return false;
+        }
+    }
+
+    private static boolean isConclusiveTransactionStatus(TransactionStatus status) {
+        return status instanceof Committed || status instanceof Aborted;
+    }
+}

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionConcluder.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionConcluder.java
@@ -26,7 +26,7 @@ import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 
 public final class AtlasDbTransactionConcluder {
-    private static final int MAX_RETRIES = 5;
+    private static final int MAX_ATTEMPTS = 5;
 
     private final TransactionService transactionService;
 
@@ -40,7 +40,7 @@ public final class AtlasDbTransactionConcluder {
             return transactionStatus;
         }
 
-        for (int retry = 0; retry < MAX_RETRIES; retry++) {
+        for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
             if (tryAbortTransaction(startTimestamp)) {
                 return TransactionStatus.aborted();
             } else {
@@ -53,7 +53,7 @@ public final class AtlasDbTransactionConcluder {
         }
 
         throw new SafeIllegalStateException(
-                "Failed to force transaction conclusion", SafeArg.of("retries", MAX_RETRIES));
+                "Failed to force transaction conclusion", SafeArg.of("attempts", MAX_ATTEMPTS));
     }
 
     // Returns true iff we successfully aborted the transaction at this start timestamp

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStore.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionStore.java
@@ -54,13 +54,13 @@ public final class AtlasDbTransactionStore implements InteractiveTransactionStor
 
     private static final SafeLogger log = SafeLoggerFactory.get(AtlasDbTransactionStore.class);
     private final TransactionManager transactionManager;
-    private final AtlasDbTransactionConcluder reader;
+    private final AtlasDbTransactionConcluder transactionConcluder;
 
     private final Map<String, TableReference> tables;
 
     private AtlasDbTransactionStore(TransactionManager transactionManager, Map<String, TableReference> tables) {
         this.transactionManager = transactionManager;
-        this.reader = new AtlasDbTransactionConcluder(transactionManager.getTransactionService());
+        this.transactionConcluder = new AtlasDbTransactionConcluder(transactionManager.getTransactionService());
         this.tables = tables;
     }
 
@@ -72,7 +72,7 @@ public final class AtlasDbTransactionStore implements InteractiveTransactionStor
 
     @Override
     public boolean isCommittedForcingTransactionConclusion(long startTimestamp) {
-        TransactionStatus status = reader.forceTransactionConclusion(startTimestamp);
+        TransactionStatus status = transactionConcluder.forceTransactionConclusion(startTimestamp);
         return status instanceof TransactionStatus.Committed;
     }
 

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/ReadOnlyTransactionStore.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/ReadOnlyTransactionStore.java
@@ -21,6 +21,10 @@ import java.util.Optional;
 /**
  * Facade around {@link ReadableTransactionStore}, to prevent users from casting to retrieve an underlying store that
  * may implement more functionality.
+ *
+ * This store is read only, in the sense that it does not allow for users to directly write to the underlying data
+ * tables. However, reads to the underlying store may require writes to be performed to the transactions table or other
+ * AtlasDB internal tables, following the protocol.
  */
 public final class ReadOnlyTransactionStore implements ReadableTransactionStore {
     private final ReadableTransactionStore delegate;
@@ -35,7 +39,7 @@ public final class ReadOnlyTransactionStore implements ReadableTransactionStore 
     }
 
     @Override
-    public boolean isCommitted(long startTimestamp) {
-        return delegate.isCommitted(startTimestamp);
+    public boolean isCommittedForcingTransactionConclusion(long startTimestamp) {
+        return delegate.isCommittedForcingTransactionConclusion(startTimestamp);
     }
 }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/ReadOnlyTransactionStore.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/store/ReadOnlyTransactionStore.java
@@ -23,8 +23,8 @@ import java.util.Optional;
  * may implement more functionality.
  *
  * This store is read only, in the sense that it does not allow for users to directly write to the underlying data
- * tables. However, reads to the underlying store may require writes to be performed to the transactions table or other
- * AtlasDB internal tables, following the protocol.
+ * tables. However, determining conclusively if a transaction was committed (see
+ * {@link #isCommittedForcingTransactionConclusion(long)} may require writing to the transactions table.
  */
 public final class ReadOnlyTransactionStore implements ReadableTransactionStore {
     private final ReadableTransactionStore delegate;

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/OnlyCommittedWitnessedTransactionVisitor.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/transaction/witnessed/OnlyCommittedWitnessedTransactionVisitor.java
@@ -35,7 +35,8 @@ public final class OnlyCommittedWitnessedTransactionVisitor
 
     @Override
     public Optional<FullyWitnessedTransaction> visit(MaybeWitnessedTransaction maybeWitnessedTransaction) {
-        return readOnlyTransactionStore.isCommitted(maybeWitnessedTransaction.startTimestamp())
+        return readOnlyTransactionStore.isCommittedForcingTransactionConclusion(
+                        maybeWitnessedTransaction.startTimestamp())
                 ? Optional.of(maybeWitnessedTransaction.toFullyWitnessed())
                 : Optional.empty();
     }

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionConcluderTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionConcluderTest.java
@@ -43,11 +43,11 @@ public final class AtlasDbTransactionConcluderTest {
     @Mock
     private TransactionService transactionService;
 
-    private AtlasDbTransactionConcluder transactionTableReader;
+    private AtlasDbTransactionConcluder transactionConcluder;
 
     @BeforeEach
     public void setUp() {
-        transactionTableReader = new AtlasDbTransactionConcluder(transactionService);
+        transactionConcluder = new AtlasDbTransactionConcluder(transactionService);
     }
 
     @MethodSource("concludedTransactionStatuses")
@@ -55,7 +55,7 @@ public final class AtlasDbTransactionConcluderTest {
     public void forceTransactionConclusionPassesThroughConcludedStatuses(TransactionStatus status) {
         when(transactionService.getV2(START_TS)).thenReturn(status);
 
-        assertThat(transactionTableReader.forceTransactionConclusion(START_TS)).isEqualTo(status);
+        assertThat(transactionConcluder.forceTransactionConclusion(START_TS)).isEqualTo(status);
     }
 
     @MethodSource("unconcludedTransactionStatuses")
@@ -63,7 +63,7 @@ public final class AtlasDbTransactionConcluderTest {
     public void forceTransactionConclusionAbortsAndReturnsAbortedForUnconcludedStatuses(TransactionStatus status) {
         when(transactionService.getV2(START_TS)).thenReturn(status);
 
-        assertThat(transactionTableReader.forceTransactionConclusion(START_TS)).isEqualTo(TransactionStatus.aborted());
+        assertThat(transactionConcluder.forceTransactionConclusion(START_TS)).isEqualTo(TransactionStatus.aborted());
         verify(transactionService).putUnlessExists(START_TS, TransactionConstants.FAILED_COMMIT_TS);
     }
 
@@ -76,7 +76,7 @@ public final class AtlasDbTransactionConcluderTest {
                 .when(transactionService)
                 .putUnlessExists(START_TS, TransactionConstants.FAILED_COMMIT_TS);
 
-        assertThat(transactionTableReader.forceTransactionConclusion(START_TS))
+        assertThat(transactionConcluder.forceTransactionConclusion(START_TS))
                 .isEqualTo(TransactionStatus.committed(COMMIT_TS));
     }
 
@@ -90,7 +90,7 @@ public final class AtlasDbTransactionConcluderTest {
                 .when(transactionService)
                 .putUnlessExists(START_TS, TransactionConstants.FAILED_COMMIT_TS);
 
-        assertThat(transactionTableReader.forceTransactionConclusion(START_TS))
+        assertThat(transactionConcluder.forceTransactionConclusion(START_TS))
                 .isEqualTo(TransactionStatus.committed(COMMIT_TS));
     }
 
@@ -102,7 +102,7 @@ public final class AtlasDbTransactionConcluderTest {
         when(transactionService.getV2(START_TS)).thenReturn(status);
         doThrow(exception).when(transactionService).putUnlessExists(START_TS, TransactionConstants.FAILED_COMMIT_TS);
 
-        assertThatThrownBy(() -> transactionTableReader.forceTransactionConclusion(START_TS))
+        assertThatThrownBy(() -> transactionConcluder.forceTransactionConclusion(START_TS))
                 .isEqualTo(exception);
     }
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionConcluderTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/store/AtlasDbTransactionConcluderTest.java
@@ -1,0 +1,116 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.workload.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.atlasdb.transaction.service.TransactionStatus;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public final class AtlasDbTransactionConcluderTest {
+    private static final long START_TS = 1L;
+    private static final long COMMIT_TS = 5L;
+
+    @Mock
+    private TransactionService transactionService;
+
+    private AtlasDbTransactionConcluder transactionTableReader;
+
+    @BeforeEach
+    public void setUp() {
+        transactionTableReader = new AtlasDbTransactionConcluder(transactionService);
+    }
+
+    @MethodSource("concludedTransactionStatuses")
+    @ParameterizedTest
+    public void forceTransactionConclusionPassesThroughConcludedStatuses(TransactionStatus status) {
+        when(transactionService.getV2(START_TS)).thenReturn(status);
+
+        assertThat(transactionTableReader.forceTransactionConclusion(START_TS)).isEqualTo(status);
+    }
+
+    @MethodSource("unconcludedTransactionStatuses")
+    @ParameterizedTest
+    public void forceTransactionConclusionAbortsAndReturnsAbortedForUnconcludedStatuses(TransactionStatus status) {
+        when(transactionService.getV2(START_TS)).thenReturn(status);
+
+        assertThat(transactionTableReader.forceTransactionConclusion(START_TS)).isEqualTo(TransactionStatus.aborted());
+        verify(transactionService).putUnlessExists(START_TS, TransactionConstants.FAILED_COMMIT_TS);
+    }
+
+    @MethodSource("unconcludedTransactionStatuses")
+    @ParameterizedTest
+    public void forceTransactionConclusionReturnsAlternativeConcurrentConclusionIfLosingDataRace(
+            TransactionStatus status) {
+        when(transactionService.getV2(START_TS)).thenReturn(status).thenReturn(TransactionStatus.committed(COMMIT_TS));
+        doThrow(new KeyAlreadyExistsException("key already exists"))
+                .when(transactionService)
+                .putUnlessExists(START_TS, TransactionConstants.FAILED_COMMIT_TS);
+
+        assertThat(transactionTableReader.forceTransactionConclusion(START_TS))
+                .isEqualTo(TransactionStatus.committed(COMMIT_TS));
+    }
+
+    @Test
+    public void forceTransactionConclusionReturnsAlternativeConcurrentConclusionIfLosingDataRaceTwice() {
+        when(transactionService.getV2(START_TS))
+                .thenReturn(TransactionStatus.unknown())
+                .thenReturn(TransactionStatus.inProgress())
+                .thenReturn(TransactionStatus.committed(COMMIT_TS));
+        doThrow(new KeyAlreadyExistsException("key already exists"))
+                .when(transactionService)
+                .putUnlessExists(START_TS, TransactionConstants.FAILED_COMMIT_TS);
+
+        assertThat(transactionTableReader.forceTransactionConclusion(START_TS))
+                .isEqualTo(TransactionStatus.committed(COMMIT_TS));
+    }
+
+    @MethodSource("unconcludedTransactionStatuses")
+    @ParameterizedTest
+    public void forceTransactionConclusionPropagatesGenericException(TransactionStatus status) {
+        RuntimeException exception = new RuntimeException("i am arbitrary");
+
+        when(transactionService.getV2(START_TS)).thenReturn(status);
+        doThrow(exception).when(transactionService).putUnlessExists(START_TS, TransactionConstants.FAILED_COMMIT_TS);
+
+        assertThatThrownBy(() -> transactionTableReader.forceTransactionConclusion(START_TS))
+                .isEqualTo(exception);
+    }
+
+    private static Stream<TransactionStatus> concludedTransactionStatuses() {
+        return Stream.of(TransactionStatus.aborted(), TransactionStatus.committed(COMMIT_TS));
+    }
+
+    private static Stream<TransactionStatus> unconcludedTransactionStatuses() {
+        return Stream.of(TransactionStatus.inProgress(), TransactionStatus.unknown());
+    }
+}

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/OnlyCommittedWitnessedTransactionVisitorTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/OnlyCommittedWitnessedTransactionVisitorTest.java
@@ -51,14 +51,16 @@ public class OnlyCommittedWitnessedTransactionVisitorTest {
 
     @Test
     public void maybeCommittedTransactionReturnsEmptyWhenNotCommitted() {
-        when(transactionStore.isCommitted(anyLong())).thenReturn(false);
+        when(transactionStore.isCommittedForcingTransactionConclusion(anyLong()))
+                .thenReturn(false);
         assertThat(MAYBE_WITNESSED_TRANSACTION.accept(new OnlyCommittedWitnessedTransactionVisitor(transactionStore)))
                 .isEmpty();
     }
 
     @Test
     public void maybeCommittedTransactionReturnsFullyWitnessedWhenCommitted() {
-        when(transactionStore.isCommitted(anyLong())).thenReturn(true);
+        when(transactionStore.isCommittedForcingTransactionConclusion(anyLong()))
+                .thenReturn(true);
         assertThat(MAYBE_WITNESSED_TRANSACTION.accept(new OnlyCommittedWitnessedTransactionVisitor(transactionStore)))
                 .contains(MAYBE_WITNESSED_TRANSACTION.toFullyWitnessed());
     }

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/transaction/witnessed/WitnessedTransactionsTest.java
@@ -111,7 +111,8 @@ public class WitnessedTransactionsTest {
 
     private MaybeWitnessedTransaction createMaybeWitnessedTransactionWithoutActions(
             long start, long commit, boolean committed) {
-        when(readOnlyTransactionStore.isCommitted(eq(start))).thenReturn(committed);
+        when(readOnlyTransactionStore.isCommittedForcingTransactionConclusion(eq(start)))
+                .thenReturn(committed);
         return MaybeWitnessedTransaction.builder()
                 .startTimestamp(start)
                 .commitTimestamp(commit)

--- a/changelog/@unreleased/pr-6993.v2.yml
+++ b/changelog/@unreleased/pr-6993.v2.yml
@@ -1,0 +1,11 @@
+type: fix
+fix:
+  description: We've fixed at least one known source of durable writes violations.
+    Specifically, the issue is that a MaybeWitnessedTransaction is currently filtered
+    out if it has not definitively committed. However, that is not a guarantee that
+    it won't subsequently commit if e.g. cassandra is slow and it told the worker
+    thread that it failed, but it actually did not. Future AtlasDB readers will normally
+    force the question of whether a given value committed or was definitely aborted
+    before returning, but the workload server generally did not do this.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6993


### PR DESCRIPTION
## General
**Before this PR**: There were a number of failures reported by the workload server, especially on the transient rows test, suggesting durable writes violations.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
We've fixed at least one known source of durable writes violations. 

Specifically, the issue is that a `MaybeWitnessedTransaction` is currently filtered out if it has not definitively committed. However, that is not a guarantee that it won't subsequently commit if e.g. cassandra is slow and the worker thread thought that it failed (network transport failures or similar), but it actually did not. This gives rise to the following race condition:

- A transaction that's part of a workload task failed with an exception during the commit stage. We keep track of this as a `MaybeWitnessedTransaction`. _Crucially, this does NOT mean that the transaction had not, or will not commit from a Cassandra perspective: it could be a connection timeout or similar._ Let's call this transaction A.
- The workload completes, and we begin validation. As part of this, we call into the `OnlyCommittedWitnessedTransactionVisitor`. This attempts to get the start timestamps of transactions, keeping those that are known to have a present start timestamp. This filters out A.
- Transaction A commits (at some point in time after the visitor had run, or at least run on A). Notice that this does not require any client-side action: it could be that the coordinator slept or even crashed after getting approval for the Paxos proposal from the other nodes and was recovering.
- The durable writes invariant involves replaying the state of the committed transactions on an in-memory store and then checking this against the actual database. However, the in memory store will not include the writes that transaction A did, but a reader of the database that reads at a fresh timestamp _will_ read any writes that transaction A did (notice that this fresh timestamp is much later than the logical commit timestamp of A, even if wall-clock wise they may be much closer or even reversed in the event of clock drift), hence an invariant violation.

**Priority**: High P2, let's get more efficiency of our testing hours

**Concerns / possible downsides (what feedback would you like?)**:
- The abort logic feels like it duplicates some of the core internals of `CommitTimestampLoader`, though I'm not sure reusing some inner class of `atlasdb-impl-shared` is the right design anyway.

**Is documentation needed?**: No.

## Compatibility
Skipping section as this PR only touches the workload server

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing much honestly

**What was existing testing like? What have you done to improve it?**: Added tests for the force-conclusion mechanism

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: No

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: No

## Execution
Skipping section as this PR only touches the workload server

## Scale
Skipping section as this PR only touches the workload server

## Development Process
**Where should we start reviewing?**: AtlasDbTransactionConcluder

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: NA

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
