### PR TITLE
improvement: Sleep between attempts to validate invariants in the workload server, and retry

### DIFF
--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
@@ -150,7 +150,7 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
         List<WorkflowAndInvariants<Workflow>> allWorkflowsAndInvariants =
                 createAllWorkflowsAndInvariants(configuration, environment, transactionStoreFactory);
 
-        new AntithesisWorkflowValidatorRunner(new DefaultWorkflowRunner(
+        AntithesisWorkflowValidatorRunner.create(new DefaultWorkflowRunner(
                         MoreExecutors.listeningDecorator(antithesisWorkflowRunnerExecutorService)))
                 .run(() -> selectWorkflowsToRun(configuration, allWorkflowsAndInvariants));
 

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunner.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunner.java
@@ -94,7 +94,7 @@ public final class AntithesisWorkflowValidatorRunner implements WorkflowValidato
                             SafeArg.of("maxAttempts", MAX_ATTEMPTS),
                             e);
 
-                    // A simple linear backoff. We don't need exponentiality, as we don't expect this to overload
+                    // A simple constant backoff. We don't need exponentiality, as we don't expect this to overload
                     // Cassandra or other dependencies. We also don't need jitter, as we normally only deploy one
                     // instance of the workload (and generally won't deploy more than a few).
                     Uninterruptibles.sleepUninterruptibly(SLEEP_BETWEEN_ATTEMPTS.toSeconds(), TimeUnit.SECONDS);

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunner.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunner.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.workload.runner;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -40,8 +41,11 @@ import java.util.stream.Collectors;
 
 public final class AntithesisWorkflowValidatorRunner implements WorkflowValidatorRunner<Workflow> {
     private static final SafeLogger log = SafeLoggerFactory.get(AntithesisWorkflowValidatorRunner.class);
-    private static final int MAX_ATTEMPTS = 10;
     private static final Duration DEFAULT_VALIDATION_RETRY_INTERVAL = Duration.ofSeconds(5);
+
+    @VisibleForTesting
+    static final int MAX_ATTEMPTS = 10;
+
     private final WorkflowRunner<Workflow> workflowRunner;
     private final Duration validationRetryInterval;
 
@@ -55,7 +59,8 @@ public final class AntithesisWorkflowValidatorRunner implements WorkflowValidato
         return new AntithesisWorkflowValidatorRunner(workflowRunner, DEFAULT_VALIDATION_RETRY_INTERVAL);
     }
 
-    public static WorkflowValidatorRunner<Workflow> createForTests(WorkflowRunner<Workflow> workflowRunner) {
+    @VisibleForTesting
+    static WorkflowValidatorRunner<Workflow> createForTests(WorkflowRunner<Workflow> workflowRunner) {
         return new AntithesisWorkflowValidatorRunner(workflowRunner, Duration.ZERO);
     }
 

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunner.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunner.java
@@ -41,11 +41,21 @@ import java.util.stream.Collectors;
 public final class AntithesisWorkflowValidatorRunner implements WorkflowValidatorRunner<Workflow> {
     private static final SafeLogger log = SafeLoggerFactory.get(AntithesisWorkflowValidatorRunner.class);
     private static final int MAX_ATTEMPTS = 10;
-    private static final Duration SLEEP_BETWEEN_ATTEMPTS = Duration.ofSeconds(5);
+    private static final Duration DEFAULT_VALIDATION_RETRY_INTERVAL = Duration.ofSeconds(5);
     private final WorkflowRunner<Workflow> workflowRunner;
+    private final Duration validationRetryInterval;
 
-    public AntithesisWorkflowValidatorRunner(WorkflowRunner<Workflow> workflowRunner) {
+    private AntithesisWorkflowValidatorRunner(WorkflowRunner<Workflow> workflowRunner, Duration validationRetryInterval) {
         this.workflowRunner = workflowRunner;
+        this.validationRetryInterval = validationRetryInterval;
+    }
+
+    public static WorkflowValidatorRunner<Workflow> create(WorkflowRunner<Workflow> workflowRunner) {
+        return new AntithesisWorkflowValidatorRunner(workflowRunner, DEFAULT_VALIDATION_RETRY_INTERVAL);
+    }
+
+    public static WorkflowValidatorRunner<Workflow> createForTests(WorkflowRunner<Workflow> workflowRunner) {
+        return new AntithesisWorkflowValidatorRunner(workflowRunner, Duration.ZERO);
     }
 
     // The only reason this receives a supplier, is that we need to start faults before actually selecting the
@@ -84,7 +94,7 @@ public final class AntithesisWorkflowValidatorRunner implements WorkflowValidato
                 if (attempt == MAX_ATTEMPTS - 1) {
                     log.error(
                             "Caught an exception when running and reporting an invariant; have retried the maximal"
-                                    + " number of times. Throwing.",
+                                    + " number of times. Will no longer attempt to validate.",
                             SafeArg.of("numAttempts", MAX_ATTEMPTS),
                             e);
                 } else {
@@ -97,7 +107,7 @@ public final class AntithesisWorkflowValidatorRunner implements WorkflowValidato
                     // A simple constant backoff. We don't need exponentiality, as we don't expect this to overload
                     // Cassandra or other dependencies. We also don't need jitter, as we normally only deploy one
                     // instance of the workload (and generally won't deploy more than a few).
-                    Uninterruptibles.sleepUninterruptibly(SLEEP_BETWEEN_ATTEMPTS.toSeconds(), TimeUnit.SECONDS);
+                    Uninterruptibles.sleepUninterruptibly(validationRetryInterval.toSeconds(), TimeUnit.SECONDS);
                 }
             }
         }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunner.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunner.java
@@ -45,7 +45,8 @@ public final class AntithesisWorkflowValidatorRunner implements WorkflowValidato
     private final WorkflowRunner<Workflow> workflowRunner;
     private final Duration validationRetryInterval;
 
-    private AntithesisWorkflowValidatorRunner(WorkflowRunner<Workflow> workflowRunner, Duration validationRetryInterval) {
+    private AntithesisWorkflowValidatorRunner(
+            WorkflowRunner<Workflow> workflowRunner, Duration validationRetryInterval) {
         this.workflowRunner = workflowRunner;
         this.validationRetryInterval = validationRetryInterval;
     }

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunnerTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunnerTest.java
@@ -83,9 +83,15 @@ public class AntithesisWorkflowValidatorRunnerTest {
 
     @Test
     public void runValidatesAllInvariantsRetryingOnExceptions() {
-        doThrow(new RuntimeException()).doAnswer(invocation -> null).when(invariantReporterOne).report(any());
-        doThrow(new RuntimeException()).doThrow(new RuntimeException()).doAnswer(invocation -> null).
-                when(invariantReporterTwo).report(any());
+        doThrow(new RuntimeException())
+                .doAnswer(invocation -> null)
+                .when(invariantReporterOne)
+                .report(any());
+        doThrow(new RuntimeException())
+                .doThrow(new RuntimeException())
+                .doAnswer(invocation -> null)
+                .when(invariantReporterTwo)
+                .report(any());
         AntithesisWorkflowValidatorRunner.createForTests(workflowRunner).run(workflowAndInvariants);
         verify(workflow, times(1)).run();
         verify(invariantReporterOne, times(2)).report(any());
@@ -120,11 +126,11 @@ public class AntithesisWorkflowValidatorRunnerTest {
         });
 
         doAnswer(_invocation -> {
-            assertThat(slowWorkflowIsDone.get())
-                    .as("the invariant reporter ran, even though the slow workflow was not done yet")
-                    .isTrue();
-            return null;
-        })
+                    assertThat(slowWorkflowIsDone.get())
+                            .as("the invariant reporter ran, even though the slow workflow was not done yet")
+                            .isTrue();
+                    return null;
+                })
                 .when(invariantReporterOne)
                 .report(any());
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunnerTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunnerTest.java
@@ -104,8 +104,8 @@ public class AntithesisWorkflowValidatorRunnerTest {
         doThrow(new RuntimeException()).when(invariantReporterTwo).report(any());
         AntithesisWorkflowValidatorRunner.createForTests(workflowRunner).run(workflowAndInvariants);
         verify(workflow, times(1)).run();
-        verify(invariantReporterOne, times(10)).report(any());
-        verify(invariantReporterTwo, times(10)).report(any());
+        verify(invariantReporterOne, times(AntithesisWorkflowValidatorRunner.MAX_ATTEMPTS)).report(any());
+        verify(invariantReporterTwo, times(AntithesisWorkflowValidatorRunner.MAX_ATTEMPTS)).report(any());
     }
 
     @Test
@@ -126,11 +126,11 @@ public class AntithesisWorkflowValidatorRunnerTest {
         });
 
         doAnswer(_invocation -> {
-                    assertThat(slowWorkflowIsDone.get())
-                            .as("the invariant reporter ran, even though the slow workflow was not done yet")
-                            .isTrue();
-                    return null;
-                })
+            assertThat(slowWorkflowIsDone.get())
+                    .as("the invariant reporter ran, even though the slow workflow was not done yet")
+                    .isTrue();
+            return null;
+        })
                 .when(invariantReporterOne)
                 .report(any());
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunnerTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunnerTest.java
@@ -104,8 +104,10 @@ public class AntithesisWorkflowValidatorRunnerTest {
         doThrow(new RuntimeException()).when(invariantReporterTwo).report(any());
         AntithesisWorkflowValidatorRunner.createForTests(workflowRunner).run(workflowAndInvariants);
         verify(workflow, times(1)).run();
-        verify(invariantReporterOne, times(AntithesisWorkflowValidatorRunner.MAX_ATTEMPTS)).report(any());
-        verify(invariantReporterTwo, times(AntithesisWorkflowValidatorRunner.MAX_ATTEMPTS)).report(any());
+        verify(invariantReporterOne, times(AntithesisWorkflowValidatorRunner.MAX_ATTEMPTS))
+                .report(any());
+        verify(invariantReporterTwo, times(AntithesisWorkflowValidatorRunner.MAX_ATTEMPTS))
+                .report(any());
     }
 
     @Test
@@ -126,11 +128,11 @@ public class AntithesisWorkflowValidatorRunnerTest {
         });
 
         doAnswer(_invocation -> {
-            assertThat(slowWorkflowIsDone.get())
-                    .as("the invariant reporter ran, even though the slow workflow was not done yet")
-                    .isTrue();
-            return null;
-        })
+                    assertThat(slowWorkflowIsDone.get())
+                            .as("the invariant reporter ran, even though the slow workflow was not done yet")
+                            .isTrue();
+                    return null;
+                })
                 .when(invariantReporterOne)
                 .report(any());
 

--- a/changelog/@unreleased/pr-6994.v2.yml
+++ b/changelog/@unreleased/pr-6994.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: If an exception is thrown when validating an invariant, we sleep for
+    five seconds and then attempt validation again. This likely reduces the false
+    positive rate of the workload server.
+  links:
+  - https://github.com/palantir/atlasdb/pull/6994


### PR DESCRIPTION
## General
**Before this PR**: We only attempt to validate each workflow once. While faults have stopped by this point, Cassandra or Timelock may still be recovering from faults in this state.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
If an exception is thrown when validating an invariant, we sleep for five seconds and then attempt validation again. This likely reduces the false positive rate of the workload server.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
- The sleep duration chosen was somewhat arbitrary. I'm happy to take suggestions here (the rough thinking was we would probably care if a simple network outage or leader election took 50 seconds to recover).
- I use a simple, constant backoff. I claim this suffices (see comments), do you agree?

**Is documentation needed?**: No.

## Compatibility
Skipping section as this only affects the workload server.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That we care about 50 second recovery times.

**What was existing testing like? What have you done to improve it?**: Not too much: CI should check that this doesn't generally break things, and then it's a question

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:  Nothing in particular

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: No

## Execution
Skipping section: workload server only.

## Scale
Skipping section: workload server only.

## Development Process
**Where should we start reviewing?**: The one file

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
