### PR TITLE
allow user of InMemoryKeyValueService to override the default OverwriteBehaviour

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/InMemoryKeyValueService.java
@@ -98,14 +98,21 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
     private final ConcurrentMap<TableReference, Table> tables = new ConcurrentHashMap<>();
     private final ConcurrentMap<TableReference, byte[]> tableMetadata = new ConcurrentHashMap<>();
     private final boolean createTablesAutomatically;
+    private final OverwriteBehaviour overwriteBehaviour;
 
     public InMemoryKeyValueService(boolean createTablesAutomatically) {
         this(createTablesAutomatically, MoreExecutors.newDirectExecutorService());
     }
 
     public InMemoryKeyValueService(boolean createTablesAutomatically, ExecutorService executor) {
+        this(createTablesAutomatically, executor, OverwriteBehaviour.OVERWRITE_SAME_VALUE);
+    }
+
+    public InMemoryKeyValueService(
+            boolean createTablesAutomatically, ExecutorService executor, OverwriteBehaviour overwriteBehaviour) {
         super(executor);
         this.createTablesAutomatically = createTablesAutomatically;
+        this.overwriteBehaviour = overwriteBehaviour;
     }
 
     @Override
@@ -406,14 +413,12 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
     @Override
     public void put(TableReference tableRef, Map<Cell, byte[]> values, long timestamp) {
         putInternal(
-                tableRef,
-                KeyValueServices.toConstantTimestampValues(values.entrySet(), timestamp),
-                OverwriteBehaviour.OVERWRITE_SAME_VALUE);
+                tableRef, KeyValueServices.toConstantTimestampValues(values.entrySet(), timestamp), overwriteBehaviour);
     }
 
     @Override
     public void putWithTimestamps(TableReference tableRef, Multimap<Cell, Value> values) {
-        putInternal(tableRef, values.entries(), OverwriteBehaviour.OVERWRITE_SAME_VALUE);
+        putInternal(tableRef, values.entries(), overwriteBehaviour);
     }
 
     @Override
@@ -468,7 +473,7 @@ public class InMemoryKeyValueService extends AbstractKeyValueService {
         return true;
     }
 
-    private enum OverwriteBehaviour {
+    public enum OverwriteBehaviour {
         DO_NOT_OVERWRITE,
         OVERWRITE_SAME_VALUE,
         OVERWRITE;

--- a/changelog/@unreleased/pr-6996.v2.yml
+++ b/changelog/@unreleased/pr-6996.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: allow user of InMemoryKeyValueService to override the default OverwriteBehaviour
+  links:
+  - https://github.com/palantir/atlasdb/pull/6996


### PR DESCRIPTION
## General
**Before this PR**:
InMemoryKeyValueService throws a `KeyAlreadyExistsException` if two puts for the same Cell and timestamp are submitted with different values. This doesn't match the behavior of Cassandra, where unless putUnlessExists is used, the database will tolerate puts on the same Cell+timestamp.

**After this PR**:
I'd like the InMemoryKeyValueService to have the same behavior as CassandraKeyValueServiceImpl, so this PR allows you to override the OverwriteBehaviour used in put and putWithTimestamps to `OVERWRITE` instead of `OVERWRITE_SAME_VALUE`, which should match the behavior of Cassandra.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
allow user of InMemoryKeyValueService to override the default OverwriteBehaviour
==COMMIT_MSG==

This is not a breaking change, and is solely used by my test code.
