### PR TITLE
Dual Read Validation

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueService.java
@@ -30,7 +30,6 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.processors.AutoDelegate;
-import com.palantir.processors.DoDelegate;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.util.Map;
 import java.util.Optional;
@@ -74,8 +73,5 @@ public interface TransactionKeyValueService {
     void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, long timestamp)
             throws KeyAlreadyExistsException;
 
-    @DoDelegate
-    default Optional<TransactionKeyValueService> maybeValidationReadTarget() {
-        return Optional.empty();
-    }
+    Optional<TransactionKeyValueService> maybeValidationReadTarget();
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueService.java
@@ -73,5 +73,5 @@ public interface TransactionKeyValueService {
     void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, long timestamp)
             throws KeyAlreadyExistsException;
 
-    Optional<TransactionKeyValueService> maybeValidationReadTarget();
+    Optional<TransactionKeyValueService> maybeValidationReadTarget(TableReference tableRef);
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueService.java
@@ -30,8 +30,10 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.processors.AutoDelegate;
+import com.palantir.processors.DoDelegate;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Key-Value API to be used with user data tables.
@@ -71,4 +73,9 @@ public interface TransactionKeyValueService {
 
     void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, long timestamp)
             throws KeyAlreadyExistsException;
+
+    @DoDelegate
+    default Optional<TransactionKeyValueService> maybeValidationReadTarget() {
+        return Optional.empty();
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.keyvalue.api;
 
 import com.google.common.collect.Multimap;
 import com.google.errorprone.annotations.MustBeClosed;
+import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
 import com.palantir.atlasdb.metrics.Timed;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.common.annotation.Idempotent;
@@ -30,6 +31,7 @@ import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -717,5 +719,10 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
         // This is in general True, but we're setting to false to start rollout only for C* of stopping to check for
         // immutable timestamp lock on non empty reads on thoroughly swept tables.
         return false;
+    }
+
+    @DoDelegate
+    default Optional<TransactionKeyValueService> maybeValidationReadTarget() {
+        return Optional.empty();
     }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -722,7 +722,7 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     }
 
     @DoDelegate
-    default Optional<TransactionKeyValueService> maybeValidationReadTarget() {
+    default Optional<TransactionKeyValueService> maybeValidationReadTarget(TableReference _tableRef) {
         return Optional.empty();
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DefaultTransactionKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DefaultTransactionKeyValueService.java
@@ -103,7 +103,7 @@ public final class DefaultTransactionKeyValueService implements TransactionKeyVa
     }
 
     @Override
-    public Optional<TransactionKeyValueService> maybeValidationReadTarget() {
-        return delegate.maybeValidationReadTarget();
+    public Optional<TransactionKeyValueService> maybeValidationReadTarget(TableReference tableRef) {
+        return delegate.maybeValidationReadTarget(tableRef);
     }
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DefaultTransactionKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DefaultTransactionKeyValueService.java
@@ -33,6 +33,7 @@ import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.util.Map;
+import java.util.Optional;
 
 public final class DefaultTransactionKeyValueService implements TransactionKeyValueService {
 
@@ -99,5 +100,10 @@ public final class DefaultTransactionKeyValueService implements TransactionKeyVa
     public void multiPut(Map<TableReference, ? extends Map<Cell, byte[]>> valuesByTable, long timestamp)
             throws KeyAlreadyExistsException {
         delegate.multiPut(valuesByTable, timestamp);
+    }
+
+    @Override
+    public Optional<TransactionKeyValueService> maybeValidationReadTarget() {
+        return delegate.maybeValidationReadTarget();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1034,7 +1034,7 @@ public class SnapshotTransaction extends AbstractTransaction
                                 public void onSuccess(Map<Cell, byte[]> fromValidationReadTarget) {
                                     fromKeyValueService.forEach((cell, value) -> {
                                         byte[] otherValue = fromValidationReadTarget.get(cell);
-                                        if (otherValue == null || !Arrays.equals(value, otherValue)) {
+                                        if (!Arrays.equals(value, otherValue)) {
                                             // TODO(rhuffman): report a metric here instead of throwing
                                             throw new SafeIllegalStateException("Validation read conflict");
                                         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1035,6 +1035,7 @@ public class SnapshotTransaction extends AbstractTransaction
                                     fromKeyValueService.forEach((cell, value) -> {
                                         byte[] otherValue = fromValidationReadTarget.get(cell);
                                         if (otherValue == null || !Arrays.equals(value, otherValue)) {
+                                            // TODO(rhuffman): report a metric here instead of throwing
                                             throw new SafeIllegalStateException("Validation read conflict");
                                         }
                                     });

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1013,7 +1013,7 @@ public class SnapshotTransaction extends AbstractTransaction
         long expectedNumberOfPresentCellsToFetch = numberOfExpectedPresentCells - numberOfNonDeleteLocalWrites;
 
         Optional<ListenableFuture<Map<Cell, byte[]>>> maybeFromValidationReadTarget = asyncKeyValueService
-                .maybeValidationReadTarget()
+                .maybeValidationReadTarget(tableRef)
                 .map(validationReadTarget -> getFromKeyValueService(
                         tableRef,
                         Sets.difference(cells, result.keySet()),


### PR DESCRIPTION
## General
**Before this PR**:

**After this PR**:
This is an in-progress attempt to enable dual-reading at the snapshot transaction level when providing a custom KeyValueService implementation. KeyValueService is already an existing plugin point that we use for dual-writing, so this implementation results in a minimal code change to Atlas.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
support dual read validation
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
