### PR TITLE
improvement: Resolve flakes in AMNPTLSIT (AbstractMultiNodePaxosTimeLockServerIntegrationTest)

### DIFF
--- a/changelog/@unreleased/pr-7002.v2.yml
+++ b/changelog/@unreleased/pr-7002.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: One of the flaky tests has been removed as its behaviour (the leader
+    services requests) is indirectly tested by many other nodes. The other was changed
+    to handle a leader election. Generally these 2 flakes relate to check then act
+    problems for which node of timelock the leader is.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7002

--- a/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
@@ -55,6 +55,7 @@ import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.SimpleHeldLocksToken;
 import com.palantir.lock.StringLockDescriptor;
 import com.palantir.lock.client.ConjureLockRequests;
+import com.palantir.lock.client.NamespacedConjureTimelockServiceImpl;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.v2.LeadershipId;
 import com.palantir.lock.v2.LockRequest;
@@ -598,8 +599,9 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
         // Whether we hit the multi client endpoint or conjureTimelockService endpoint(services one client in one
         // call), for a namespace, the underlying service to process the request is the same
         multiClientResponses.forEach((namespace, responseFromBatchedEndpoint) -> {
-            GetCommitTimestampsResponse conjureGetCommitTimestampResponse =
-                    client.namespacedConjureTimelockService().getCommitTimestamps(defaultCommitTimestampRequest());
+            GetCommitTimestampsResponse conjureGetCommitTimestampResponse = new NamespacedConjureTimelockServiceImpl(
+                            client.conjureTimelockService(), namespace.get())
+                    .getCommitTimestamps(defaultCommitTimestampRequest());
             if (conjureGetCommitTimestampResponse
                     .getLockWatchUpdate()
                     .logId()

--- a/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
@@ -123,8 +123,8 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
     public void nonLeadersReturn503_conjure() {
         cluster.nonLeaders(client.namespace()).forEach((namespace, server) -> {
             assertThatThrownBy(() -> server.client(namespace)
-                    .namespacedConjureTimelockService()
-                    .leaderTime())
+                            .namespacedConjureTimelockService()
+                            .leaderTime())
                     .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
         });
     }
@@ -369,18 +369,18 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
                         refreshed -> assertThat(refreshed.getTokenId()).isEqualTo(refreshed.getTokenId()));
         AuthHeader authHeader = AuthHeader.valueOf("Bearer unused");
         assertThat(client.conjureLegacyLockService()
-                .refreshLockRefreshTokens(authHeader, client.namespace(), ImmutableList.of(conjureAnalogue)))
+                        .refreshLockRefreshTokens(authHeader, client.namespace(), ImmutableList.of(conjureAnalogue)))
                 .as("it is possible to refresh a live token through the conjure API")
                 .hasOnlyOneElementSatisfying(
                         refreshed -> assertThat(refreshed.getTokenId()).isEqualTo(refreshed.getTokenId()));
 
         ConjureSimpleHeldLocksToken conjureHeldLocksToken = ConjureSimpleHeldLocksToken.of(token.getTokenId(), 0L);
         assertThat(client.conjureLegacyLockService()
-                .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
+                        .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
                 .as("it is possible to unlock a live token through the conjure API")
                 .isTrue();
         assertThat(client.conjureLegacyLockService()
-                .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
+                        .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
                 .as("a token unlocked through the conjure API stays unlocked")
                 .isFalse();
         assertThat(client.legacyLockService().unlockSimple(SimpleHeldLocksToken.fromLockRefreshToken(token)))
@@ -416,8 +416,8 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
                 .as("lock taken by conjure impl that was unlocked can now be acquired by legacy impl")
                 .isNotNull();
         assertThat(client.conjureLegacyLockService()
-                .lockAndGetHeldLocks(
-                        AuthHeader.valueOf("Bearer unused"), client.namespace(), conjureLockRequest))
+                        .lockAndGetHeldLocks(
+                                AuthHeader.valueOf("Bearer unused"), client.namespace(), conjureLockRequest))
                 .as("if the legacy impl has taken a lock, the conjure impl mustn't be able to take it")
                 .isEmpty();
     }
@@ -600,7 +600,9 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
         multiClientResponses.forEach((namespace, responseFromBatchedEndpoint) -> {
             GetCommitTimestampsResponse conjureGetCommitTimestampResponse =
                     client.namespacedConjureTimelockService().getCommitTimestamps(defaultCommitTimestampRequest());
-            if (conjureGetCommitTimestampResponse.getLockWatchUpdate().logId()
+            if (conjureGetCommitTimestampResponse
+                    .getLockWatchUpdate()
+                    .logId()
                     .equals(responseFromBatchedEndpoint.getLockWatchUpdate().logId())) {
                 assertThat(conjureGetCommitTimestampResponse.getInclusiveLower())
                         .as("timestamps should contiguously increase per namespace if there are no elections.")
@@ -791,10 +793,10 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
         assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
 
         assertThat(startedTransactions.values().stream()
-                .map(ConjureStartTransactionsResponse::getTimestamps)
-                .mapToLong(partitionedTimestamps ->
-                        partitionedTimestamps.stream().count())
-                .sum())
+                        .map(ConjureStartTransactionsResponse::getTimestamps)
+                        .mapToLong(partitionedTimestamps ->
+                                partitionedTimestamps.stream().count())
+                        .sum())
                 .isEqualTo(namespaces.size() * numTransactions);
         return startedTransactions;
     }

--- a/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
@@ -123,8 +123,8 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
     public void nonLeadersReturn503_conjure() {
         cluster.nonLeaders(client.namespace()).forEach((namespace, server) -> {
             assertThatThrownBy(() -> server.client(namespace)
-                    .namespacedConjureTimelockService()
-                    .leaderTime())
+                            .namespacedConjureTimelockService()
+                            .leaderTime())
                     .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
         });
     }
@@ -369,18 +369,18 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
                         refreshed -> assertThat(refreshed.getTokenId()).isEqualTo(refreshed.getTokenId()));
         AuthHeader authHeader = AuthHeader.valueOf("Bearer unused");
         assertThat(client.conjureLegacyLockService()
-                .refreshLockRefreshTokens(authHeader, client.namespace(), ImmutableList.of(conjureAnalogue)))
+                        .refreshLockRefreshTokens(authHeader, client.namespace(), ImmutableList.of(conjureAnalogue)))
                 .as("it is possible to refresh a live token through the conjure API")
                 .hasOnlyOneElementSatisfying(
                         refreshed -> assertThat(refreshed.getTokenId()).isEqualTo(refreshed.getTokenId()));
 
         ConjureSimpleHeldLocksToken conjureHeldLocksToken = ConjureSimpleHeldLocksToken.of(token.getTokenId(), 0L);
         assertThat(client.conjureLegacyLockService()
-                .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
+                        .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
                 .as("it is possible to unlock a live token through the conjure API")
                 .isTrue();
         assertThat(client.conjureLegacyLockService()
-                .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
+                        .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
                 .as("a token unlocked through the conjure API stays unlocked")
                 .isFalse();
         assertThat(client.legacyLockService().unlockSimple(SimpleHeldLocksToken.fromLockRefreshToken(token)))
@@ -416,8 +416,8 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
                 .as("lock taken by conjure impl that was unlocked can now be acquired by legacy impl")
                 .isNotNull();
         assertThat(client.conjureLegacyLockService()
-                .lockAndGetHeldLocks(
-                        AuthHeader.valueOf("Bearer unused"), client.namespace(), conjureLockRequest))
+                        .lockAndGetHeldLocks(
+                                AuthHeader.valueOf("Bearer unused"), client.namespace(), conjureLockRequest))
                 .as("if the legacy impl has taken a lock, the conjure impl mustn't be able to take it")
                 .isEmpty();
     }
@@ -785,10 +785,10 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
         assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
 
         assertThat(startedTransactions.values().stream()
-                .map(ConjureStartTransactionsResponse::getTimestamps)
-                .mapToLong(partitionedTimestamps ->
-                        partitionedTimestamps.stream().count())
-                .sum())
+                        .map(ConjureStartTransactionsResponse::getTimestamps)
+                        .mapToLong(partitionedTimestamps ->
+                                partitionedTimestamps.stream().count())
+                        .sum())
                 .isEqualTo(namespaces.size() * numTransactions);
         return startedTransactions;
     }

--- a/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
@@ -123,8 +123,8 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
     public void nonLeadersReturn503_conjure() {
         cluster.nonLeaders(client.namespace()).forEach((namespace, server) -> {
             assertThatThrownBy(() -> server.client(namespace)
-                    .namespacedConjureTimelockService()
-                    .leaderTime())
+                            .namespacedConjureTimelockService()
+                            .leaderTime())
                     .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
         });
     }
@@ -369,18 +369,18 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
                         refreshed -> assertThat(refreshed.getTokenId()).isEqualTo(refreshed.getTokenId()));
         AuthHeader authHeader = AuthHeader.valueOf("Bearer unused");
         assertThat(client.conjureLegacyLockService()
-                .refreshLockRefreshTokens(authHeader, client.namespace(), ImmutableList.of(conjureAnalogue)))
+                        .refreshLockRefreshTokens(authHeader, client.namespace(), ImmutableList.of(conjureAnalogue)))
                 .as("it is possible to refresh a live token through the conjure API")
                 .hasOnlyOneElementSatisfying(
                         refreshed -> assertThat(refreshed.getTokenId()).isEqualTo(refreshed.getTokenId()));
 
         ConjureSimpleHeldLocksToken conjureHeldLocksToken = ConjureSimpleHeldLocksToken.of(token.getTokenId(), 0L);
         assertThat(client.conjureLegacyLockService()
-                .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
+                        .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
                 .as("it is possible to unlock a live token through the conjure API")
                 .isTrue();
         assertThat(client.conjureLegacyLockService()
-                .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
+                        .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
                 .as("a token unlocked through the conjure API stays unlocked")
                 .isFalse();
         assertThat(client.legacyLockService().unlockSimple(SimpleHeldLocksToken.fromLockRefreshToken(token)))
@@ -416,8 +416,8 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
                 .as("lock taken by conjure impl that was unlocked can now be acquired by legacy impl")
                 .isNotNull();
         assertThat(client.conjureLegacyLockService()
-                .lockAndGetHeldLocks(
-                        AuthHeader.valueOf("Bearer unused"), client.namespace(), conjureLockRequest))
+                        .lockAndGetHeldLocks(
+                                AuthHeader.valueOf("Bearer unused"), client.namespace(), conjureLockRequest))
                 .as("if the legacy impl has taken a lock, the conjure impl mustn't be able to take it")
                 .isEmpty();
     }
@@ -793,10 +793,10 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
         assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
 
         assertThat(startedTransactions.values().stream()
-                .map(ConjureStartTransactionsResponse::getTimestamps)
-                .mapToLong(partitionedTimestamps ->
-                        partitionedTimestamps.stream().count())
-                .sum())
+                        .map(ConjureStartTransactionsResponse::getTimestamps)
+                        .mapToLong(partitionedTimestamps ->
+                                partitionedTimestamps.stream().count())
+                        .sum())
                 .isEqualTo(namespaces.size() * numTransactions);
         return startedTransactions;
     }

--- a/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
@@ -123,8 +123,8 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
     public void nonLeadersReturn503_conjure() {
         cluster.nonLeaders(client.namespace()).forEach((namespace, server) -> {
             assertThatThrownBy(() -> server.client(namespace)
-                            .namespacedConjureTimelockService()
-                            .leaderTime())
+                    .namespacedConjureTimelockService()
+                    .leaderTime())
                     .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
         });
     }
@@ -369,18 +369,18 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
                         refreshed -> assertThat(refreshed.getTokenId()).isEqualTo(refreshed.getTokenId()));
         AuthHeader authHeader = AuthHeader.valueOf("Bearer unused");
         assertThat(client.conjureLegacyLockService()
-                        .refreshLockRefreshTokens(authHeader, client.namespace(), ImmutableList.of(conjureAnalogue)))
+                .refreshLockRefreshTokens(authHeader, client.namespace(), ImmutableList.of(conjureAnalogue)))
                 .as("it is possible to refresh a live token through the conjure API")
                 .hasOnlyOneElementSatisfying(
                         refreshed -> assertThat(refreshed.getTokenId()).isEqualTo(refreshed.getTokenId()));
 
         ConjureSimpleHeldLocksToken conjureHeldLocksToken = ConjureSimpleHeldLocksToken.of(token.getTokenId(), 0L);
         assertThat(client.conjureLegacyLockService()
-                        .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
+                .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
                 .as("it is possible to unlock a live token through the conjure API")
                 .isTrue();
         assertThat(client.conjureLegacyLockService()
-                        .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
+                .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
                 .as("a token unlocked through the conjure API stays unlocked")
                 .isFalse();
         assertThat(client.legacyLockService().unlockSimple(SimpleHeldLocksToken.fromLockRefreshToken(token)))
@@ -416,8 +416,8 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
                 .as("lock taken by conjure impl that was unlocked can now be acquired by legacy impl")
                 .isNotNull();
         assertThat(client.conjureLegacyLockService()
-                        .lockAndGetHeldLocks(
-                                AuthHeader.valueOf("Bearer unused"), client.namespace(), conjureLockRequest))
+                .lockAndGetHeldLocks(
+                        AuthHeader.valueOf("Bearer unused"), client.namespace(), conjureLockRequest))
                 .as("if the legacy impl has taken a lock, the conjure impl mustn't be able to take it")
                 .isEmpty();
     }
@@ -611,7 +611,7 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
                 // There was an election, we cannot be sure about contiguity, but can still check timestamp guarantees
                 assertThat(conjureGetCommitTimestampResponse.getInclusiveLower())
                         .as("timestamps should increase in the presence of elections.")
-                        .isLessThan(responseFromBatchedEndpoint.getInclusiveUpper());
+                        .isGreaterThan(responseFromBatchedEndpoint.getInclusiveUpper());
             }
         });
     }
@@ -793,10 +793,10 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
         assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
 
         assertThat(startedTransactions.values().stream()
-                        .map(ConjureStartTransactionsResponse::getTimestamps)
-                        .mapToLong(partitionedTimestamps ->
-                                partitionedTimestamps.stream().count())
-                        .sum())
+                .map(ConjureStartTransactionsResponse::getTimestamps)
+                .mapToLong(partitionedTimestamps ->
+                        partitionedTimestamps.stream().count())
+                .sum())
                 .isEqualTo(namespaces.size() * numTransactions);
         return startedTransactions;
     }

--- a/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
+++ b/timelock-server/src/integ2Test/java/com/palantir/atlasdb/timelock/AbstractMultiNodePaxosTimeLockServerIntegrationTest.java
@@ -72,6 +72,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
@@ -122,8 +123,8 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
     public void nonLeadersReturn503_conjure() {
         cluster.nonLeaders(client.namespace()).forEach((namespace, server) -> {
             assertThatThrownBy(() -> server.client(namespace)
-                            .namespacedConjureTimelockService()
-                            .leaderTime())
+                    .namespacedConjureTimelockService()
+                    .leaderTime())
                     .satisfies(ExceptionMatchers::isRetryableExceptionWhereLeaderCannotBeFound);
         });
     }
@@ -141,7 +142,7 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void leaderLosesLeadershipIfQuorumIsNotAlive() {
+    public void leaderLosesLeadershipIfQuorumIsNotAlive() throws ExecutionException {
         NamespacedClients leader = cluster.currentLeaderFor(client.namespace()).client(client.namespace());
         cluster.killAndAwaitTermination(cluster.nonLeaders(client.namespace()).values());
 
@@ -150,7 +151,7 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
     }
 
     @Test
-    public void someoneBecomesLeaderAgainAfterQuorumIsRestored() {
+    public void someoneBecomesLeaderAgainAfterQuorumIsRestored() throws ExecutionException {
         Set<TestableTimelockServer> nonLeaders =
                 ImmutableSet.copyOf(cluster.nonLeaders(client.namespace()).values());
         cluster.killAndAwaitTermination(nonLeaders);
@@ -368,18 +369,18 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
                         refreshed -> assertThat(refreshed.getTokenId()).isEqualTo(refreshed.getTokenId()));
         AuthHeader authHeader = AuthHeader.valueOf("Bearer unused");
         assertThat(client.conjureLegacyLockService()
-                        .refreshLockRefreshTokens(authHeader, client.namespace(), ImmutableList.of(conjureAnalogue)))
+                .refreshLockRefreshTokens(authHeader, client.namespace(), ImmutableList.of(conjureAnalogue)))
                 .as("it is possible to refresh a live token through the conjure API")
                 .hasOnlyOneElementSatisfying(
                         refreshed -> assertThat(refreshed.getTokenId()).isEqualTo(refreshed.getTokenId()));
 
         ConjureSimpleHeldLocksToken conjureHeldLocksToken = ConjureSimpleHeldLocksToken.of(token.getTokenId(), 0L);
         assertThat(client.conjureLegacyLockService()
-                        .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
+                .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
                 .as("it is possible to unlock a live token through the conjure API")
                 .isTrue();
         assertThat(client.conjureLegacyLockService()
-                        .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
+                .unlockSimple(authHeader, client.namespace(), conjureHeldLocksToken))
                 .as("a token unlocked through the conjure API stays unlocked")
                 .isFalse();
         assertThat(client.legacyLockService().unlockSimple(SimpleHeldLocksToken.fromLockRefreshToken(token)))
@@ -415,8 +416,8 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
                 .as("lock taken by conjure impl that was unlocked can now be acquired by legacy impl")
                 .isNotNull();
         assertThat(client.conjureLegacyLockService()
-                        .lockAndGetHeldLocks(
-                                AuthHeader.valueOf("Bearer unused"), client.namespace(), conjureLockRequest))
+                .lockAndGetHeldLocks(
+                        AuthHeader.valueOf("Bearer unused"), client.namespace(), conjureLockRequest))
                 .as("if the legacy impl has taken a lock, the conjure impl mustn't be able to take it")
                 .isEmpty();
     }
@@ -598,7 +599,7 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
         // call), for a namespace, the underlying service to process the request is the same
         multiClientResponses.forEach((namespace, responseFromBatchedEndpoint) -> {
             GetCommitTimestampsResponse conjureGetCommitTimestampResponse =
-                    client.conjureTimelockService().getCommitTimestamps(defaultCommitTimestampRequest());
+                    client.namespacedConjureTimelockService().getCommitTimestamps(defaultCommitTimestampRequest());
             assertThat(conjureGetCommitTimestampResponse.getLockWatchUpdate().logId())
                     .isEqualTo(responseFromBatchedEndpoint.getLockWatchUpdate().logId());
             assertThat(conjureGetCommitTimestampResponse.getInclusiveLower())
@@ -784,10 +785,10 @@ public abstract class AbstractMultiNodePaxosTimeLockServerIntegrationTest {
         assertThat(namespaces).hasSameElementsAs(expectedNamespaces);
 
         assertThat(startedTransactions.values().stream()
-                        .map(ConjureStartTransactionsResponse::getTimestamps)
-                        .mapToLong(partitionedTimestamps ->
-                                partitionedTimestamps.stream().count())
-                        .sum())
+                .map(ConjureStartTransactionsResponse::getTimestamps)
+                .mapToLong(partitionedTimestamps ->
+                        partitionedTimestamps.stream().count())
+                .sum())
                 .isEqualTo(namespaces.size() * numTransactions);
         return startedTransactions;
     }

--- a/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
+++ b/timelock-server/src/testCommon/java/com/palantir/atlasdb/timelock/TestableTimelockCluster.java
@@ -29,6 +29,7 @@ import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.timelock.NamespacedClients.ProxyFactory;
+import com.palantir.atlasdb.timelock.api.MultiClientConjureTimelockService;
 import com.palantir.atlasdb.timelock.paxos.PaxosQuorumCheckingCoalescingFunction.PaxosContainer;
 import com.palantir.atlasdb.timelock.util.TestProxies;
 import com.palantir.atlasdb.timelock.util.TestProxies.ProxyMode;
@@ -276,6 +277,10 @@ public class TestableTimelockCluster implements BeforeAllCallback, AfterAllCallb
 
     NamespacedClients uncachedNamespacedClients(String namespace) {
         return NamespacedClients.from(namespace, proxyFactory);
+    }
+
+    MultiClientConjureTimelockService multiClientConjureTimelockService() {
+        return proxyFactory.createProxy(MultiClientConjureTimelockService.class, ProxyMode.DIRECT);
     }
 
     private static final class FailoverProxyFactory implements ProxyFactory {


### PR DESCRIPTION
## General
**Before this PR**:
Two tests in AMNPTLSIT were reported as flaky.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
One of the flaky tests has been removed as its behaviour (the leader services requests) is indirectly tested by many other nodes. The other was changed to handle a leader election. Generally these 2 flakes relate to check then act problems for which node of timelock the leader is.
==COMMIT_MSG==

**Priority**: p2

**Concerns / possible downsides (what feedback would you like?)**: Nothing much

**Is documentation needed?**: No

## Compatibility
Only a test change.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That we have tests that check the timelock leader can serve requests.

**What was existing testing like? What have you done to improve it?**: These should be less flaky

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
Only a test change

## Scale
Only a test change

## Development Process
**Where should we start reviewing?**: It's small

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
