### PR TITLE
Improve stream store exceptions

### DIFF
--- a/atlasdb-client/build.gradle
+++ b/atlasdb-client/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   api 'com.google.code.findbugs:jsr305'
   api 'com.google.guava:guava'
   api 'com.google.protobuf:protobuf-java'
+  api 'com.palantir.safe-logging:preconditions'
   api 'org.slf4j:slf4j-api'
   api project(':atlasdb-api')
   api project(':atlasdb-client-protobufs')
@@ -54,7 +55,6 @@ dependencies {
   implementation 'com.palantir.goethe:goethe'
   implementation 'com.palantir.nylon:nylon-threads'
   implementation 'com.palantir.refreshable:refreshable'
-  implementation 'com.palantir.safe-logging:preconditions'
   implementation 'com.palantir.safe-logging:safe-logging'
   implementation 'com.palantir.tracing:tracing'
   implementation 'com.palantir.tritium:tritium-api'
@@ -81,6 +81,7 @@ dependencies {
   testImplementation 'com.palantir.safe-logging:preconditions'
   testImplementation 'com.palantir.tracing:tracing-api'
   testImplementation 'com.palantir.tritium:tritium-api'
+  testImplementation 'commons-io:commons-io'
   testImplementation 'io.dropwizard.metrics:metrics-core'
   testImplementation 'org.apache.commons:commons-lang3'
   testImplementation 'org.slf4j:slf4j-api'

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/ApiTestTableFactory.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/ApiTestTableFactory.java
@@ -57,6 +57,26 @@ public final class ApiTestTableFactory {
         return SchemaApiTestTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
     }
 
+    public StreamTestStreamHashAidxTable getStreamTestStreamHashAidxTable(
+            Transaction t, StreamTestStreamHashAidxTable.StreamTestStreamHashAidxTrigger... triggers) {
+        return StreamTestStreamHashAidxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public StreamTestStreamIdxTable getStreamTestStreamIdxTable(
+            Transaction t, StreamTestStreamIdxTable.StreamTestStreamIdxTrigger... triggers) {
+        return StreamTestStreamIdxTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public StreamTestStreamMetadataTable getStreamTestStreamMetadataTable(
+            Transaction t, StreamTestStreamMetadataTable.StreamTestStreamMetadataTrigger... triggers) {
+        return StreamTestStreamMetadataTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
+    public StreamTestStreamValueTable getStreamTestStreamValueTable(
+            Transaction t, StreamTestStreamValueTable.StreamTestStreamValueTrigger... triggers) {
+        return StreamTestStreamValueTable.of(t, namespace, Triggers.getAllTriggers(t, sharedTriggers, triggers));
+    }
+
     public SchemaApiTestV2Table getSchemaApiTestV2Table(Transaction t) {
         return SchemaApiTestV2Table.of(t, namespace);
     }
@@ -64,7 +84,11 @@ public final class ApiTestTableFactory {
     public interface SharedTriggers
             extends AllValueTypesTestTable.AllValueTypesTestTrigger,
                     HashComponentsTestTable.HashComponentsTestTrigger,
-                    SchemaApiTestTable.SchemaApiTestTrigger {}
+                    SchemaApiTestTable.SchemaApiTestTrigger,
+                    StreamTestStreamHashAidxTable.StreamTestStreamHashAidxTrigger,
+                    StreamTestStreamIdxTable.StreamTestStreamIdxTrigger,
+                    StreamTestStreamMetadataTable.StreamTestStreamMetadataTrigger,
+                    StreamTestStreamValueTable.StreamTestStreamValueTrigger {}
 
     public abstract static class NullSharedTriggers implements SharedTriggers {
         @Override
@@ -90,6 +114,42 @@ public final class ApiTestTableFactory {
                 Multimap<
                                 SchemaApiTestTable.SchemaApiTestRow,
                                 ? extends SchemaApiTestTable.SchemaApiTestNamedColumnValue<?>>
+                        newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putStreamTestStreamHashAidx(
+                Multimap<
+                                StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow,
+                                ? extends StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumnValue>
+                        newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putStreamTestStreamIdx(
+                Multimap<
+                                StreamTestStreamIdxTable.StreamTestStreamIdxRow,
+                                ? extends StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue>
+                        newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putStreamTestStreamMetadata(
+                Multimap<
+                                StreamTestStreamMetadataTable.StreamTestStreamMetadataRow,
+                                ? extends StreamTestStreamMetadataTable.StreamTestStreamMetadataNamedColumnValue<?>>
+                        newRows) {
+            // do nothing
+        }
+
+        @Override
+        public void putStreamTestStreamValue(
+                Multimap<
+                                StreamTestStreamValueTable.StreamTestStreamValueRow,
+                                ? extends StreamTestStreamValueTable.StreamTestStreamValueNamedColumnValue<?>>
                         newRows) {
             // do nothing
         }

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestIndexCleanupTask.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestIndexCleanupTask.java
@@ -1,0 +1,51 @@
+package com.palantir.atlasdb.table.description.generated;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.BatchingVisitable;
+
+public class StreamTestIndexCleanupTask implements OnCleanupTask {
+
+    private final ApiTestTableFactory tables;
+
+    public StreamTestIndexCleanupTask(Namespace namespace) {
+        tables = ApiTestTableFactory.of(namespace);
+    }
+
+    @Override
+    public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
+        StreamTestStreamIdxTable usersIndex = tables.getStreamTestStreamIdxTable(t);
+        Set<StreamTestStreamIdxTable.StreamTestStreamIdxRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
+        for (Cell cell : cells) {
+            rows.add(StreamTestStreamIdxTable.StreamTestStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
+        }
+        BatchColumnRangeSelection oneColumn = BatchColumnRangeSelection.create(
+                PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1);
+        Map<StreamTestStreamIdxTable.StreamTestStreamIdxRow, BatchingVisitable<StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue>> existentRows
+                = usersIndex.getRowsColumnRange(rows, oneColumn);
+        Set<StreamTestStreamIdxTable.StreamTestStreamIdxRow> rowsInDb = Sets.newHashSetWithExpectedSize(cells.size());
+        for (Map.Entry<StreamTestStreamIdxTable.StreamTestStreamIdxRow, BatchingVisitable<StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue>> rowVisitable
+                : existentRows.entrySet()) {
+            rowVisitable.getValue().batchAccept(1, columnValues -> {
+                if (!columnValues.isEmpty()) {
+                    rowsInDb.add(rowVisitable.getKey());
+                }
+                return false;
+            });
+        }
+        Set<Long> toDelete = Sets.newHashSetWithExpectedSize(rows.size() - rowsInDb.size());
+        for (StreamTestStreamIdxTable.StreamTestStreamIdxRow rowToDelete : Sets.difference(rows, rowsInDb)) {
+            toDelete.add(rowToDelete.getId());
+        }
+        StreamTestStreamStore.of(tables).deleteStreams(t, toDelete);
+        return false;
+    }
+}

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestMetadataCleanupTask.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestMetadataCleanupTask.java
@@ -1,0 +1,64 @@
+package com.palantir.atlasdb.table.description.generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Sets;
+import com.palantir.atlasdb.cleaner.api.OnCleanupTask;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
+import com.palantir.atlasdb.transaction.api.Transaction;
+
+public class StreamTestMetadataCleanupTask implements OnCleanupTask {
+
+    private final ApiTestTableFactory tables;
+
+    public StreamTestMetadataCleanupTask(Namespace namespace) {
+        tables = ApiTestTableFactory.of(namespace);
+    }
+
+    @Override
+    public boolean cellsCleanedUp(Transaction t, Set<Cell> cells) {
+        StreamTestStreamMetadataTable metaTable = tables.getStreamTestStreamMetadataTable(t);
+        Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> rows = Sets.newHashSetWithExpectedSize(cells.size());
+        for (Cell cell : cells) {
+            rows.add(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName()));
+        }
+        StreamTestStreamIdxTable indexTable = tables.getStreamTestStreamIdxTable(t);
+        Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> rowsWithNoIndexEntries =
+                        getUnreferencedStreamsByIterator(indexTable, rows);
+        Set<Long> toDelete = new HashSet<>();
+        Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> currentMetadata =
+                metaTable.getMetadatas(rows);
+        for (Map.Entry<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> e : currentMetadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED || rowsWithNoIndexEntries.contains(e.getKey())) {
+                toDelete.add(e.getKey().getId());
+            }
+        }
+        StreamTestStreamStore.of(tables).deleteStreams(t, toDelete);
+        return false;
+    }
+
+    private static Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> getUnreferencedStreamsByIterator(StreamTestStreamIdxTable indexTable, Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> metadataRows) {
+        Set<StreamTestStreamIdxTable.StreamTestStreamIdxRow> indexRows = metadataRows.stream()
+                .map(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow::getId)
+                .map(StreamTestStreamIdxTable.StreamTestStreamIdxRow::of)
+                .collect(Collectors.toSet());
+        Map<StreamTestStreamIdxTable.StreamTestStreamIdxRow, Iterator<StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue>> referenceIteratorByStream
+                = indexTable.getRowsColumnRangeIterator(indexRows,
+                        BatchColumnRangeSelection.create(PtBytes.EMPTY_BYTE_ARRAY, PtBytes.EMPTY_BYTE_ARRAY, 1));
+        return referenceIteratorByStream.entrySet().stream()
+                .filter(entry -> !entry.getValue().hasNext())
+                .map(Map.Entry::getKey)
+                .map(StreamTestStreamIdxTable.StreamTestStreamIdxRow::getId)
+                .map(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow::of)
+                .collect(Collectors.toSet());
+    }
+}

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestStreamHashAidxTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestStreamHashAidxTable.java
@@ -1,0 +1,741 @@
+package com.palantir.atlasdb.table.description.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.ImmutableGetRangesQuery;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings({"deprecation"})
+public final class StreamTestStreamHashAidxTable implements
+        AtlasDbDynamicMutablePersistentTable<StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow,
+                                                StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumn,
+                                                StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumnValue,
+                                                StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRowResult> {
+    private final Transaction t;
+    private final List<StreamTestStreamHashAidxTrigger> triggers;
+    private final static String rawTableName = "stream_test_stream_hash_aidx";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = ColumnSelection.all();
+
+    static StreamTestStreamHashAidxTable of(Transaction t, Namespace namespace) {
+        return new StreamTestStreamHashAidxTable(t, namespace, ImmutableList.<StreamTestStreamHashAidxTrigger>of());
+    }
+
+    static StreamTestStreamHashAidxTable of(Transaction t, Namespace namespace, StreamTestStreamHashAidxTrigger trigger, StreamTestStreamHashAidxTrigger... triggers) {
+        return new StreamTestStreamHashAidxTable(t, namespace, ImmutableList.<StreamTestStreamHashAidxTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static StreamTestStreamHashAidxTable of(Transaction t, Namespace namespace, List<StreamTestStreamHashAidxTrigger> triggers) {
+        return new StreamTestStreamHashAidxTable(t, namespace, triggers);
+    }
+
+    private StreamTestStreamHashAidxTable(Transaction t, Namespace namespace, List<StreamTestStreamHashAidxTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * StreamTestStreamHashAidxRow {
+     *   {@literal Sha256Hash hash};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestStreamHashAidxRow implements Persistable, Comparable<StreamTestStreamHashAidxRow> {
+        private final Sha256Hash hash;
+
+        public static StreamTestStreamHashAidxRow of(Sha256Hash hash) {
+            return new StreamTestStreamHashAidxRow(hash);
+        }
+
+        private StreamTestStreamHashAidxRow(Sha256Hash hash) {
+            this.hash = hash;
+        }
+
+        public Sha256Hash getHash() {
+            return hash;
+        }
+
+        public static Function<StreamTestStreamHashAidxRow, Sha256Hash> getHashFun() {
+            return new Function<StreamTestStreamHashAidxRow, Sha256Hash>() {
+                @Override
+                public Sha256Hash apply(StreamTestStreamHashAidxRow row) {
+                    return row.hash;
+                }
+            };
+        }
+
+        public static Function<Sha256Hash, StreamTestStreamHashAidxRow> fromHashFun() {
+            return new Function<Sha256Hash, StreamTestStreamHashAidxRow>() {
+                @Override
+                public StreamTestStreamHashAidxRow apply(Sha256Hash row) {
+                    return StreamTestStreamHashAidxRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] hashBytes = hash.getBytes();
+            return EncodingUtils.add(hashBytes);
+        }
+
+        public static final Hydrator<StreamTestStreamHashAidxRow> BYTES_HYDRATOR = new Hydrator<StreamTestStreamHashAidxRow>() {
+            @Override
+            public StreamTestStreamHashAidxRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                Sha256Hash hash = new Sha256Hash(EncodingUtils.get32Bytes(__input, __index));
+                return new StreamTestStreamHashAidxRow(hash);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("hash", hash)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestStreamHashAidxRow other = (StreamTestStreamHashAidxRow) obj;
+            return Objects.equals(hash, other.hash);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(hash);
+        }
+
+        @Override
+        public int compareTo(StreamTestStreamHashAidxRow o) {
+            return ComparisonChain.start()
+                .compare(this.hash, o.hash)
+                .result();
+        }
+    }
+
+    /**
+     * <pre>
+     * StreamTestStreamHashAidxColumn {
+     *   {@literal Long streamId};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestStreamHashAidxColumn implements Persistable, Comparable<StreamTestStreamHashAidxColumn> {
+        private final long streamId;
+
+        public static StreamTestStreamHashAidxColumn of(long streamId) {
+            return new StreamTestStreamHashAidxColumn(streamId);
+        }
+
+        private StreamTestStreamHashAidxColumn(long streamId) {
+            this.streamId = streamId;
+        }
+
+        public long getStreamId() {
+            return streamId;
+        }
+
+        public static Function<StreamTestStreamHashAidxColumn, Long> getStreamIdFun() {
+            return new Function<StreamTestStreamHashAidxColumn, Long>() {
+                @Override
+                public Long apply(StreamTestStreamHashAidxColumn row) {
+                    return row.streamId;
+                }
+            };
+        }
+
+        public static Function<Long, StreamTestStreamHashAidxColumn> fromStreamIdFun() {
+            return new Function<Long, StreamTestStreamHashAidxColumn>() {
+                @Override
+                public StreamTestStreamHashAidxColumn apply(Long row) {
+                    return StreamTestStreamHashAidxColumn.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] streamIdBytes = EncodingUtils.encodeUnsignedVarLong(streamId);
+            return EncodingUtils.add(streamIdBytes);
+        }
+
+        public static final Hydrator<StreamTestStreamHashAidxColumn> BYTES_HYDRATOR = new Hydrator<StreamTestStreamHashAidxColumn>() {
+            @Override
+            public StreamTestStreamHashAidxColumn hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                long streamId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                return new StreamTestStreamHashAidxColumn(streamId);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("streamId", streamId)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestStreamHashAidxColumn other = (StreamTestStreamHashAidxColumn) obj;
+            return Objects.equals(streamId, other.streamId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(streamId);
+        }
+
+        @Override
+        public int compareTo(StreamTestStreamHashAidxColumn o) {
+            return ComparisonChain.start()
+                .compare(this.streamId, o.streamId)
+                .result();
+        }
+    }
+
+    public interface StreamTestStreamHashAidxTrigger {
+        public void putStreamTestStreamHashAidx(Multimap<StreamTestStreamHashAidxRow, ? extends StreamTestStreamHashAidxColumnValue> newRows);
+    }
+
+    /**
+     * <pre>
+     * Column name description {
+     *   {@literal Long streamId};
+     * }
+     * Column value description {
+     *   type: Long;
+     * }
+     * </pre>
+     */
+    public static final class StreamTestStreamHashAidxColumnValue implements ColumnValue<Long> {
+        private final StreamTestStreamHashAidxColumn columnName;
+        private final Long value;
+
+        public static StreamTestStreamHashAidxColumnValue of(StreamTestStreamHashAidxColumn columnName, Long value) {
+            return new StreamTestStreamHashAidxColumnValue(columnName, value);
+        }
+
+        private StreamTestStreamHashAidxColumnValue(StreamTestStreamHashAidxColumn columnName, Long value) {
+            this.columnName = columnName;
+            this.value = value;
+        }
+
+        public StreamTestStreamHashAidxColumn getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public Long getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return columnName.persistToBytes();
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = EncodingUtils.encodeUnsignedVarLong(value);
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        public static Long hydrateValue(byte[] bytes) {
+            bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+            return EncodingUtils.decodeUnsignedVarLong(bytes, 0);
+        }
+
+        public static Function<StreamTestStreamHashAidxColumnValue, StreamTestStreamHashAidxColumn> getColumnNameFun() {
+            return new Function<StreamTestStreamHashAidxColumnValue, StreamTestStreamHashAidxColumn>() {
+                @Override
+                public StreamTestStreamHashAidxColumn apply(StreamTestStreamHashAidxColumnValue columnValue) {
+                    return columnValue.getColumnName();
+                }
+            };
+        }
+
+        public static Function<StreamTestStreamHashAidxColumnValue, Long> getValueFun() {
+            return new Function<StreamTestStreamHashAidxColumnValue, Long>() {
+                @Override
+                public Long apply(StreamTestStreamHashAidxColumnValue columnValue) {
+                    return columnValue.getValue();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("ColumnName", this.columnName)
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public static final class StreamTestStreamHashAidxRowResult implements TypedRowResult {
+        private final StreamTestStreamHashAidxRow rowName;
+        private final ImmutableSet<StreamTestStreamHashAidxColumnValue> columnValues;
+
+        public static StreamTestStreamHashAidxRowResult of(RowResult<byte[]> rowResult) {
+            StreamTestStreamHashAidxRow rowName = StreamTestStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+            Set<StreamTestStreamHashAidxColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                StreamTestStreamHashAidxColumn col = StreamTestStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long value = StreamTestStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                columnValues.add(StreamTestStreamHashAidxColumnValue.of(col, value));
+            }
+            return new StreamTestStreamHashAidxRowResult(rowName, ImmutableSet.copyOf(columnValues));
+        }
+
+        private StreamTestStreamHashAidxRowResult(StreamTestStreamHashAidxRow rowName, ImmutableSet<StreamTestStreamHashAidxColumnValue> columnValues) {
+            this.rowName = rowName;
+            this.columnValues = columnValues;
+        }
+
+        @Override
+        public StreamTestStreamHashAidxRow getRowName() {
+            return rowName;
+        }
+
+        public Set<StreamTestStreamHashAidxColumnValue> getColumnValues() {
+            return columnValues;
+        }
+
+        public static Function<StreamTestStreamHashAidxRowResult, StreamTestStreamHashAidxRow> getRowNameFun() {
+            return new Function<StreamTestStreamHashAidxRowResult, StreamTestStreamHashAidxRow>() {
+                @Override
+                public StreamTestStreamHashAidxRow apply(StreamTestStreamHashAidxRowResult rowResult) {
+                    return rowResult.rowName;
+                }
+            };
+        }
+
+        public static Function<StreamTestStreamHashAidxRowResult, ImmutableSet<StreamTestStreamHashAidxColumnValue>> getColumnValuesFun() {
+            return new Function<StreamTestStreamHashAidxRowResult, ImmutableSet<StreamTestStreamHashAidxColumnValue>>() {
+                @Override
+                public ImmutableSet<StreamTestStreamHashAidxColumnValue> apply(StreamTestStreamHashAidxRowResult rowResult) {
+                    return rowResult.columnValues;
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("ColumnValues", getColumnValues())
+                .toString();
+        }
+    }
+
+    @Override
+    public void delete(StreamTestStreamHashAidxRow row, StreamTestStreamHashAidxColumn column) {
+        delete(ImmutableMultimap.of(row, column));
+    }
+
+    @Override
+    public void delete(Iterable<StreamTestStreamHashAidxRow> rows) {
+        Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumn> toRemove = HashMultimap.create();
+        Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> result = getRowsMultimap(rows);
+        for (Entry<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> e : result.entries()) {
+            toRemove.put(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toRemove);
+    }
+
+    @Override
+    public void delete(Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumn> values) {
+        t.delete(tableRef, ColumnValues.toCells(values));
+    }
+
+    @Override
+    public void put(StreamTestStreamHashAidxRow rowName, Iterable<StreamTestStreamHashAidxColumnValue> values) {
+        put(ImmutableMultimap.<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(StreamTestStreamHashAidxRow rowName, StreamTestStreamHashAidxColumnValue... values) {
+        put(ImmutableMultimap.<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(Multimap<StreamTestStreamHashAidxRow, ? extends StreamTestStreamHashAidxColumnValue> values) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(values));
+        for (StreamTestStreamHashAidxTrigger trigger : triggers) {
+            trigger.putStreamTestStreamHashAidx(values);
+        }
+    }
+
+    @Override
+    public void touch(Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumn> values) {
+        Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> currentValues = get(values);
+        put(currentValues);
+        Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumn> toDelete = HashMultimap.create(values);
+        for (Map.Entry<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> e : currentValues.entries()) {
+            toDelete.remove(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toDelete);
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<StreamTestStreamHashAidxColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, Persistables.persistToBytesFunction()));
+    }
+
+    public static ColumnSelection getColumnSelection(StreamTestStreamHashAidxColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    @Override
+    public Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> get(Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumn> cells) {
+        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
+        Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> rowMap = ArrayListMultimap.create();
+        for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
+            if (e.getValue().length > 0) {
+                StreamTestStreamHashAidxRow row = StreamTestStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+                StreamTestStreamHashAidxColumn col = StreamTestStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                Long val = StreamTestStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, StreamTestStreamHashAidxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public List<StreamTestStreamHashAidxColumnValue> getRowColumns(StreamTestStreamHashAidxRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<StreamTestStreamHashAidxColumnValue> getRowColumns(StreamTestStreamHashAidxRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<StreamTestStreamHashAidxColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                StreamTestStreamHashAidxColumn col = StreamTestStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = StreamTestStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                ret.add(StreamTestStreamHashAidxColumnValue.of(col, val));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> getRowsMultimap(Iterable<StreamTestStreamHashAidxRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> getRowsMultimap(Iterable<StreamTestStreamHashAidxRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> getRowsMultimapInternal(Iterable<StreamTestStreamHashAidxRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue> rowMap = ArrayListMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            StreamTestStreamHashAidxRow row = StreamTestStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                StreamTestStreamHashAidxColumn col = StreamTestStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = StreamTestStreamHashAidxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, StreamTestStreamHashAidxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<StreamTestStreamHashAidxRow, BatchingVisitable<StreamTestStreamHashAidxColumnValue>> getRowsColumnRange(Iterable<StreamTestStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamHashAidxRow, BatchingVisitable<StreamTestStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamHashAidxRow row = StreamTestStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<StreamTestStreamHashAidxColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                StreamTestStreamHashAidxColumn col = StreamTestStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return StreamTestStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<StreamTestStreamHashAidxRow, StreamTestStreamHashAidxColumnValue>> getRowsColumnRange(Iterable<StreamTestStreamHashAidxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            StreamTestStreamHashAidxRow row = StreamTestStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            StreamTestStreamHashAidxColumn col = StreamTestStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+            Long val = StreamTestStreamHashAidxColumnValue.hydrateValue(e.getValue());
+            StreamTestStreamHashAidxColumnValue colValue = StreamTestStreamHashAidxColumnValue.of(col, val);
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    @Override
+    public Map<StreamTestStreamHashAidxRow, Iterator<StreamTestStreamHashAidxColumnValue>> getRowsColumnRangeIterator(Iterable<StreamTestStreamHashAidxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamHashAidxRow, Iterator<StreamTestStreamHashAidxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamHashAidxRow row = StreamTestStreamHashAidxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestStreamHashAidxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                StreamTestStreamHashAidxColumn col = StreamTestStreamHashAidxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestStreamHashAidxColumnValue.hydrateValue(result.getValue());
+                return StreamTestStreamHashAidxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
+        if (columns.allColumnsSelected()) {
+            return allColumns;
+        }
+        return columns;
+    }
+
+    public BatchingVisitableView<StreamTestStreamHashAidxRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<StreamTestStreamHashAidxRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder()
+                .retainColumns(optimizeColumnSelection(columns)).build()),
+                new Function<RowResult<byte[]>, StreamTestStreamHashAidxRowResult>() {
+            @Override
+            public StreamTestStreamHashAidxRowResult apply(RowResult<byte[]> input) {
+                return StreamTestStreamHashAidxRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableGetRangesQuery}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Nullable}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "sdHiKQYLDXKvGEi1uDO44g==";
+}

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestStreamIdxTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestStreamIdxTable.java
@@ -1,0 +1,741 @@
+package com.palantir.atlasdb.table.description.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.ImmutableGetRangesQuery;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings({"deprecation"})
+public final class StreamTestStreamIdxTable implements
+        AtlasDbDynamicMutablePersistentTable<StreamTestStreamIdxTable.StreamTestStreamIdxRow,
+                                                StreamTestStreamIdxTable.StreamTestStreamIdxColumn,
+                                                StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue,
+                                                StreamTestStreamIdxTable.StreamTestStreamIdxRowResult> {
+    private final Transaction t;
+    private final List<StreamTestStreamIdxTrigger> triggers;
+    private final static String rawTableName = "stream_test_stream_idx";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = ColumnSelection.all();
+
+    static StreamTestStreamIdxTable of(Transaction t, Namespace namespace) {
+        return new StreamTestStreamIdxTable(t, namespace, ImmutableList.<StreamTestStreamIdxTrigger>of());
+    }
+
+    static StreamTestStreamIdxTable of(Transaction t, Namespace namespace, StreamTestStreamIdxTrigger trigger, StreamTestStreamIdxTrigger... triggers) {
+        return new StreamTestStreamIdxTable(t, namespace, ImmutableList.<StreamTestStreamIdxTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static StreamTestStreamIdxTable of(Transaction t, Namespace namespace, List<StreamTestStreamIdxTrigger> triggers) {
+        return new StreamTestStreamIdxTable(t, namespace, triggers);
+    }
+
+    private StreamTestStreamIdxTable(Transaction t, Namespace namespace, List<StreamTestStreamIdxTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * StreamTestStreamIdxRow {
+     *   {@literal Long id};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestStreamIdxRow implements Persistable, Comparable<StreamTestStreamIdxRow> {
+        private final long id;
+
+        public static StreamTestStreamIdxRow of(long id) {
+            return new StreamTestStreamIdxRow(id);
+        }
+
+        private StreamTestStreamIdxRow(long id) {
+            this.id = id;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public static Function<StreamTestStreamIdxRow, Long> getIdFun() {
+            return new Function<StreamTestStreamIdxRow, Long>() {
+                @Override
+                public Long apply(StreamTestStreamIdxRow row) {
+                    return row.id;
+                }
+            };
+        }
+
+        public static Function<Long, StreamTestStreamIdxRow> fromIdFun() {
+            return new Function<Long, StreamTestStreamIdxRow>() {
+                @Override
+                public StreamTestStreamIdxRow apply(Long row) {
+                    return StreamTestStreamIdxRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] idBytes = EncodingUtils.encodeUnsignedVarLong(id);
+            return EncodingUtils.add(idBytes);
+        }
+
+        public static final Hydrator<StreamTestStreamIdxRow> BYTES_HYDRATOR = new Hydrator<StreamTestStreamIdxRow>() {
+            @Override
+            public StreamTestStreamIdxRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                return new StreamTestStreamIdxRow(id);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("id", id)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestStreamIdxRow other = (StreamTestStreamIdxRow) obj;
+            return Objects.equals(id, other.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(id);
+        }
+
+        @Override
+        public int compareTo(StreamTestStreamIdxRow o) {
+            return ComparisonChain.start()
+                .compare(this.id, o.id)
+                .result();
+        }
+    }
+
+    /**
+     * <pre>
+     * StreamTestStreamIdxColumn {
+     *   {@literal byte[] reference};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestStreamIdxColumn implements Persistable, Comparable<StreamTestStreamIdxColumn> {
+        private final byte[] reference;
+
+        public static StreamTestStreamIdxColumn of(byte[] reference) {
+            return new StreamTestStreamIdxColumn(reference);
+        }
+
+        private StreamTestStreamIdxColumn(byte[] reference) {
+            this.reference = reference;
+        }
+
+        public byte[] getReference() {
+            return reference;
+        }
+
+        public static Function<StreamTestStreamIdxColumn, byte[]> getReferenceFun() {
+            return new Function<StreamTestStreamIdxColumn, byte[]>() {
+                @Override
+                public byte[] apply(StreamTestStreamIdxColumn row) {
+                    return row.reference;
+                }
+            };
+        }
+
+        public static Function<byte[], StreamTestStreamIdxColumn> fromReferenceFun() {
+            return new Function<byte[], StreamTestStreamIdxColumn>() {
+                @Override
+                public StreamTestStreamIdxColumn apply(byte[] row) {
+                    return StreamTestStreamIdxColumn.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] referenceBytes = EncodingUtils.encodeSizedBytes(reference);
+            return EncodingUtils.add(referenceBytes);
+        }
+
+        public static final Hydrator<StreamTestStreamIdxColumn> BYTES_HYDRATOR = new Hydrator<StreamTestStreamIdxColumn>() {
+            @Override
+            public StreamTestStreamIdxColumn hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                byte[] reference = EncodingUtils.decodeSizedBytes(__input, __index);
+                return new StreamTestStreamIdxColumn(reference);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("reference", reference)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestStreamIdxColumn other = (StreamTestStreamIdxColumn) obj;
+            return Arrays.equals(reference, other.reference);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(reference);
+        }
+
+        @Override
+        public int compareTo(StreamTestStreamIdxColumn o) {
+            return ComparisonChain.start()
+                .compare(this.reference, o.reference, UnsignedBytes.lexicographicalComparator())
+                .result();
+        }
+    }
+
+    public interface StreamTestStreamIdxTrigger {
+        public void putStreamTestStreamIdx(Multimap<StreamTestStreamIdxRow, ? extends StreamTestStreamIdxColumnValue> newRows);
+    }
+
+    /**
+     * <pre>
+     * Column name description {
+     *   {@literal byte[] reference};
+     * }
+     * Column value description {
+     *   type: Long;
+     * }
+     * </pre>
+     */
+    public static final class StreamTestStreamIdxColumnValue implements ColumnValue<Long> {
+        private final StreamTestStreamIdxColumn columnName;
+        private final Long value;
+
+        public static StreamTestStreamIdxColumnValue of(StreamTestStreamIdxColumn columnName, Long value) {
+            return new StreamTestStreamIdxColumnValue(columnName, value);
+        }
+
+        private StreamTestStreamIdxColumnValue(StreamTestStreamIdxColumn columnName, Long value) {
+            this.columnName = columnName;
+            this.value = value;
+        }
+
+        public StreamTestStreamIdxColumn getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public Long getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return columnName.persistToBytes();
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = EncodingUtils.encodeUnsignedVarLong(value);
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        public static Long hydrateValue(byte[] bytes) {
+            bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+            return EncodingUtils.decodeUnsignedVarLong(bytes, 0);
+        }
+
+        public static Function<StreamTestStreamIdxColumnValue, StreamTestStreamIdxColumn> getColumnNameFun() {
+            return new Function<StreamTestStreamIdxColumnValue, StreamTestStreamIdxColumn>() {
+                @Override
+                public StreamTestStreamIdxColumn apply(StreamTestStreamIdxColumnValue columnValue) {
+                    return columnValue.getColumnName();
+                }
+            };
+        }
+
+        public static Function<StreamTestStreamIdxColumnValue, Long> getValueFun() {
+            return new Function<StreamTestStreamIdxColumnValue, Long>() {
+                @Override
+                public Long apply(StreamTestStreamIdxColumnValue columnValue) {
+                    return columnValue.getValue();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("ColumnName", this.columnName)
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public static final class StreamTestStreamIdxRowResult implements TypedRowResult {
+        private final StreamTestStreamIdxRow rowName;
+        private final ImmutableSet<StreamTestStreamIdxColumnValue> columnValues;
+
+        public static StreamTestStreamIdxRowResult of(RowResult<byte[]> rowResult) {
+            StreamTestStreamIdxRow rowName = StreamTestStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(rowResult.getRowName());
+            Set<StreamTestStreamIdxColumnValue> columnValues = Sets.newHashSetWithExpectedSize(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                StreamTestStreamIdxColumn col = StreamTestStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long value = StreamTestStreamIdxColumnValue.hydrateValue(e.getValue());
+                columnValues.add(StreamTestStreamIdxColumnValue.of(col, value));
+            }
+            return new StreamTestStreamIdxRowResult(rowName, ImmutableSet.copyOf(columnValues));
+        }
+
+        private StreamTestStreamIdxRowResult(StreamTestStreamIdxRow rowName, ImmutableSet<StreamTestStreamIdxColumnValue> columnValues) {
+            this.rowName = rowName;
+            this.columnValues = columnValues;
+        }
+
+        @Override
+        public StreamTestStreamIdxRow getRowName() {
+            return rowName;
+        }
+
+        public Set<StreamTestStreamIdxColumnValue> getColumnValues() {
+            return columnValues;
+        }
+
+        public static Function<StreamTestStreamIdxRowResult, StreamTestStreamIdxRow> getRowNameFun() {
+            return new Function<StreamTestStreamIdxRowResult, StreamTestStreamIdxRow>() {
+                @Override
+                public StreamTestStreamIdxRow apply(StreamTestStreamIdxRowResult rowResult) {
+                    return rowResult.rowName;
+                }
+            };
+        }
+
+        public static Function<StreamTestStreamIdxRowResult, ImmutableSet<StreamTestStreamIdxColumnValue>> getColumnValuesFun() {
+            return new Function<StreamTestStreamIdxRowResult, ImmutableSet<StreamTestStreamIdxColumnValue>>() {
+                @Override
+                public ImmutableSet<StreamTestStreamIdxColumnValue> apply(StreamTestStreamIdxRowResult rowResult) {
+                    return rowResult.columnValues;
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("ColumnValues", getColumnValues())
+                .toString();
+        }
+    }
+
+    @Override
+    public void delete(StreamTestStreamIdxRow row, StreamTestStreamIdxColumn column) {
+        delete(ImmutableMultimap.of(row, column));
+    }
+
+    @Override
+    public void delete(Iterable<StreamTestStreamIdxRow> rows) {
+        Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumn> toRemove = HashMultimap.create();
+        Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> result = getRowsMultimap(rows);
+        for (Entry<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> e : result.entries()) {
+            toRemove.put(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toRemove);
+    }
+
+    @Override
+    public void delete(Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumn> values) {
+        t.delete(tableRef, ColumnValues.toCells(values));
+    }
+
+    @Override
+    public void put(StreamTestStreamIdxRow rowName, Iterable<StreamTestStreamIdxColumnValue> values) {
+        put(ImmutableMultimap.<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(StreamTestStreamIdxRow rowName, StreamTestStreamIdxColumnValue... values) {
+        put(ImmutableMultimap.<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue>builder().putAll(rowName, values).build());
+    }
+
+    @Override
+    public void put(Multimap<StreamTestStreamIdxRow, ? extends StreamTestStreamIdxColumnValue> values) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(values));
+        for (StreamTestStreamIdxTrigger trigger : triggers) {
+            trigger.putStreamTestStreamIdx(values);
+        }
+    }
+
+    @Override
+    public void touch(Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumn> values) {
+        Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> currentValues = get(values);
+        put(currentValues);
+        Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumn> toDelete = HashMultimap.create(values);
+        for (Map.Entry<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> e : currentValues.entries()) {
+            toDelete.remove(e.getKey(), e.getValue().getColumnName());
+        }
+        delete(toDelete);
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<StreamTestStreamIdxColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, Persistables.persistToBytesFunction()));
+    }
+
+    public static ColumnSelection getColumnSelection(StreamTestStreamIdxColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    @Override
+    public Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> get(Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumn> cells) {
+        Set<Cell> rawCells = ColumnValues.toCells(cells);
+        Map<Cell, byte[]> rawResults = t.get(tableRef, rawCells);
+        Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> rowMap = ArrayListMultimap.create();
+        for (Entry<Cell, byte[]> e : rawResults.entrySet()) {
+            if (e.getValue().length > 0) {
+                StreamTestStreamIdxRow row = StreamTestStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+                StreamTestStreamIdxColumn col = StreamTestStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+                Long val = StreamTestStreamIdxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, StreamTestStreamIdxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public List<StreamTestStreamIdxColumnValue> getRowColumns(StreamTestStreamIdxRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<StreamTestStreamIdxColumnValue> getRowColumns(StreamTestStreamIdxRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<StreamTestStreamIdxColumnValue> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                StreamTestStreamIdxColumn col = StreamTestStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = StreamTestStreamIdxColumnValue.hydrateValue(e.getValue());
+                ret.add(StreamTestStreamIdxColumnValue.of(col, val));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> getRowsMultimap(Iterable<StreamTestStreamIdxRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> getRowsMultimap(Iterable<StreamTestStreamIdxRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> getRowsMultimapInternal(Iterable<StreamTestStreamIdxRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue> rowMap = ArrayListMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            StreamTestStreamIdxRow row = StreamTestStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                StreamTestStreamIdxColumn col = StreamTestStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+                Long val = StreamTestStreamIdxColumnValue.hydrateValue(e.getValue());
+                rowMap.put(row, StreamTestStreamIdxColumnValue.of(col, val));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<StreamTestStreamIdxRow, BatchingVisitable<StreamTestStreamIdxColumnValue>> getRowsColumnRange(Iterable<StreamTestStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamIdxRow, BatchingVisitable<StreamTestStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamIdxRow row = StreamTestStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<StreamTestStreamIdxColumnValue> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                StreamTestStreamIdxColumn col = StreamTestStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestStreamIdxColumnValue.hydrateValue(result.getValue());
+                return StreamTestStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<StreamTestStreamIdxRow, StreamTestStreamIdxColumnValue>> getRowsColumnRange(Iterable<StreamTestStreamIdxRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            StreamTestStreamIdxRow row = StreamTestStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            StreamTestStreamIdxColumn col = StreamTestStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getColumnName());
+            Long val = StreamTestStreamIdxColumnValue.hydrateValue(e.getValue());
+            StreamTestStreamIdxColumnValue colValue = StreamTestStreamIdxColumnValue.of(col, val);
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    @Override
+    public Map<StreamTestStreamIdxRow, Iterator<StreamTestStreamIdxColumnValue>> getRowsColumnRangeIterator(Iterable<StreamTestStreamIdxRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamIdxRow, Iterator<StreamTestStreamIdxColumnValue>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamIdxRow row = StreamTestStreamIdxRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestStreamIdxColumnValue> bv = Iterators.transform(e.getValue(), result -> {
+                StreamTestStreamIdxColumn col = StreamTestStreamIdxColumn.BYTES_HYDRATOR.hydrateFromBytes(result.getKey().getColumnName());
+                Long val = StreamTestStreamIdxColumnValue.hydrateValue(result.getValue());
+                return StreamTestStreamIdxColumnValue.of(col, val);
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
+        if (columns.allColumnsSelected()) {
+            return allColumns;
+        }
+        return columns;
+    }
+
+    public BatchingVisitableView<StreamTestStreamIdxRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<StreamTestStreamIdxRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder()
+                .retainColumns(optimizeColumnSelection(columns)).build()),
+                new Function<RowResult<byte[]>, StreamTestStreamIdxRowResult>() {
+            @Override
+            public StreamTestStreamIdxRowResult apply(RowResult<byte[]> input) {
+                return StreamTestStreamIdxRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableGetRangesQuery}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Nullable}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "aftEJkmZB46McizLoEc9bg==";
+}

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestStreamMetadataTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestStreamMetadataTable.java
@@ -1,0 +1,710 @@
+package com.palantir.atlasdb.table.description.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.ImmutableGetRangesQuery;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings({"deprecation"})
+public final class StreamTestStreamMetadataTable implements
+        AtlasDbMutablePersistentTable<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow,
+                                         StreamTestStreamMetadataTable.StreamTestStreamMetadataNamedColumnValue<?>,
+                                         StreamTestStreamMetadataTable.StreamTestStreamMetadataRowResult>,
+        AtlasDbNamedMutableTable<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow,
+                                    StreamTestStreamMetadataTable.StreamTestStreamMetadataNamedColumnValue<?>,
+                                    StreamTestStreamMetadataTable.StreamTestStreamMetadataRowResult> {
+    private final Transaction t;
+    private final List<StreamTestStreamMetadataTrigger> triggers;
+    private final static String rawTableName = "stream_test_stream_metadata";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = getColumnSelection(StreamTestStreamMetadataNamedColumn.values());
+
+    static StreamTestStreamMetadataTable of(Transaction t, Namespace namespace) {
+        return new StreamTestStreamMetadataTable(t, namespace, ImmutableList.<StreamTestStreamMetadataTrigger>of());
+    }
+
+    static StreamTestStreamMetadataTable of(Transaction t, Namespace namespace, StreamTestStreamMetadataTrigger trigger, StreamTestStreamMetadataTrigger... triggers) {
+        return new StreamTestStreamMetadataTable(t, namespace, ImmutableList.<StreamTestStreamMetadataTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static StreamTestStreamMetadataTable of(Transaction t, Namespace namespace, List<StreamTestStreamMetadataTrigger> triggers) {
+        return new StreamTestStreamMetadataTable(t, namespace, triggers);
+    }
+
+    private StreamTestStreamMetadataTable(Transaction t, Namespace namespace, List<StreamTestStreamMetadataTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * StreamTestStreamMetadataRow {
+     *   {@literal Long id};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestStreamMetadataRow implements Persistable, Comparable<StreamTestStreamMetadataRow> {
+        private final long id;
+
+        public static StreamTestStreamMetadataRow of(long id) {
+            return new StreamTestStreamMetadataRow(id);
+        }
+
+        private StreamTestStreamMetadataRow(long id) {
+            this.id = id;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public static Function<StreamTestStreamMetadataRow, Long> getIdFun() {
+            return new Function<StreamTestStreamMetadataRow, Long>() {
+                @Override
+                public Long apply(StreamTestStreamMetadataRow row) {
+                    return row.id;
+                }
+            };
+        }
+
+        public static Function<Long, StreamTestStreamMetadataRow> fromIdFun() {
+            return new Function<Long, StreamTestStreamMetadataRow>() {
+                @Override
+                public StreamTestStreamMetadataRow apply(Long row) {
+                    return StreamTestStreamMetadataRow.of(row);
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] idBytes = EncodingUtils.encodeUnsignedVarLong(id);
+            return EncodingUtils.add(idBytes);
+        }
+
+        public static final Hydrator<StreamTestStreamMetadataRow> BYTES_HYDRATOR = new Hydrator<StreamTestStreamMetadataRow>() {
+            @Override
+            public StreamTestStreamMetadataRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                return new StreamTestStreamMetadataRow(id);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("id", id)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestStreamMetadataRow other = (StreamTestStreamMetadataRow) obj;
+            return Objects.equals(id, other.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(id);
+        }
+
+        @Override
+        public int compareTo(StreamTestStreamMetadataRow o) {
+            return ComparisonChain.start()
+                .compare(this.id, o.id)
+                .result();
+        }
+    }
+
+    public interface StreamTestStreamMetadataNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+
+    /**
+     * <pre>
+     * Column value description {
+     *   type: com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
+     *   name: "StreamMetadata"
+     *   field {
+     *     name: "status"
+     *     number: 1
+     *     label: LABEL_REQUIRED
+     *     type: TYPE_ENUM
+     *     type_name: ".com.palantir.atlasdb.protos.generated.Status"
+     *   }
+     *   field {
+     *     name: "length"
+     *     number: 2
+     *     label: LABEL_REQUIRED
+     *     type: TYPE_INT64
+     *   }
+     *   field {
+     *     name: "hash"
+     *     number: 3
+     *     label: LABEL_REQUIRED
+     *     type: TYPE_BYTES
+     *   }
+     *   
+     * }
+     * </pre>
+     */
+    public static final class Metadata implements StreamTestStreamMetadataNamedColumnValue<com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> {
+        private final com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value;
+
+        public static Metadata of(com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+            return new Metadata(value);
+        }
+
+        private Metadata(com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getColumnName() {
+            return "metadata";
+        }
+
+        @Override
+        public String getShortColumnName() {
+            return "md";
+        }
+
+        @Override
+        public com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = value.toByteArray();
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return PtBytes.toCachedBytes("md");
+        }
+
+        public static final Hydrator<Metadata> BYTES_HYDRATOR = new Hydrator<Metadata>() {
+            @Override
+            public Metadata hydrateFromBytes(byte[] bytes) {
+                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+                try {
+                    return of(com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata.parseFrom(bytes));
+                } catch (InvalidProtocolBufferException e) {
+                    throw Throwables.throwUncheckedException(e);
+                }
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public interface StreamTestStreamMetadataTrigger {
+        public void putStreamTestStreamMetadata(Multimap<StreamTestStreamMetadataRow, ? extends StreamTestStreamMetadataNamedColumnValue<?>> newRows);
+    }
+
+    public static final class StreamTestStreamMetadataRowResult implements TypedRowResult {
+        private final RowResult<byte[]> row;
+
+        public static StreamTestStreamMetadataRowResult of(RowResult<byte[]> row) {
+            return new StreamTestStreamMetadataRowResult(row);
+        }
+
+        private StreamTestStreamMetadataRowResult(RowResult<byte[]> row) {
+            this.row = row;
+        }
+
+        @Override
+        public StreamTestStreamMetadataRow getRowName() {
+            return StreamTestStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        }
+
+        public static Function<StreamTestStreamMetadataRowResult, StreamTestStreamMetadataRow> getRowNameFun() {
+            return new Function<StreamTestStreamMetadataRowResult, StreamTestStreamMetadataRow>() {
+                @Override
+                public StreamTestStreamMetadataRow apply(StreamTestStreamMetadataRowResult rowResult) {
+                    return rowResult.getRowName();
+                }
+            };
+        }
+
+        public static Function<RowResult<byte[]>, StreamTestStreamMetadataRowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, StreamTestStreamMetadataRowResult>() {
+                @Override
+                public StreamTestStreamMetadataRowResult apply(RowResult<byte[]> rowResult) {
+                    return new StreamTestStreamMetadataRowResult(rowResult);
+                }
+            };
+        }
+
+        public boolean hasMetadata() {
+            return row.getColumns().containsKey(PtBytes.toCachedBytes("md"));
+        }
+
+        public com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata getMetadata() {
+            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("md"));
+            if (bytes == null) {
+                return null;
+            }
+            Metadata value = Metadata.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            return value.getValue();
+        }
+
+        public static Function<StreamTestStreamMetadataRowResult, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> getMetadataFun() {
+            return new Function<StreamTestStreamMetadataRowResult, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata>() {
+                @Override
+                public com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata apply(StreamTestStreamMetadataRowResult rowResult) {
+                    return rowResult.getMetadata();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("Metadata", getMetadata())
+                .toString();
+        }
+    }
+
+    public enum StreamTestStreamMetadataNamedColumn {
+        METADATA {
+            @Override
+            public byte[] getShortName() {
+                return PtBytes.toCachedBytes("md");
+            }
+        };
+
+        public abstract byte[] getShortName();
+
+        public static Function<StreamTestStreamMetadataNamedColumn, byte[]> toShortName() {
+            return new Function<StreamTestStreamMetadataNamedColumn, byte[]>() {
+                @Override
+                public byte[] apply(StreamTestStreamMetadataNamedColumn namedColumn) {
+                    return namedColumn.getShortName();
+                }
+            };
+        }
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<StreamTestStreamMetadataNamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, StreamTestStreamMetadataNamedColumn.toShortName()));
+    }
+
+    public static ColumnSelection getColumnSelection(StreamTestStreamMetadataNamedColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    private static final Map<String, Hydrator<? extends StreamTestStreamMetadataNamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends StreamTestStreamMetadataNamedColumnValue<?>>>builder()
+                .put("md", Metadata.BYTES_HYDRATOR)
+                .build();
+
+    public Map<StreamTestStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> getMetadatas(Collection<StreamTestStreamMetadataRow> rows) {
+        Map<Cell, StreamTestStreamMetadataRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (StreamTestStreamMetadataRow row : rows) {
+            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("md")), row);
+        }
+        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
+        Map<StreamTestStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> ret = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<Cell, byte[]> e : results.entrySet()) {
+            com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata val = Metadata.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            ret.put(cells.get(e.getKey()), val);
+        }
+        return ret;
+    }
+
+    public void putMetadata(StreamTestStreamMetadataRow row, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata value) {
+        put(ImmutableMultimap.of(row, Metadata.of(value)));
+    }
+
+    public void putMetadata(Map<StreamTestStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> map) {
+        Map<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<StreamTestStreamMetadataRow, com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata> e : map.entrySet()) {
+            toPut.put(e.getKey(), Metadata.of(e.getValue()));
+        }
+        put(Multimaps.forMap(toPut));
+    }
+
+    @Override
+    public void put(Multimap<StreamTestStreamMetadataRow, ? extends StreamTestStreamMetadataNamedColumnValue<?>> rows) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(rows));
+        for (StreamTestStreamMetadataTrigger trigger : triggers) {
+            trigger.putStreamTestStreamMetadata(rows);
+        }
+    }
+
+    public void deleteMetadata(StreamTestStreamMetadataRow row) {
+        deleteMetadata(ImmutableSet.of(row));
+    }
+
+    public void deleteMetadata(Iterable<StreamTestStreamMetadataRow> rows) {
+        byte[] col = PtBytes.toCachedBytes("md");
+        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public void delete(StreamTestStreamMetadataRow row) {
+        delete(ImmutableSet.of(row));
+    }
+
+    @Override
+    public void delete(Iterable<StreamTestStreamMetadataRow> rows) {
+        List<byte[]> rowBytes = Persistables.persistAll(rows);
+        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
+        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("md")));
+        t.delete(tableRef, cells);
+    }
+
+    public Optional<StreamTestStreamMetadataRowResult> getRow(StreamTestStreamMetadataRow row) {
+        return getRow(row, allColumns);
+    }
+
+    public Optional<StreamTestStreamMetadataRowResult> getRow(StreamTestStreamMetadataRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(StreamTestStreamMetadataRowResult.of(rowResult));
+        }
+    }
+
+    @Override
+    public List<StreamTestStreamMetadataRowResult> getRows(Iterable<StreamTestStreamMetadataRow> rows) {
+        return getRows(rows, allColumns);
+    }
+
+    @Override
+    public List<StreamTestStreamMetadataRowResult> getRows(Iterable<StreamTestStreamMetadataRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        List<StreamTestStreamMetadataRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        for (RowResult<byte[]> row : results.values()) {
+            rowResults.add(StreamTestStreamMetadataRowResult.of(row));
+        }
+        return rowResults;
+    }
+
+    @Override
+    public List<StreamTestStreamMetadataNamedColumnValue<?>> getRowColumns(StreamTestStreamMetadataRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<StreamTestStreamMetadataNamedColumnValue<?>> getRowColumns(StreamTestStreamMetadataRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<StreamTestStreamMetadataNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestStreamMetadataRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestStreamMetadataRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> getRowsMultimapInternal(Iterable<StreamTestStreamMetadataRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>> rowMap = ArrayListMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            StreamTestStreamMetadataRow row = StreamTestStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<StreamTestStreamMetadataRow, BatchingVisitable<StreamTestStreamMetadataNamedColumnValue<?>>> getRowsColumnRange(Iterable<StreamTestStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamMetadataRow, BatchingVisitable<StreamTestStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamMetadataRow row = StreamTestStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<StreamTestStreamMetadataNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<StreamTestStreamMetadataRow, StreamTestStreamMetadataNamedColumnValue<?>>> getRowsColumnRange(Iterable<StreamTestStreamMetadataRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            StreamTestStreamMetadataRow row = StreamTestStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            StreamTestStreamMetadataNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    @Override
+    public Map<StreamTestStreamMetadataRow, Iterator<StreamTestStreamMetadataNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<StreamTestStreamMetadataRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamMetadataRow, Iterator<StreamTestStreamMetadataNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamMetadataRow row = StreamTestStreamMetadataRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestStreamMetadataNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
+        if (columns.allColumnsSelected()) {
+            return allColumns;
+        }
+        return columns;
+    }
+
+    public BatchingVisitableView<StreamTestStreamMetadataRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<StreamTestStreamMetadataRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder()
+                .retainColumns(optimizeColumnSelection(columns)).build()),
+                new Function<RowResult<byte[]>, StreamTestStreamMetadataRowResult>() {
+            @Override
+            public StreamTestStreamMetadataRowResult apply(RowResult<byte[]> input) {
+                return StreamTestStreamMetadataRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableGetRangesQuery}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Nullable}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "HUYG8R6+gmoLE4CTpUdmnA==";
+}

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestStreamStore.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestStreamStore.java
@@ -1,0 +1,479 @@
+package com.palantir.atlasdb.table.description.generated;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.processing.Generated;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.CountingInputStream;
+import com.google.common.primitives.Ints;
+import com.google.protobuf.ByteString;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.Status;
+import com.palantir.atlasdb.protos.generated.StreamPersistence.StreamMetadata;
+import com.palantir.atlasdb.stream.AbstractPersistentStreamStore;
+import com.palantir.atlasdb.stream.BlockConsumingInputStream;
+import com.palantir.atlasdb.stream.BlockGetter;
+import com.palantir.atlasdb.stream.BlockLoader;
+import com.palantir.atlasdb.stream.PersistentStreamStore;
+import com.palantir.atlasdb.stream.StreamCleanedException;
+import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
+import com.palantir.atlasdb.transaction.api.TransactionManager;
+import com.palantir.atlasdb.transaction.api.TransactionTask;
+import com.palantir.atlasdb.transaction.impl.TxTask;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.compression.StreamCompression;
+import com.palantir.common.io.ConcatenatedInputStream;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.logsafe.exceptions.SafeUncheckedIoException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.ByteArrayIOStream;
+import com.palantir.util.Pair;
+import com.palantir.util.crypto.Sha256Hash;
+import com.palantir.util.file.DeleteOnCloseFileInputStream;
+import com.palantir.util.file.TempFileUtils;
+
+@Generated("com.palantir.atlasdb.table.description.render.StreamStoreRenderer")
+@SuppressWarnings({"deprecation"})
+public final class StreamTestStreamStore extends AbstractPersistentStreamStore {
+    public static final int BLOCK_SIZE_IN_BYTES = 1000000; // 1MB. DO NOT CHANGE THIS WITHOUT AN UPGRADE TASK
+    public static final int IN_MEMORY_THRESHOLD = 4194304; // streams under this size are kept in memory when loaded
+    public static final String STREAM_FILE_PREFIX = "StreamTest_stream_";
+    public static final String STREAM_FILE_SUFFIX = ".tmp";
+
+    private static final SafeLogger log = SafeLoggerFactory.get(StreamTestStreamStore.class);
+
+    private final ApiTestTableFactory tables;
+
+    private StreamTestStreamStore(TransactionManager txManager, ApiTestTableFactory tables) {
+        this(txManager, tables, () -> StreamStorePersistenceConfiguration.DEFAULT_CONFIG);
+    }
+
+    private StreamTestStreamStore(TransactionManager txManager, ApiTestTableFactory tables, Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        super(txManager, StreamCompression.NONE, persistenceConfiguration);
+        this.tables = tables;
+    }
+
+    public static StreamTestStreamStore of(TransactionManager txManager, ApiTestTableFactory tables) {
+        return new StreamTestStreamStore(txManager, tables);
+    }
+
+    public static StreamTestStreamStore of(TransactionManager txManager, ApiTestTableFactory tables,  Supplier<StreamStorePersistenceConfiguration> persistenceConfiguration) {
+        return new StreamTestStreamStore(txManager, tables, persistenceConfiguration);
+    }
+
+    /**
+     * This should only be used by test code or as a performance optimization.
+     */
+    static StreamTestStreamStore of(ApiTestTableFactory tables) {
+        return new StreamTestStreamStore(null, tables);
+    }
+
+    @Override
+    protected long getInMemoryThreshold() {
+        return IN_MEMORY_THRESHOLD;
+    }
+
+    @Override
+    protected void storeBlock(Transaction t, long id, long blockNumber, final byte[] block) {
+        Preconditions.checkArgument(block.length <= BLOCK_SIZE_IN_BYTES, "Block to store in DB must be less than BLOCK_SIZE_IN_BYTES");
+        final StreamTestStreamValueTable.StreamTestStreamValueRow row = StreamTestStreamValueTable.StreamTestStreamValueRow.of(id, blockNumber);
+        try {
+            // Do a touch operation on this table to ensure we get a conflict if someone cleans it up.
+            touchMetadataWhileStoringForConflicts(t, row.getId(), row.getBlockId());
+            tables.getStreamTestStreamValueTable(t).putValue(row, block);
+        } catch (RuntimeException e) {
+            throw new SafeRuntimeException(
+                    "Error storing block for stream",
+                    e,
+                    SafeArg.of("blockId", row.getBlockId()),
+                    SafeArg.of("id", row.getId()));
+        }
+    }
+
+    private void touchMetadataWhileStoringForConflicts(Transaction t, Long id, long blockNumber) {
+        StreamTestStreamMetadataTable metaTable = tables.getStreamTestStreamMetadataTable(t);
+        StreamTestStreamMetadataTable.StreamTestStreamMetadataRow row = StreamTestStreamMetadataTable.StreamTestStreamMetadataRow.of(id);
+        StreamMetadata metadata = metaTable.getMetadatas(ImmutableSet.of(row)).values().iterator().next();
+        Preconditions.checkState(metadata.getStatus() == Status.STORING, "This stream is being cleaned up while storing blocks", SafeArg.of("id", id));
+        StreamMetadata.Builder builder = StreamMetadata.newBuilder(metadata);
+        builder.setLength(blockNumber * BLOCK_SIZE_IN_BYTES + 1);
+        metaTable.putMetadata(row, builder.build());
+    }
+
+    @Override
+    protected void putMetadataAndHashIndexTask(Transaction t, Map<Long, StreamMetadata> streamIdsToMetadata) {
+        StreamTestStreamMetadataTable mdTable = tables.getStreamTestStreamMetadataTable(t);
+        Map<Long, StreamMetadata> prevMetadatas = getMetadata(t, streamIdsToMetadata.keySet());
+
+        Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> rowsToStoredMetadata = new HashMap<>();
+        Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> rowsToUnstoredMetadata = new HashMap<>();
+        for (Entry<Long, StreamMetadata> e : streamIdsToMetadata.entrySet()) {
+            long streamId = e.getKey();
+            StreamMetadata metadata = e.getValue();
+            StreamMetadata prevMetadata = prevMetadatas.get(streamId);
+            if (metadata.getStatus() == Status.STORED) {
+                if (prevMetadata == null || prevMetadata.getStatus() != Status.STORING) {
+                    // This can happen if we cleanup old streams.
+                    throw new TransactionFailedRetriableException("Cannot mark a stream as stored that isn't currently storing: " + prevMetadata);
+                }
+                rowsToStoredMetadata.put(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow.of(streamId), metadata);
+            } else if (metadata.getStatus() == Status.STORING) {
+                // This will prevent two users trying to store the same id.
+                if (prevMetadata != null) {
+                    throw new TransactionFailedRetriableException("Cannot reuse the same stream id: " + streamId);
+                }
+                rowsToUnstoredMetadata.put(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow.of(streamId), metadata);
+            }
+        }
+        putHashIndexTask(t, rowsToStoredMetadata);
+
+        Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> rowsToMetadata =
+                Maps.newHashMapWithExpectedSize(streamIdsToMetadata.size());
+        rowsToMetadata.putAll(rowsToStoredMetadata);
+        rowsToMetadata.putAll(rowsToUnstoredMetadata);
+        mdTable.putMetadata(rowsToMetadata);
+    }
+
+    private long getNumberOfBlocksFromMetadata(StreamMetadata metadata) {
+        return (metadata.getLength() + BLOCK_SIZE_IN_BYTES - 1) / BLOCK_SIZE_IN_BYTES;
+    }
+
+    @Override
+    protected File createTempFile(Long id) throws IOException {
+        File file = TempFileUtils.createTempFile(STREAM_FILE_PREFIX + id, STREAM_FILE_SUFFIX);
+        file.deleteOnExit();
+        return file;
+    }
+
+    @Override
+    protected void loadSingleBlockToOutputStream(Transaction t, Long streamId, long blockId, OutputStream os) {
+        StreamTestStreamValueTable.StreamTestStreamValueRow row = StreamTestStreamValueTable.StreamTestStreamValueRow.of(streamId, blockId);
+        try {
+            byte[] block = getBlock(t, row);
+            if (block == null) {
+                throw new SafeRuntimeException(
+                        "Block for stream not found. This is likely due to returning a stream  from a transaction and attempting to use it after it has been marked as unused.",
+                        SafeArg.of("blockId", row.getBlockId()),
+                        SafeArg.of("id", row.getId()));
+            }
+            os.write(block);
+        } catch (RuntimeException e) {
+            throw new SafeRuntimeException(
+                    "Error storing block for stream",
+                    e,
+                    SafeArg.of("blockId", row.getBlockId()),
+                    SafeArg.of("id", row.getId()));
+        } catch (IOException e) {
+            throw new SafeUncheckedIoException(
+                    "Error writing block to file when getting stream",
+                    e,
+                    SafeArg.of("blockId", row.getBlockId()),
+                    SafeArg.of("id", row.getId()));
+        }
+    }
+
+    private byte[] getBlock(Transaction t, StreamTestStreamValueTable.StreamTestStreamValueRow row) {
+        StreamTestStreamValueTable valueTable = tables.getStreamTestStreamValueTable(t);
+        return valueTable.getValues(ImmutableSet.of(row)).get(row);
+    }
+
+    @Override
+    protected Map<Long, StreamMetadata> getMetadata(Transaction t, Set<Long> streamIds) {
+        if (streamIds.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        StreamTestStreamMetadataTable table = tables.getStreamTestStreamMetadataTable(t);
+        Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> metadatas = table.getMetadatas(getMetadataRowsForIds(streamIds));
+        Map<Long, StreamMetadata> ret = Maps.newHashMapWithExpectedSize(metadatas.size());
+        for (Map.Entry<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            ret.put(e.getKey().getId(), e.getValue());
+        }
+        return ret;
+    }
+
+    @Override
+    public Map<Sha256Hash, Long> lookupStreamIdsByHash(Transaction t, final Set<Sha256Hash> hashes) {
+        if (hashes.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        StreamTestStreamHashAidxTable idx = tables.getStreamTestStreamHashAidxTable(t);
+        Set<StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow> rows = getHashIndexRowsForHashes(hashes);
+
+        Multimap<StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow, StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumnValue> m = idx.getRowsMultimap(rows);
+        Map<Long, Sha256Hash> hashForStreams = Maps.newHashMapWithExpectedSize(m.size());
+        for (StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow r : m.keySet()) {
+            for (StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumnValue v : m.get(r)) {
+                Long streamId = v.getColumnName().getStreamId();
+                Sha256Hash hash = r.getHash();
+                if (hashForStreams.containsKey(streamId)) {
+                    AssertUtils.assertAndLog(log, hashForStreams.get(streamId).equals(hash), "(BUG) Stream ID has 2 different hashes: " + streamId);
+                }
+                hashForStreams.put(streamId, hash);
+            }
+        }
+        Map<Long, StreamMetadata> metadata = getMetadata(t, hashForStreams.keySet());
+
+        Map<Sha256Hash, Long> ret = new HashMap<>();
+        for (Map.Entry<Long, StreamMetadata> e : metadata.entrySet()) {
+            if (e.getValue().getStatus() != Status.STORED) {
+                continue;
+            }
+            Sha256Hash hash = hashForStreams.get(e.getKey());
+            ret.put(hash, e.getKey());
+        }
+
+        return ret;
+    }
+
+    private Set<StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow> getHashIndexRowsForHashes(final Set<Sha256Hash> hashes) {
+        Set<StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow> rows = Sets.newHashSetWithExpectedSize(hashes.size());
+        for (Sha256Hash h : hashes) {
+            rows.add(StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow.of(h));
+        }
+        return rows;
+    }
+
+    private Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> getMetadataRowsForIds(final Iterable<Long> ids) {
+        Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> rows = new HashSet<>();
+        for (Long id : ids) {
+            rows.add(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow.of(id));
+        }
+        return rows;
+    }
+
+    private void putHashIndexTask(Transaction t, Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> rowsToMetadata) {
+        Multimap<StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow, StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumnValue> indexMap = HashMultimap.create();
+        for (Entry<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> e : rowsToMetadata.entrySet()) {
+            StreamTestStreamMetadataTable.StreamTestStreamMetadataRow row = e.getKey();
+            StreamMetadata metadata = e.getValue();
+            Preconditions.checkArgument(
+                    metadata.getStatus() == Status.STORED,
+                    "Should only index successfully stored streams.");
+
+            Sha256Hash hash = Sha256Hash.EMPTY;
+            if (!ByteString.EMPTY.equals(metadata.getHash())) {
+                hash = new Sha256Hash(metadata.getHash().toByteArray());
+            }
+            StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow hashRow = StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow.of(hash);
+            StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumn column = StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumn.of(row.getId());
+            StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumnValue columnValue = StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumnValue.of(column, 0L);
+            indexMap.put(hashRow, columnValue);
+        }
+        StreamTestStreamHashAidxTable hiTable = tables.getStreamTestStreamHashAidxTable(t);
+        hiTable.put(indexMap);
+    }
+
+    /**
+     * This should only be used from the cleanup tasks.
+     */
+    void deleteStreams(Transaction t, final Set<Long> streamIds) {
+        if (streamIds.isEmpty()) {
+            return;
+        }
+        Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> smRows = new HashSet<>();
+        Multimap<StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow, StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumn> shToDelete = HashMultimap.create();
+        for (Long streamId : streamIds) {
+            smRows.add(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow.of(streamId));
+        }
+        StreamTestStreamMetadataTable table = tables.getStreamTestStreamMetadataTable(t);
+        Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> metadatas = table.getMetadatas(smRows);
+        Set<StreamTestStreamValueTable.StreamTestStreamValueRow> streamValueToDelete = new HashSet<>();
+        for (Entry<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            Long streamId = e.getKey().getId();
+            long blocks = getNumberOfBlocksFromMetadata(e.getValue());
+            for (long i = 0; i < blocks; i++) {
+                streamValueToDelete.add(StreamTestStreamValueTable.StreamTestStreamValueRow.of(streamId, i));
+            }
+            ByteString streamHash = e.getValue().getHash();
+            Sha256Hash hash = Sha256Hash.EMPTY;
+            if (!ByteString.EMPTY.equals(streamHash)) {
+                hash = new Sha256Hash(streamHash.toByteArray());
+            } else {
+                log.error(
+                        "Empty hash for stream {}",
+                        SafeArg.of("id", streamId));
+            }
+            StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow hashRow = StreamTestStreamHashAidxTable.StreamTestStreamHashAidxRow.of(hash);
+            StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumn column = StreamTestStreamHashAidxTable.StreamTestStreamHashAidxColumn.of(streamId);
+            shToDelete.put(hashRow, column);
+        }
+        tables.getStreamTestStreamHashAidxTable(t).delete(shToDelete);
+        tables.getStreamTestStreamValueTable(t).delete(streamValueToDelete);
+        table.delete(smRows);
+    }
+
+    @Override
+    protected void markStreamsAsUsedInternal(Transaction t, final Map<Long, byte[]> streamIdsToReference) {
+        if (streamIdsToReference.isEmpty()) {
+            return;
+        }
+        StreamTestStreamIdxTable index = tables.getStreamTestStreamIdxTable(t);
+        Multimap<StreamTestStreamIdxTable.StreamTestStreamIdxRow, StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue> rowsToValues = HashMultimap.create();
+        for (Map.Entry<Long, byte[]> entry : streamIdsToReference.entrySet()) {
+            Long streamId = entry.getKey();
+            byte[] reference = entry.getValue();
+            StreamTestStreamIdxTable.StreamTestStreamIdxColumn col = StreamTestStreamIdxTable.StreamTestStreamIdxColumn.of(reference);
+            StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue value = StreamTestStreamIdxTable.StreamTestStreamIdxColumnValue.of(col, 0L);
+            rowsToValues.put(StreamTestStreamIdxTable.StreamTestStreamIdxRow.of(streamId), value);
+        }
+        index.put(rowsToValues);
+    }
+
+    @Override
+    public void unmarkStreamsAsUsed(Transaction t, final Map<Long, byte[]> streamIdsToReference) {
+        if (streamIdsToReference.isEmpty()) {
+            return;
+        }
+        StreamTestStreamIdxTable index = tables.getStreamTestStreamIdxTable(t);
+        Multimap<StreamTestStreamIdxTable.StreamTestStreamIdxRow, StreamTestStreamIdxTable.StreamTestStreamIdxColumn> toDelete = ArrayListMultimap.create(streamIdsToReference.size(), 1);
+        for (Map.Entry<Long, byte[]> entry : streamIdsToReference.entrySet()) {
+            Long streamId = entry.getKey();
+            byte[] reference = entry.getValue();
+            StreamTestStreamIdxTable.StreamTestStreamIdxColumn col = StreamTestStreamIdxTable.StreamTestStreamIdxColumn.of(reference);
+            toDelete.put(StreamTestStreamIdxTable.StreamTestStreamIdxRow.of(streamId), col);
+        }
+        index.delete(toDelete);
+    }
+
+    @Override
+    protected void touchMetadataWhileMarkingUsedForConflicts(Transaction t, Iterable<Long> ids) {
+        StreamTestStreamMetadataTable metaTable = tables.getStreamTestStreamMetadataTable(t);
+        Set<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> rows = new HashSet<>();
+        for (Long id : ids) {
+            rows.add(StreamTestStreamMetadataTable.StreamTestStreamMetadataRow.of(id));
+        }
+        Map<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> metadatas = metaTable.getMetadatas(rows);
+        for (Map.Entry<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow, StreamMetadata> e : metadatas.entrySet()) {
+            StreamMetadata metadata = e.getValue();
+            Preconditions.checkState(
+                    metadata.getStatus() == Status.STORED,
+                    "Stream has stored status",
+                    SafeArg.of("streamId", e.getKey().getId()),
+                    SafeArg.of("status", metadata.getStatus()));
+            metaTable.putMetadata(e.getKey(), metadata);
+        }
+        SetView<StreamTestStreamMetadataTable.StreamTestStreamMetadataRow> missingRows = Sets.difference(rows, metadatas.keySet());
+        if (!missingRows.isEmpty()) {
+            throw new IllegalStateException("Missing metadata rows for:" + missingRows
+            + " rows: " + rows + " metadata: " + metadatas + " txn timestamp: " + t.getTimestamp());
+        }
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbstractPersistentStreamStore}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link BiConsumer}
+     * {@link BlockConsumingInputStream}
+     * {@link BlockGetter}
+     * {@link BlockLoader}
+     * {@link BufferedInputStream}
+     * {@link ByteArrayIOStream}
+     * {@link ByteArrayInputStream}
+     * {@link ByteStreams}
+     * {@link ByteString}
+     * {@link Cell}
+     * {@link CheckForNull}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ConcatenatedInputStream}
+     * {@link CountingInputStream}
+     * {@link DeleteOnCloseFileInputStream}
+     * {@link DigestInputStream}
+     * {@link Entry}
+     * {@link File}
+     * {@link FileNotFoundException}
+     * {@link FileOutputStream}
+     * {@link Functions}
+     * {@link Generated}
+     * {@link HashMap}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link IOException}
+     * {@link ImmutableMap}
+     * {@link ImmutableSet}
+     * {@link InputStream}
+     * {@link Ints}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MessageDigest}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link Optional}
+     * {@link OutputStream}
+     * {@link Pair}
+     * {@link PersistentStreamStore}
+     * {@link Preconditions}
+     * {@link SafeArg}
+     * {@link SafeLogger}
+     * {@link SafeLoggerFactory}
+     * {@link SafeRuntimeException}
+     * {@link SafeUncheckedIoException}
+     * {@link Set}
+     * {@link SetView}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link Status}
+     * {@link StreamCleanedException}
+     * {@link StreamCompression}
+     * {@link StreamMetadata}
+     * {@link StreamStorePersistenceConfiguration}
+     * {@link Supplier}
+     * {@link TempFileUtils}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TransactionFailedRetriableException}
+     * {@link TransactionManager}
+     * {@link TransactionTask}
+     * {@link TxTask}
+     * {@link UnsafeArg}
+     */
+    static final int dummy = 0;
+}

--- a/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestStreamValueTable.java
+++ b/atlasdb-client/src/integrationInput/java/com/palantir/atlasdb/table/description/generated/StreamTestStreamValueTable.java
@@ -1,0 +1,697 @@
+package com.palantir.atlasdb.table.description.generated;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+import javax.annotation.processing.Generated;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.UnsignedBytes;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.palantir.atlasdb.compress.CompressionUtils;
+import com.palantir.atlasdb.encoding.PtBytes;
+import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
+import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelections;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.Prefix;
+import com.palantir.atlasdb.keyvalue.api.RangeRequest;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.ptobject.EncodingUtils;
+import com.palantir.atlasdb.table.api.AtlasDbDynamicMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbMutablePersistentTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedMutableTable;
+import com.palantir.atlasdb.table.api.AtlasDbNamedPersistentSet;
+import com.palantir.atlasdb.table.api.ColumnValue;
+import com.palantir.atlasdb.table.api.TypedRowResult;
+import com.palantir.atlasdb.table.description.ColumnValueDescription.Compression;
+import com.palantir.atlasdb.table.description.ValueType;
+import com.palantir.atlasdb.table.generation.ColumnValues;
+import com.palantir.atlasdb.table.generation.Descending;
+import com.palantir.atlasdb.table.generation.NamedColumnValue;
+import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.ConstraintCheckingTransaction;
+import com.palantir.atlasdb.transaction.api.ImmutableGetRangesQuery;
+import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.common.base.AbortingVisitor;
+import com.palantir.common.base.AbortingVisitors;
+import com.palantir.common.base.BatchingVisitable;
+import com.palantir.common.base.BatchingVisitableView;
+import com.palantir.common.base.BatchingVisitables;
+import com.palantir.common.base.Throwables;
+import com.palantir.common.collect.IterableView;
+import com.palantir.common.persist.Persistable;
+import com.palantir.common.persist.Persistable.Hydrator;
+import com.palantir.common.persist.Persistables;
+import com.palantir.util.AssertUtils;
+import com.palantir.util.crypto.Sha256Hash;
+
+@Generated("com.palantir.atlasdb.table.description.render.TableRenderer")
+@SuppressWarnings({"deprecation"})
+public final class StreamTestStreamValueTable implements
+        AtlasDbMutablePersistentTable<StreamTestStreamValueTable.StreamTestStreamValueRow,
+                                         StreamTestStreamValueTable.StreamTestStreamValueNamedColumnValue<?>,
+                                         StreamTestStreamValueTable.StreamTestStreamValueRowResult>,
+        AtlasDbNamedMutableTable<StreamTestStreamValueTable.StreamTestStreamValueRow,
+                                    StreamTestStreamValueTable.StreamTestStreamValueNamedColumnValue<?>,
+                                    StreamTestStreamValueTable.StreamTestStreamValueRowResult> {
+    private final Transaction t;
+    private final List<StreamTestStreamValueTrigger> triggers;
+    private final static String rawTableName = "stream_test_stream_value";
+    private final TableReference tableRef;
+    private final static ColumnSelection allColumns = getColumnSelection(StreamTestStreamValueNamedColumn.values());
+
+    static StreamTestStreamValueTable of(Transaction t, Namespace namespace) {
+        return new StreamTestStreamValueTable(t, namespace, ImmutableList.<StreamTestStreamValueTrigger>of());
+    }
+
+    static StreamTestStreamValueTable of(Transaction t, Namespace namespace, StreamTestStreamValueTrigger trigger, StreamTestStreamValueTrigger... triggers) {
+        return new StreamTestStreamValueTable(t, namespace, ImmutableList.<StreamTestStreamValueTrigger>builder().add(trigger).add(triggers).build());
+    }
+
+    static StreamTestStreamValueTable of(Transaction t, Namespace namespace, List<StreamTestStreamValueTrigger> triggers) {
+        return new StreamTestStreamValueTable(t, namespace, triggers);
+    }
+
+    private StreamTestStreamValueTable(Transaction t, Namespace namespace, List<StreamTestStreamValueTrigger> triggers) {
+        this.t = t;
+        this.tableRef = TableReference.create(namespace, rawTableName);
+        this.triggers = triggers;
+    }
+
+    public static String getRawTableName() {
+        return rawTableName;
+    }
+
+    public TableReference getTableRef() {
+        return tableRef;
+    }
+
+    public String getTableName() {
+        return tableRef.getQualifiedName();
+    }
+
+    public Namespace getNamespace() {
+        return tableRef.getNamespace();
+    }
+
+    /**
+     * <pre>
+     * StreamTestStreamValueRow {
+     *   {@literal Long id};
+     *   {@literal Long blockId};
+     * }
+     * </pre>
+     */
+    public static final class StreamTestStreamValueRow implements Persistable, Comparable<StreamTestStreamValueRow> {
+        private final long id;
+        private final long blockId;
+
+        public static StreamTestStreamValueRow of(long id, long blockId) {
+            return new StreamTestStreamValueRow(id, blockId);
+        }
+
+        private StreamTestStreamValueRow(long id, long blockId) {
+            this.id = id;
+            this.blockId = blockId;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public long getBlockId() {
+            return blockId;
+        }
+
+        public static Function<StreamTestStreamValueRow, Long> getIdFun() {
+            return new Function<StreamTestStreamValueRow, Long>() {
+                @Override
+                public Long apply(StreamTestStreamValueRow row) {
+                    return row.id;
+                }
+            };
+        }
+
+        public static Function<StreamTestStreamValueRow, Long> getBlockIdFun() {
+            return new Function<StreamTestStreamValueRow, Long>() {
+                @Override
+                public Long apply(StreamTestStreamValueRow row) {
+                    return row.blockId;
+                }
+            };
+        }
+
+        @Override
+        public byte[] persistToBytes() {
+            byte[] idBytes = EncodingUtils.encodeUnsignedVarLong(id);
+            byte[] blockIdBytes = EncodingUtils.encodeUnsignedVarLong(blockId);
+            return EncodingUtils.add(idBytes, blockIdBytes);
+        }
+
+        public static final Hydrator<StreamTestStreamValueRow> BYTES_HYDRATOR = new Hydrator<StreamTestStreamValueRow>() {
+            @Override
+            public StreamTestStreamValueRow hydrateFromBytes(byte[] __input) {
+                int __index = 0;
+                long id = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                __index += EncodingUtils.sizeOfUnsignedVarLong(id);
+                long blockId = EncodingUtils.decodeUnsignedVarLong(__input, __index);
+                return new StreamTestStreamValueRow(id, blockId);
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("id", id)
+                .add("blockId", blockId)
+                .toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            StreamTestStreamValueRow other = (StreamTestStreamValueRow) obj;
+            return Objects.equals(id, other.id) && Objects.equals(blockId, other.blockId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.deepHashCode(new Object[]{ id, blockId });
+        }
+
+        @Override
+        public int compareTo(StreamTestStreamValueRow o) {
+            return ComparisonChain.start()
+                .compare(this.id, o.id)
+                .compare(this.blockId, o.blockId)
+                .result();
+        }
+    }
+
+    public interface StreamTestStreamValueNamedColumnValue<T> extends NamedColumnValue<T> { /* */ }
+
+    /**
+     * <pre>
+     * Column value description {
+     *   type: byte[];
+     * }
+     * </pre>
+     */
+    public static final class Value implements StreamTestStreamValueNamedColumnValue<byte[]> {
+        private final byte[] value;
+
+        public static Value of(byte[] value) {
+            return new Value(value);
+        }
+
+        private Value(byte[] value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getColumnName() {
+            return "value";
+        }
+
+        @Override
+        public String getShortColumnName() {
+            return "v";
+        }
+
+        @Override
+        public byte[] getValue() {
+            return value;
+        }
+
+        @Override
+        public byte[] persistValue() {
+            byte[] bytes = value;
+            return CompressionUtils.compress(bytes, Compression.NONE);
+        }
+
+        @Override
+        public byte[] persistColumnName() {
+            return PtBytes.toCachedBytes("v");
+        }
+
+        public static final Hydrator<Value> BYTES_HYDRATOR = new Hydrator<Value>() {
+            @Override
+            public Value hydrateFromBytes(byte[] bytes) {
+                bytes = CompressionUtils.decompress(bytes, Compression.NONE);
+                return of(EncodingUtils.getBytesFromOffsetToEnd(bytes, 0));
+            }
+        };
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("Value", this.value)
+                .toString();
+        }
+    }
+
+    public interface StreamTestStreamValueTrigger {
+        public void putStreamTestStreamValue(Multimap<StreamTestStreamValueRow, ? extends StreamTestStreamValueNamedColumnValue<?>> newRows);
+    }
+
+    public static final class StreamTestStreamValueRowResult implements TypedRowResult {
+        private final RowResult<byte[]> row;
+
+        public static StreamTestStreamValueRowResult of(RowResult<byte[]> row) {
+            return new StreamTestStreamValueRowResult(row);
+        }
+
+        private StreamTestStreamValueRowResult(RowResult<byte[]> row) {
+            this.row = row;
+        }
+
+        @Override
+        public StreamTestStreamValueRow getRowName() {
+            return StreamTestStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(row.getRowName());
+        }
+
+        public static Function<StreamTestStreamValueRowResult, StreamTestStreamValueRow> getRowNameFun() {
+            return new Function<StreamTestStreamValueRowResult, StreamTestStreamValueRow>() {
+                @Override
+                public StreamTestStreamValueRow apply(StreamTestStreamValueRowResult rowResult) {
+                    return rowResult.getRowName();
+                }
+            };
+        }
+
+        public static Function<RowResult<byte[]>, StreamTestStreamValueRowResult> fromRawRowResultFun() {
+            return new Function<RowResult<byte[]>, StreamTestStreamValueRowResult>() {
+                @Override
+                public StreamTestStreamValueRowResult apply(RowResult<byte[]> rowResult) {
+                    return new StreamTestStreamValueRowResult(rowResult);
+                }
+            };
+        }
+
+        public boolean hasValue() {
+            return row.getColumns().containsKey(PtBytes.toCachedBytes("v"));
+        }
+
+        public byte[] getValue() {
+            byte[] bytes = row.getColumns().get(PtBytes.toCachedBytes("v"));
+            if (bytes == null) {
+                return null;
+            }
+            Value value = Value.BYTES_HYDRATOR.hydrateFromBytes(bytes);
+            return value.getValue();
+        }
+
+        public static Function<StreamTestStreamValueRowResult, byte[]> getValueFun() {
+            return new Function<StreamTestStreamValueRowResult, byte[]>() {
+                @Override
+                public byte[] apply(StreamTestStreamValueRowResult rowResult) {
+                    return rowResult.getValue();
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(getClass().getSimpleName())
+                .add("RowName", getRowName())
+                .add("Value", getValue())
+                .toString();
+        }
+    }
+
+    public enum StreamTestStreamValueNamedColumn {
+        VALUE {
+            @Override
+            public byte[] getShortName() {
+                return PtBytes.toCachedBytes("v");
+            }
+        };
+
+        public abstract byte[] getShortName();
+
+        public static Function<StreamTestStreamValueNamedColumn, byte[]> toShortName() {
+            return new Function<StreamTestStreamValueNamedColumn, byte[]>() {
+                @Override
+                public byte[] apply(StreamTestStreamValueNamedColumn namedColumn) {
+                    return namedColumn.getShortName();
+                }
+            };
+        }
+    }
+
+    public static ColumnSelection getColumnSelection(Collection<StreamTestStreamValueNamedColumn> cols) {
+        return ColumnSelection.create(Collections2.transform(cols, StreamTestStreamValueNamedColumn.toShortName()));
+    }
+
+    public static ColumnSelection getColumnSelection(StreamTestStreamValueNamedColumn... cols) {
+        return getColumnSelection(Arrays.asList(cols));
+    }
+
+    private static final Map<String, Hydrator<? extends StreamTestStreamValueNamedColumnValue<?>>> shortNameToHydrator =
+            ImmutableMap.<String, Hydrator<? extends StreamTestStreamValueNamedColumnValue<?>>>builder()
+                .put("v", Value.BYTES_HYDRATOR)
+                .build();
+
+    public Map<StreamTestStreamValueRow, byte[]> getValues(Collection<StreamTestStreamValueRow> rows) {
+        Map<Cell, StreamTestStreamValueRow> cells = Maps.newHashMapWithExpectedSize(rows.size());
+        for (StreamTestStreamValueRow row : rows) {
+            cells.put(Cell.create(row.persistToBytes(), PtBytes.toCachedBytes("v")), row);
+        }
+        Map<Cell, byte[]> results = t.get(tableRef, cells.keySet());
+        Map<StreamTestStreamValueRow, byte[]> ret = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<Cell, byte[]> e : results.entrySet()) {
+            byte[] val = Value.BYTES_HYDRATOR.hydrateFromBytes(e.getValue()).getValue();
+            ret.put(cells.get(e.getKey()), val);
+        }
+        return ret;
+    }
+
+    public void putValue(StreamTestStreamValueRow row, byte[] value) {
+        put(ImmutableMultimap.of(row, Value.of(value)));
+    }
+
+    public void putValue(Map<StreamTestStreamValueRow, byte[]> map) {
+        Map<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> toPut = Maps.newHashMapWithExpectedSize(map.size());
+        for (Entry<StreamTestStreamValueRow, byte[]> e : map.entrySet()) {
+            toPut.put(e.getKey(), Value.of(e.getValue()));
+        }
+        put(Multimaps.forMap(toPut));
+    }
+
+    @Override
+    public void put(Multimap<StreamTestStreamValueRow, ? extends StreamTestStreamValueNamedColumnValue<?>> rows) {
+        t.useTable(tableRef, this);
+        t.put(tableRef, ColumnValues.toCellValues(rows));
+        for (StreamTestStreamValueTrigger trigger : triggers) {
+            trigger.putStreamTestStreamValue(rows);
+        }
+    }
+
+    public void deleteValue(StreamTestStreamValueRow row) {
+        deleteValue(ImmutableSet.of(row));
+    }
+
+    public void deleteValue(Iterable<StreamTestStreamValueRow> rows) {
+        byte[] col = PtBytes.toCachedBytes("v");
+        Set<Cell> cells = Cells.cellsWithConstantColumn(Persistables.persistAll(rows), col);
+        t.delete(tableRef, cells);
+    }
+
+    @Override
+    public void delete(StreamTestStreamValueRow row) {
+        delete(ImmutableSet.of(row));
+    }
+
+    @Override
+    public void delete(Iterable<StreamTestStreamValueRow> rows) {
+        List<byte[]> rowBytes = Persistables.persistAll(rows);
+        Set<Cell> cells = Sets.newHashSetWithExpectedSize(rowBytes.size());
+        cells.addAll(Cells.cellsWithConstantColumn(rowBytes, PtBytes.toCachedBytes("v")));
+        t.delete(tableRef, cells);
+    }
+
+    public Optional<StreamTestStreamValueRowResult> getRow(StreamTestStreamValueRow row) {
+        return getRow(row, allColumns);
+    }
+
+    public Optional<StreamTestStreamValueRowResult> getRow(StreamTestStreamValueRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(StreamTestStreamValueRowResult.of(rowResult));
+        }
+    }
+
+    @Override
+    public List<StreamTestStreamValueRowResult> getRows(Iterable<StreamTestStreamValueRow> rows) {
+        return getRows(rows, allColumns);
+    }
+
+    @Override
+    public List<StreamTestStreamValueRowResult> getRows(Iterable<StreamTestStreamValueRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        List<StreamTestStreamValueRowResult> rowResults = Lists.newArrayListWithCapacity(results.size());
+        for (RowResult<byte[]> row : results.values()) {
+            rowResults.add(StreamTestStreamValueRowResult.of(row));
+        }
+        return rowResults;
+    }
+
+    @Override
+    public List<StreamTestStreamValueNamedColumnValue<?>> getRowColumns(StreamTestStreamValueRow row) {
+        return getRowColumns(row, allColumns);
+    }
+
+    @Override
+    public List<StreamTestStreamValueNamedColumnValue<?>> getRowColumns(StreamTestStreamValueRow row, ColumnSelection columns) {
+        byte[] bytes = row.persistToBytes();
+        RowResult<byte[]> rowResult = t.getRows(tableRef, ImmutableSet.of(bytes), columns).get(bytes);
+        if (rowResult == null) {
+            return ImmutableList.of();
+        } else {
+            List<StreamTestStreamValueNamedColumnValue<?>> ret = Lists.newArrayListWithCapacity(rowResult.getColumns().size());
+            for (Entry<byte[], byte[]> e : rowResult.getColumns().entrySet()) {
+                ret.add(shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+            return ret;
+        }
+    }
+
+    @Override
+    public Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestStreamValueRow> rows) {
+        return getRowsMultimapInternal(rows, allColumns);
+    }
+
+    @Override
+    public Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> getRowsMultimap(Iterable<StreamTestStreamValueRow> rows, ColumnSelection columns) {
+        return getRowsMultimapInternal(rows, columns);
+    }
+
+    private Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> getRowsMultimapInternal(Iterable<StreamTestStreamValueRow> rows, ColumnSelection columns) {
+        SortedMap<byte[], RowResult<byte[]>> results = t.getRows(tableRef, Persistables.persistAll(rows), columns);
+        return getRowMapFromRowResults(results.values());
+    }
+
+    private static Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> getRowMapFromRowResults(Collection<RowResult<byte[]>> rowResults) {
+        Multimap<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>> rowMap = ArrayListMultimap.create();
+        for (RowResult<byte[]> result : rowResults) {
+            StreamTestStreamValueRow row = StreamTestStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(result.getRowName());
+            for (Entry<byte[], byte[]> e : result.getColumns().entrySet()) {
+                rowMap.put(row, shortNameToHydrator.get(PtBytes.toString(e.getKey())).hydrateFromBytes(e.getValue()));
+            }
+        }
+        return rowMap;
+    }
+
+    @Override
+    public Map<StreamTestStreamValueRow, BatchingVisitable<StreamTestStreamValueNamedColumnValue<?>>> getRowsColumnRange(Iterable<StreamTestStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRange(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamValueRow, BatchingVisitable<StreamTestStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], BatchingVisitable<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamValueRow row = StreamTestStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            BatchingVisitable<StreamTestStreamValueNamedColumnValue<?>> bv = BatchingVisitables.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    @Override
+    public Iterator<Map.Entry<StreamTestStreamValueRow, StreamTestStreamValueNamedColumnValue<?>>> getRowsColumnRange(Iterable<StreamTestStreamValueRow> rows, ColumnRangeSelection columnRangeSelection, int batchHint) {
+        Iterator<Map.Entry<Cell, byte[]>> results = t.getRowsColumnRange(getTableRef(), Persistables.persistAll(rows), columnRangeSelection, batchHint);
+        return Iterators.transform(results, e -> {
+            StreamTestStreamValueRow row = StreamTestStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey().getRowName());
+            StreamTestStreamValueNamedColumnValue<?> colValue = shortNameToHydrator.get(PtBytes.toString(e.getKey().getColumnName())).hydrateFromBytes(e.getValue());
+            return Maps.immutableEntry(row, colValue);
+        });
+    }
+
+    @Override
+    public Map<StreamTestStreamValueRow, Iterator<StreamTestStreamValueNamedColumnValue<?>>> getRowsColumnRangeIterator(Iterable<StreamTestStreamValueRow> rows, BatchColumnRangeSelection columnRangeSelection) {
+        Map<byte[], Iterator<Map.Entry<Cell, byte[]>>> results = t.getRowsColumnRangeIterator(tableRef, Persistables.persistAll(rows), columnRangeSelection);
+        Map<StreamTestStreamValueRow, Iterator<StreamTestStreamValueNamedColumnValue<?>>> transformed = Maps.newHashMapWithExpectedSize(results.size());
+        for (Entry<byte[], Iterator<Map.Entry<Cell, byte[]>>> e : results.entrySet()) {
+            StreamTestStreamValueRow row = StreamTestStreamValueRow.BYTES_HYDRATOR.hydrateFromBytes(e.getKey());
+            Iterator<StreamTestStreamValueNamedColumnValue<?>> bv = Iterators.transform(e.getValue(), result -> {
+                return shortNameToHydrator.get(PtBytes.toString(result.getKey().getColumnName())).hydrateFromBytes(result.getValue());
+            });
+            transformed.put(row, bv);
+        }
+        return transformed;
+    }
+
+    private ColumnSelection optimizeColumnSelection(ColumnSelection columns) {
+        if (columns.allColumnsSelected()) {
+            return allColumns;
+        }
+        return columns;
+    }
+
+    public BatchingVisitableView<StreamTestStreamValueRowResult> getAllRowsUnordered() {
+        return getAllRowsUnordered(allColumns);
+    }
+
+    public BatchingVisitableView<StreamTestStreamValueRowResult> getAllRowsUnordered(ColumnSelection columns) {
+        return BatchingVisitables.transform(t.getRange(tableRef, RangeRequest.builder()
+                .retainColumns(optimizeColumnSelection(columns)).build()),
+                new Function<RowResult<byte[]>, StreamTestStreamValueRowResult>() {
+            @Override
+            public StreamTestStreamValueRowResult apply(RowResult<byte[]> input) {
+                return StreamTestStreamValueRowResult.of(input);
+            }
+        });
+    }
+
+    @Override
+    public List<String> findConstraintFailures(Map<Cell, byte[]> writes,
+                                               ConstraintCheckingTransaction transaction,
+                                               AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<String> findConstraintFailuresNoRead(Map<Cell, byte[]> writes,
+                                                     AtlasDbConstraintCheckingMode constraintCheckingMode) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * This exists to avoid unused import warnings
+     * {@link AbortingVisitor}
+     * {@link AbortingVisitors}
+     * {@link ArrayListMultimap}
+     * {@link Arrays}
+     * {@link AssertUtils}
+     * {@link AtlasDbConstraintCheckingMode}
+     * {@link AtlasDbDynamicMutablePersistentTable}
+     * {@link AtlasDbMutablePersistentTable}
+     * {@link AtlasDbNamedMutableTable}
+     * {@link AtlasDbNamedPersistentSet}
+     * {@link BatchColumnRangeSelection}
+     * {@link BatchingVisitable}
+     * {@link BatchingVisitableView}
+     * {@link BatchingVisitables}
+     * {@link BiFunction}
+     * {@link Bytes}
+     * {@link Callable}
+     * {@link Cell}
+     * {@link Cells}
+     * {@link Collection}
+     * {@link Collections2}
+     * {@link ColumnRangeSelection}
+     * {@link ColumnRangeSelections}
+     * {@link ColumnSelection}
+     * {@link ColumnValue}
+     * {@link ColumnValues}
+     * {@link ComparisonChain}
+     * {@link Compression}
+     * {@link CompressionUtils}
+     * {@link ConstraintCheckingTransaction}
+     * {@link Descending}
+     * {@link EncodingUtils}
+     * {@link Entry}
+     * {@link EnumSet}
+     * {@link Function}
+     * {@link Generated}
+     * {@link HashMultimap}
+     * {@link HashSet}
+     * {@link Hashing}
+     * {@link Hydrator}
+     * {@link ImmutableGetRangesQuery}
+     * {@link ImmutableList}
+     * {@link ImmutableMap}
+     * {@link ImmutableMultimap}
+     * {@link ImmutableSet}
+     * {@link InvalidProtocolBufferException}
+     * {@link IterableView}
+     * {@link Iterables}
+     * {@link Iterator}
+     * {@link Iterators}
+     * {@link Joiner}
+     * {@link List}
+     * {@link Lists}
+     * {@link Map}
+     * {@link Maps}
+     * {@link MoreObjects}
+     * {@link Multimap}
+     * {@link Multimaps}
+     * {@link NamedColumnValue}
+     * {@link Namespace}
+     * {@link Nullable}
+     * {@link Objects}
+     * {@link Optional}
+     * {@link Persistable}
+     * {@link Persistables}
+     * {@link Prefix}
+     * {@link PtBytes}
+     * {@link RangeRequest}
+     * {@link RowResult}
+     * {@link Set}
+     * {@link Sets}
+     * {@link Sha256Hash}
+     * {@link SortedMap}
+     * {@link Stream}
+     * {@link Supplier}
+     * {@link TableReference}
+     * {@link Throwables}
+     * {@link TimeUnit}
+     * {@link Transaction}
+     * {@link TypedRowResult}
+     * {@link UUID}
+     * {@link UnsignedBytes}
+     * {@link ValueType}
+     */
+    static String __CLASS_HASH = "5YkezY00cIu2r+EwDYUMFQ==";
+}

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/render/StreamStoreRenderer.java
@@ -285,11 +285,12 @@ public class StreamStoreRenderer {
                     }
                     line("} catch (RuntimeException e) {");
                     {
-                        line("throw new SafeRuntimeException(");
+                        line("log.error(");
                         line("        \"Error storing block for stream\",");
-                        line("        e,");
+                        line("        SafeArg.of(\"streamId\", row.getId()),");
                         line("        SafeArg.of(\"blockId\", row.getBlockId()),");
-                        line("        SafeArg.of(\"id\", row.getId()));");
+                        line("        e);");
+                        line("throw e;");
                     }
                     line("}");
                 }
@@ -307,7 +308,7 @@ public class StreamStoreRenderer {
                     line("StreamMetadata metadata ="
                             + " metaTable.getMetadatas(ImmutableSet.of(row)).values().iterator().next();");
                     line("Preconditions.checkState(metadata.getStatus() == Status.STORING, \"This stream is being"
-                            + " cleaned up while storing blocks\", SafeArg.of(\"id\", id));");
+                            + " cleaned up while storing blocks\", SafeArg.of(\"streamId\", id));");
                     line("StreamMetadata.Builder builder = StreamMetadata.newBuilder(metadata);");
                     line("builder.setLength(blockNumber * BLOCK_SIZE_IN_BYTES + 1);");
                     line("metaTable.putMetadata(row, builder.build());");
@@ -413,29 +414,30 @@ public class StreamStoreRenderer {
                         line("byte[] block = getBlock(t, row);");
                         line("if (block == null) {");
                         line("throw new SafeRuntimeException(");
-                        line("        \"Block for stream not found. This is likely due to returning a stream "
+                        line("        \"Block for stream not found. This is likely due to returning a stream"
                                 + " from a transaction and attempting to use it after it has been marked as"
                                 + " unused.\",");
-                        line("        SafeArg.of(\"blockId\", row.getBlockId()),");
-                        line("        SafeArg.of(\"id\", row.getId()));");
+                        line("        SafeArg.of(\"streamId\", row.getId()),");
+                        line("        SafeArg.of(\"blockId\", row.getBlockId()));");
                         line("}");
                         line("os.write(block);");
                     }
                     line("} catch (RuntimeException e) {");
                     {
-                        line("throw new SafeRuntimeException(");
+                        line("log.error(");
                         line("        \"Error storing block for stream\",");
-                        line("        e,");
+                        line("        SafeArg.of(\"streamId\", row.getId()),");
                         line("        SafeArg.of(\"blockId\", row.getBlockId()),");
-                        line("        SafeArg.of(\"id\", row.getId()));");
+                        line("        e);");
+                        line("throw e;");
                     }
                     line("} catch (IOException e) {");
                     {
                         line("throw new SafeUncheckedIoException(");
                         line("        \"Error writing block to file when getting stream\",");
                         line("        e,");
-                        line("        SafeArg.of(\"blockId\", row.getBlockId()),");
-                        line("        SafeArg.of(\"id\", row.getId()));");
+                        line("        SafeArg.of(\"streamId\", row.getId()),");
+                        line("        SafeArg.of(\"blockId\", row.getBlockId()));");
                     }
                     line("}");
                 }
@@ -666,7 +668,7 @@ public class StreamStoreRenderer {
                         {
                             line("log.error(");
                             line("        \"Empty hash for stream {}\",");
-                            line("        SafeArg.of(\"id\", streamId));");
+                            line("        SafeArg.of(\"streamId\", streamId));");
                         }
                         line("}");
                         line(StreamHashAidxRow, " hashRow = ", StreamHashAidxRow, ".of(hash);");

--- a/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ApiTestSchema.java
+++ b/atlasdb-client/src/test/java/com/palantir/atlasdb/table/description/ApiTestSchema.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.table.description;
 
 import com.palantir.atlasdb.keyvalue.api.Namespace;
 import com.palantir.atlasdb.schema.AtlasSchema;
+import com.palantir.atlasdb.schema.stream.StreamStoreDefinitionBuilder;
 import com.palantir.atlasdb.table.description.test.StringValuePersister;
 import java.io.File;
 import java.util.stream.Stream;
@@ -87,6 +88,9 @@ public class ApiTestSchema implements AtlasSchema {
                         .forEachOrdered(type -> column("column" + type.ordinal(), "c" + type.ordinal(), type));
             }
         });
+
+        schema.addStreamStoreDefinition(
+                new StreamStoreDefinitionBuilder("stream_test", "stream_test", ValueType.VAR_LONG).build());
 
         return schema;
     }


### PR DESCRIPTION
We recently had a bug a `NullPointerException` was being thrown when consuming a stream.

```
java.lang.NullPointerException: {throwable0_message}
    at java.base/java.io.OutputStream.write(OutputStream.java:124)
    at com.palantir.example.MyStreamStore.loadSingleBlockToOutputStream(MyStreamStore.java:193)
    at com.palantir.example.MyStreamStore.loadSingleBlockToOutputStream(MyStreamStore.java:75)
    at com.palantir.atlasdb.stream.AbstractGenericStreamStore.loadNBlocksToOutputStream(AbstractGenericStreamStore.java:211)
    at com.palantir.atlasdb.stream.AbstractGenericStreamStore$1.lambda$get$0(AbstractGenericStreamStore.java:135)
```

In this instance, we were attempting to consume a stream outside of the transaction where it was loaded. A subsequent transaction marked the stream as unused and we then failed to read a block from the stream, resulting in a `NullPointerException` thrown in `OutputStream.write` when we attempt to get the length of a null `byte[]`.

https://github.com/openjdk/jdk/blob/890adb6410dab4606a4f26a942aed02fb2f55387/src/java.base/share/classes/java/io/OutputStream.java#L124

This is clearly not a AtlasDB bug. But there are some changes we could make to the stream store to make it easier to diagnose these issues in the future:
- Explicitly check if the block is not found and throw an exception with a message indicating that this is user error and why.
- Re-throw caught exceptions with a descriptive error message instead of just logging. This ensures these errors are discoverable when the exception is ultimately consumed. Logging _and_ re-throwing exceptions is an anti-pattern, we should do one or the other.
