### PR TITLE
Async initialization for TransactionKeyValueServiceManager.

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -42,6 +42,11 @@ acceptedBreaks:
         \ com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig, com.palantir.refreshable.Refreshable<com.palantir.atlasdb.spi.TransactionKeyValueServiceRuntimeConfig>,\
         \ boolean)"
       justification: "Adding observability to TransactionKeyValueServiceManager"
+  "0.1047.0":
+    com.palantir.atlasdb:atlasdb-api:
+    - code: "java.method.addedToInterface"
+      new: "method boolean com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager::isInitialized()"
+      justification: "Adding async init to TransactionKeyValueServiceManager"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueServiceManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueServiceManager.java
@@ -29,6 +29,8 @@ public interface TransactionKeyValueServiceManager extends AutoCloseable {
 
     DdlManager getDdlManager();
 
+    boolean isInitialized();
+
     @Override
     void close();
 }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DelegatingTransactionKeyValueServiceManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DelegatingTransactionKeyValueServiceManager.java
@@ -51,6 +51,13 @@ public final class DelegatingTransactionKeyValueServiceManager implements Transa
     }
 
     @Override
+    public boolean isInitialized() {
+        // TODO(jakubk): This is already covered by code in TransactionManagers,
+        // but again it does not hurt to be explicit for now.
+        return delegate.get().isInitialized();
+    }
+
+    @Override
     public void close() {
         // TODO(jakubk): I don't think this is entirely correct, because we shouldn't own the KeyValueService,
         // especially if it's being reused in some way. However, the cleanup codepaths in SnapshotTransactionManager

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -555,7 +555,7 @@ public abstract class TransactionManagers {
                         sweepStrategyManager,
                         cleaner,
                         () -> areTransactionManagerInitializationPrerequisitesSatisfied(
-                                initializer, lockAndTimestampServices),
+                                initializer, internalKeyValueService, lockAndTimestampServices),
                         allowHiddenTableAccess(),
                         derivedSnapshotConfig.concurrentGetRangesThreadPoolSize(),
                         derivedSnapshotConfig.defaultGetRangesConcurrency(),
@@ -875,8 +875,12 @@ public abstract class TransactionManagers {
     }
 
     private static boolean areTransactionManagerInitializationPrerequisitesSatisfied(
-            AsyncInitializer initializer, LockAndTimestampServices lockAndTimestampServices) {
-        return initializer.isInitialized() && timeLockMigrationCompleteIfNeeded(lockAndTimestampServices);
+            AsyncInitializer initializer,
+            KeyValueService internalKeyValueService,
+            LockAndTimestampServices lockAndTimestampServices) {
+        return initializer.isInitialized()
+                && internalKeyValueService.isInitialized()
+                && timeLockMigrationCompleteIfNeeded(lockAndTimestampServices);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## General
**Before this PR**:
Async initialization for TransactionManager still checks KeyValueService.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Async initialization for TransactionKeyValueServiceManager.
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
* Because of the delegation we have, for cases without internal migration service, everything should still work the same.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
