### PR TITLE
Wire internal KVS to TargetedSweeper.

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKvsSerializableTransactionTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractCassandraKvsSerializableTransactionTest extends Ab
 
     @Override
     protected MultiTableSweepQueueWriter getSweepQueueWriterUninitialized() {
-        return TargetedSweeper.createUninitializedForTest(() -> 128);
+        return TargetedSweeper.createUninitializedForTest(keyValueService, () -> 128);
     }
 
     @Override

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
@@ -359,7 +359,7 @@ public class KeyValueServiceMigratorsTest {
         when(mockServices.getManagedTimestampService()).thenReturn(timestampService);
         when(mockServices.getTransactionService()).thenReturn(transactionService);
         when(mockServices.getKeyValueService()).thenReturn(kvs);
-        TargetedSweeper sweeper = TargetedSweeper.createUninitializedForTest(() -> 1);
+        TargetedSweeper sweeper = TargetedSweeper.createUninitializedForTest(kvs, () -> 1);
         SerializableTransactionManager txManager = SerializableTransactionManager.createForTest(
                 metricsManager,
                 new DelegatingTransactionKeyValueServiceManager(kvs),

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1042,7 +1042,8 @@ public abstract class TransactionManagers {
                 runtime,
                 install,
                 ImmutableList.of(follower),
-                abandonedTxnStore::addAbandonedTimestamps);
+                abandonedTxnStore::addAbandonedTimestamps,
+                kvs);
     }
 
     @Value.Immutable

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -97,7 +97,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
         TaggedMetricRegistry taggedMetrics = SharedTaggedMetricRegistries.getSingleton();
         TransactionManager txManager = tryToCreateTransactionManager(config, environment, taggedMetrics);
         Supplier<SweepTaskRunner> sweepTaskRunner = Suppliers.memoize(() -> getSweepTaskRunner(txManager));
-        TargetedSweeper sweeper = TargetedSweeper.createUninitializedForTest(() -> 1);
+        TargetedSweeper sweeper = TargetedSweeper.createUninitializedForTest(txManager.getKeyValueService(), () -> 1);
         Supplier<TargetedSweeper> sweeperSupplier = Suppliers.memoize(() -> initializeAndGet(sweeper, txManager));
         ensureTransactionSchemaVersionInstalled(config.getAtlasDbConfig(), config.getAtlasDbRuntimeConfig(), txManager);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/TargetedSweeper.java
@@ -67,6 +67,8 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
     private final AbandonedTransactionConsumer abandonedTransactionConsumer;
     private final BackgroundSweepScheduler noneScheduler;
 
+    private final KeyValueService keyValueService;
+
     private LastSweptTimestampUpdater lastSweptTimestampUpdater;
     private TargetedSweepMetrics metrics;
     private SweepQueue queue;
@@ -80,7 +82,8 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
             Supplier<TargetedSweepRuntimeConfig> runtime,
             TargetedSweepInstallConfig install,
             List<Follower> followers,
-            AbandonedTransactionConsumer abandonedTransactionConsumer) {
+            AbandonedTransactionConsumer abandonedTransactionConsumer,
+            KeyValueService keyValueService) {
         this.metricsManager = metricsManager;
         this.runtime = runtime;
         this.conservativeScheduler =
@@ -91,6 +94,7 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
         this.followers = followers;
         this.metricsConfiguration = install.metricsConfiguration();
         this.abandonedTransactionConsumer = abandonedTransactionConsumer;
+        this.keyValueService = keyValueService;
     }
 
     public boolean isInitialized() {
@@ -113,24 +117,25 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
             Supplier<TargetedSweepRuntimeConfig> runtime,
             TargetedSweepInstallConfig install,
             List<Follower> followers,
-            AbandonedTransactionConsumer abandonedTransactionConsumer) {
-        return new TargetedSweeper(metrics, runtime, install, followers, abandonedTransactionConsumer);
+            AbandonedTransactionConsumer abandonedTransactionConsumer,
+            KeyValueService kvs) {
+        return new TargetedSweeper(metrics, runtime, install, followers, abandonedTransactionConsumer, kvs);
     }
 
     public static TargetedSweeper createUninitializedForTest(
-            MetricsManager metricsManager, Supplier<TargetedSweepRuntimeConfig> runtime) {
+            KeyValueService kvs, MetricsManager metricsManager, Supplier<TargetedSweepRuntimeConfig> runtime) {
         TargetedSweepInstallConfig install = ImmutableTargetedSweepInstallConfig.builder()
                 .conservativeThreads(0)
                 .thoroughThreads(0)
                 .build();
-        return createUninitialized(metricsManager, runtime, install, ImmutableList.of(), _unused -> {});
+        return createUninitialized(metricsManager, runtime, install, ImmutableList.of(), _unused -> {}, kvs);
     }
 
-    public static TargetedSweeper createUninitializedForTest(Supplier<Integer> shards) {
+    public static TargetedSweeper createUninitializedForTest(KeyValueService kvs, Supplier<Integer> shards) {
         Supplier<TargetedSweepRuntimeConfig> runtime = () -> ImmutableTargetedSweepRuntimeConfig.builder()
                 .shards(shards.get())
                 .build();
-        return createUninitializedForTest(MetricsManagers.createForTests(), runtime);
+        return createUninitializedForTest(kvs, MetricsManagers.createForTests(), runtime);
     }
 
     @Override
@@ -143,7 +148,7 @@ public class TargetedSweeper implements MultiTableSweepQueueWriter, BackgroundSw
         initializeWithoutRunning(
                 SpecialTimestampsSupplier.create(txManager),
                 txManager.getTimelockService(),
-                txManager.getKeyValueService(),
+                keyValueService,
                 txManager.getTransactionService(),
                 new TargetedSweepFollower(followers, txManager));
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
@@ -60,7 +60,7 @@ public class AbstractTargetedSweepTest extends AbstractSweepTest {
 
         MetricsManager metricsManager = MetricsManagers.createForTests();
         sweepQueue = TargetedSweeper.createUninitializedForTest(
-                metricsManager, () -> ImmutableTargetedSweepRuntimeConfig.builder()
+                kvs, metricsManager, () -> ImmutableTargetedSweepRuntimeConfig.builder()
                         .shards(1)
                         .maximumPartitionsToBatchInSingleRead(8)
                         .build());

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -75,7 +75,7 @@ public final class SweepTestUtils {
                 () -> AtlasDbConstraintCheckingMode.NO_CONSTRAINT_CHECKING;
         ConflictDetectionManager cdm = ConflictDetectionManagers.createWithoutWarmingCache(kvs);
         Cleaner cleaner = new NoOpCleaner();
-        MultiTableSweepQueueWriter writer = TargetedSweeper.createUninitializedForTest(() -> 1);
+        MultiTableSweepQueueWriter writer = TargetedSweeper.createUninitializedForTest(kvs, () -> 1);
         TransactionKnowledgeComponents knowledge =
                 TransactionKnowledgeComponents.createForTests(kvs, metricsManager.getTaggedRegistry());
         TransactionManager txManager = SerializableTransactionManager.createForTest(

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -95,7 +95,7 @@ public class AtlasDbTestCase {
         transactionService = spy(TransactionServices.createRaw(keyValueService, timestampService, false));
         conflictDetectionManager = ConflictDetectionManagers.createWithoutWarmingCache(keyValueService);
         sweepStrategyManager = SweepStrategyManagers.createDefault(keyValueService);
-        sweepQueue = spy(TargetedSweeper.createUninitializedForTest(() -> sweepQueueShards));
+        sweepQueue = spy(TargetedSweeper.createUninitializedForTest(keyValueService, () -> sweepQueueShards));
         knowledge = TransactionKnowledgeComponents.createForTests(keyValueService, metricsManager.getTaggedRegistry());
         setUpTransactionManagers();
         sweepQueue.initialize(serializableTxManager);


### PR DESCRIPTION
## General
**Before this PR**:
TargetedSweeper still gets it's KVS through TransactionManagers#getKeyValueService.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Wire internal KVS to TargetedSweeper.
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
* This is obviously still broken, the deletes from user tables should actually be going through TransactionKeyValueService, but I want to punt this for later as it does not affect correctness immediately.
* The consequences are that when running with internal migration service, eventually sweep will be doing it's deletes to wrong KVSes for particular tables, effectively removing sweep entirely and tanking performance. We will fix that eventually.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
