### PR TITLE
[KeyValueSnapshotReader Phase I] Part 1: Extract Commit Timestamp Loading

### DIFF
--- a/atlasdb-api/build.gradle
+++ b/atlasdb-api/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation 'com.palantir.safe-logging:preconditions'
   implementation 'com.palantir.safe-logging:safe-logging'
   implementation 'io.dropwizard.metrics:metrics-core'
+  implementation 'org.eclipse.collections:eclipse-collections-api'
   implementation project(':commons-annotations')
   implementation project(':lock-api-objects')
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/CommitTimestampLoader.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/CommitTimestampLoader.java
@@ -24,8 +24,12 @@ import org.eclipse.collections.api.map.primitive.LongLongMap;
 
 public interface CommitTimestampLoader {
     /**
-     * Returns a map from start timestamp to commit timestamp. If a start timestamp wasn't committed, then it will be
-     * missing from the map. This method will block until the transactions for these start timestamps are complete.
+     * Returns a map from start timestamp to commit timestamp. If the transaction corresponding to a start timestamp
+     * has neither committed nor aborted, it will be missing from the map. If configured, this method will block until
+     * the transactions for these start timestamps are believed to no longer be running.
+     *
+     * Note that this method does not actively abort transactions - in particular, a transaction that is believed to
+     * no longer be running may still commit in the future.
      */
     ListenableFuture<LongLongMap> getCommitTimestamps(
             @Nullable TableReference tableRef, LongIterable startTimestamps, boolean shouldWaitForCommitterToComplete);

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/CommitTimestampLoader.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/CommitTimestampLoader.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.api;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import javax.annotation.Nullable;
+import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.map.primitive.LongLongMap;
+
+public interface CommitTimestampLoader {
+    /**
+     * Returns a map from start timestamp to commit timestamp. If a start timestamp wasn't committed, then it will be
+     * missing from the map. This method will block until the transactions for these start timestamps are complete.
+     */
+    ListenableFuture<LongLongMap> getCommitTimestamps(
+            @Nullable TableReference tableRef, LongIterable startTimestamps, boolean shouldWaitForCommitterToComplete);
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommitTimestampLoaderFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/CommitTimestampLoaderFactory.java
@@ -1,0 +1,69 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import com.palantir.atlasdb.cache.TimestampCache;
+import com.palantir.atlasdb.transaction.TransactionConfig;
+import com.palantir.atlasdb.transaction.api.CommitTimestampLoader;
+import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.TimelockService;
+import java.util.Optional;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+public final class CommitTimestampLoaderFactory {
+    private final TimestampCache timestampCache;
+    private final MetricsManager metricsManager;
+    private final TimelockService timelockService;
+    private final TransactionKnowledgeComponents transactionKnowledgeComponents;
+    private final TransactionService transactionService;
+    private final Supplier<TransactionConfig> transactionConfigSupplier;
+
+    public CommitTimestampLoaderFactory(
+            TimestampCache timestampCache,
+            MetricsManager metricsManager,
+            TimelockService timelockService,
+            TransactionKnowledgeComponents transactionKnowledgeComponents,
+            TransactionService transactionService,
+            Supplier<TransactionConfig> transactionConfigSupplier) {
+        this.timestampCache = timestampCache;
+        this.metricsManager = metricsManager;
+        this.timelockService = timelockService;
+        this.transactionKnowledgeComponents = transactionKnowledgeComponents;
+        this.transactionService = transactionService;
+        this.transactionConfigSupplier = transactionConfigSupplier;
+    }
+
+    public CommitTimestampLoader createCommitTimestampLoader(
+            LongSupplier snapshotTimestampSupplier,
+            long immutableTimestamp,
+            Optional<LockToken> immutableTimestampLock) {
+        return new DefaultCommitTimestampLoader(
+                timestampCache,
+                immutableTimestampLock,
+                snapshotTimestampSupplier::getAsLong,
+                transactionConfigSupplier,
+                metricsManager,
+                timelockService,
+                immutableTimestamp,
+                transactionKnowledgeComponents,
+                transactionService);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoader.java
@@ -219,7 +219,8 @@ public final class DefaultCommitTimestampLoader implements CommitTimestampLoader
     }
 
     private Timer getTimer(String name) {
-        return metricsManager.registerOrGetTimer(DefaultCommitTimestampLoader.class, name);
+        // Maintaining for backward compatibility
+        return metricsManager.registerOrGetTimer(CommitTimestampLoader.class, name);
     }
 
     private ListenableFuture<Map<Long, TransactionStatus>> loadCommitTimestamps(LongSet startTimestamps) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoader.java
@@ -129,7 +129,7 @@ public final class DefaultCommitTimestampLoader implements CommitTimestampLoader
         }
 
         return Futures.transform(
-                loadCommitTimestamps(transactionService, pendingGets),
+                loadCommitTimestamps(pendingGets),
                 rawResults -> {
                     LongLongMap loadedCommitTs = cacheKnownLoadedValuesAndValidate(rawResults);
                     result.putAll(loadedCommitTs);
@@ -226,8 +226,7 @@ public final class DefaultCommitTimestampLoader implements CommitTimestampLoader
         return metricsManager.registerOrGetTimer(DefaultCommitTimestampLoader.class, name);
     }
 
-    private static ListenableFuture<Map<Long, TransactionStatus>> loadCommitTimestamps(
-            TransactionService transactionService, LongSet startTimestamps) {
+    private ListenableFuture<Map<Long, TransactionStatus>> loadCommitTimestamps(LongSet startTimestamps) {
         // distinguish between a single timestamp and a batch, for more granular metrics
         if (startTimestamps.size() == 1) {
             long singleTs = startTimestamps.longIterator().next();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoader.java
@@ -97,10 +97,6 @@ public final class DefaultCommitTimestampLoader implements CommitTimestampLoader
         this.transactionService = transactionService;
     }
 
-    /**
-     * Returns a map from start timestamp to commit timestamp. If a start timestamp wasn't committed, then it will be
-     * missing from the map. This method will block until the transactions for these start timestamps are complete.
-     */
     @Override
     public ListenableFuture<LongLongMap> getCommitTimestamps(
             @Nullable TableReference tableRef, LongIterable startTimestamps, boolean shouldWaitForCommitterToComplete) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoader.java
@@ -26,10 +26,11 @@ import com.palantir.atlasdb.cache.TimestampCache;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.transaction.TransactionConfig;
+import com.palantir.atlasdb.transaction.api.CommitTimestampLoader;
 import com.palantir.atlasdb.transaction.api.TransactionLockAcquisitionTimeoutException;
 import com.palantir.atlasdb.transaction.knowledge.KnownAbandonedTransactions;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
-import com.palantir.atlasdb.transaction.service.AsyncTransactionService;
+import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionStatus;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.AtlasRowLockDescriptor;
@@ -59,8 +60,8 @@ import org.eclipse.collections.impl.factory.primitive.LongLongMaps;
 import org.eclipse.collections.impl.factory.primitive.LongSets;
 import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
 
-public final class CommitTimestampLoader {
-    private static final SafeLogger log = SafeLoggerFactory.get(CommitTimestampLoader.class);
+public final class DefaultCommitTimestampLoader implements CommitTimestampLoader {
+    private static final SafeLogger log = SafeLoggerFactory.get(DefaultCommitTimestampLoader.class);
     private static final SafeLogger perfLogger = SafeLoggerFactory.get("dualschema.perf");
     private final TimestampCache timestampCache;
     private final Optional<LockToken> immutableTimestampLock;
@@ -70,10 +71,11 @@ public final class CommitTimestampLoader {
     private final TimelockService timelockService;
     private final long immutableTimestamp;
     private final Supplier<Long> lastSeenCommitTsSupplier;
+    private final TransactionService transactionService;
 
     private final KnownAbandonedTransactions abortedTransactionsCache;
 
-    public CommitTimestampLoader(
+    public DefaultCommitTimestampLoader(
             TimestampCache timestampCache,
             Optional<LockToken> immutableTimestampLock,
             Supplier<Long> startTimestampSupplier,
@@ -81,7 +83,8 @@ public final class CommitTimestampLoader {
             MetricsManager metricsManager,
             TimelockService timelockService,
             long immutableTimestamp,
-            TransactionKnowledgeComponents knowledge) {
+            TransactionKnowledgeComponents knowledge,
+            TransactionService transactionService) {
         this.timestampCache = timestampCache;
         this.immutableTimestampLock = immutableTimestampLock;
         this.startTimestampSupplier = startTimestampSupplier;
@@ -91,17 +94,16 @@ public final class CommitTimestampLoader {
         this.immutableTimestamp = immutableTimestamp;
         this.lastSeenCommitTsSupplier = knowledge.lastSeenCommitSupplier();
         this.abortedTransactionsCache = knowledge.abandoned();
+        this.transactionService = transactionService;
     }
 
     /**
      * Returns a map from start timestamp to commit timestamp. If a start timestamp wasn't committed, then it will be
      * missing from the map. This method will block until the transactions for these start timestamps are complete.
      */
-    ListenableFuture<LongLongMap> getCommitTimestamps(
-            @Nullable TableReference tableRef,
-            LongIterable startTimestamps,
-            boolean shouldWaitForCommitterToComplete,
-            AsyncTransactionService asyncTransactionService) {
+    @Override
+    public ListenableFuture<LongLongMap> getCommitTimestamps(
+            @Nullable TableReference tableRef, LongIterable startTimestamps, boolean shouldWaitForCommitterToComplete) {
         if (startTimestamps.isEmpty()) {
             return Futures.immediateFuture(LongLongMaps.immutable.of());
         }
@@ -127,7 +129,7 @@ public final class CommitTimestampLoader {
         }
 
         return Futures.transform(
-                loadCommitTimestamps(asyncTransactionService, pendingGets),
+                loadCommitTimestamps(transactionService, pendingGets),
                 rawResults -> {
                     LongLongMap loadedCommitTs = cacheKnownLoadedValuesAndValidate(rawResults);
                     result.putAll(loadedCommitTs);
@@ -221,20 +223,20 @@ public final class CommitTimestampLoader {
     }
 
     private Timer getTimer(String name) {
-        return metricsManager.registerOrGetTimer(CommitTimestampLoader.class, name);
+        return metricsManager.registerOrGetTimer(DefaultCommitTimestampLoader.class, name);
     }
 
     private static ListenableFuture<Map<Long, TransactionStatus>> loadCommitTimestamps(
-            AsyncTransactionService asyncTransactionService, LongSet startTimestamps) {
+            TransactionService transactionService, LongSet startTimestamps) {
         // distinguish between a single timestamp and a batch, for more granular metrics
         if (startTimestamps.size() == 1) {
             long singleTs = startTimestamps.longIterator().next();
             return Futures.transform(
-                    asyncTransactionService.getAsyncV2(singleTs),
+                    transactionService.getAsyncV2(singleTs),
                     commitState -> ImmutableMap.of(singleTs, commitState),
                     MoreExecutors.directExecutor());
         } else {
-            return asyncTransactionService.getAsyncV2(startTimestamps.collect(Long::valueOf));
+            return transactionService.getAsyncV2(startTimestamps.collect(Long::valueOf));
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -58,6 +58,7 @@ import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.TransactionConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
+import com.palantir.atlasdb.transaction.api.CommitTimestampLoader;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
@@ -173,7 +174,8 @@ public class SerializableTransaction extends SnapshotTransaction {
             Supplier<TransactionConfig> transactionConfig,
             ConflictTracer conflictTracer,
             TableLevelMetricsController tableLevelMetricsController,
-            TransactionKnowledgeComponents knowledge) {
+            TransactionKnowledgeComponents knowledge,
+            CommitTimestampLoader commitTimestampLoader) {
         super(
                 metricsManager,
                 keyValueService,
@@ -200,7 +202,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 transactionConfig,
                 conflictTracer,
                 tableLevelMetricsController,
-                knowledge);
+                knowledge,
+                commitTimestampLoader);
     }
 
     @Override
@@ -938,7 +941,9 @@ public class SerializableTransaction extends SnapshotTransaction {
                 transactionConfig,
                 conflictTracer,
                 tableLevelMetricsController,
-                knowledge) {
+                knowledge,
+                // TODO (jkong): Remove when extracting a custom read-only commit timestamp loader
+                commitTimestampLoader) {
             @Override
             protected TransactionScopedCache getCache() {
                 return lockWatchManager.getReadOnlyTransactionScopedCache(SerializableTransaction.this.getTimestamp());
@@ -946,24 +951,18 @@ public class SerializableTransaction extends SnapshotTransaction {
 
             @Override
             protected ListenableFuture<LongLongMap> getCommitTimestamps(
-                    TableReference tableRef,
-                    LongIterable startTimestamps,
-                    boolean shouldWaitForCommitterToComplete,
-                    AsyncTransactionService asyncTransactionService) {
+                    TableReference tableRef, LongIterable startTimestamps, boolean shouldWaitForCommitterToComplete) {
                 long myStart = SerializableTransaction.this.getTimestamp();
                 PartitionedTimestamps partitionedTimestamps = splitTransactionBeforeAndAfter(myStart, startTimestamps);
 
                 ListenableFuture<LongLongMap> postStartCommitTimestamps =
                         getCommitTimestampsForTransactionsStartedAfterMe(
-                                tableRef, asyncTransactionService, partitionedTimestamps.afterStart());
+                                tableRef, defaultTransactionService, partitionedTimestamps.afterStart());
 
                 // We are ok to block here because if there is a cycle of transactions that could result in a deadlock,
                 // then at least one of them will be in the ab
                 ListenableFuture<LongLongMap> preStartCommitTimestamps = super.getCommitTimestamps(
-                        tableRef,
-                        partitionedTimestamps.beforeStart(),
-                        shouldWaitForCommitterToComplete,
-                        asyncTransactionService);
+                        tableRef, partitionedTimestamps.beforeStart(), shouldWaitForCommitterToComplete);
 
                 return Futures.whenAllComplete(postStartCommitTimestamps, preStartCommitTimestamps)
                         .call(
@@ -987,7 +986,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                         // We do not block when waiting for results that were written after our start timestamp.
                         // If we block here it may lead to deadlock if two transactions (or a cycle of any length) have
                         // all written their data and all doing checks before committing.
-                        super.getCommitTimestamps(tableRef, startTimestamps, false, asyncTransactionService),
+                        super.getCommitTimestamps(tableRef, startTimestamps, false),
                         startToCommitTimestamps -> {
                             if (startToCommitTimestamps.keySet().containsAll(startTimestamps)) {
                                 return startToCommitTimestamps;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -68,7 +68,6 @@ import com.palantir.atlasdb.transaction.api.annotations.ReviewedRestrictedApiUsa
 import com.palantir.atlasdb.transaction.api.exceptions.MoreCellsPresentThanExpectedException;
 import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
-import com.palantir.atlasdb.transaction.service.AsyncTransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.ByteArrayUtilities;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -956,8 +955,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                 PartitionedTimestamps partitionedTimestamps = splitTransactionBeforeAndAfter(myStart, startTimestamps);
 
                 ListenableFuture<LongLongMap> postStartCommitTimestamps =
-                        getCommitTimestampsForTransactionsStartedAfterMe(
-                                tableRef, defaultTransactionService, partitionedTimestamps.afterStart());
+                        getCommitTimestampsForTransactionsStartedAfterMe(tableRef, partitionedTimestamps.afterStart());
 
                 // We are ok to block here because if there is a cycle of transactions that could result in a deadlock,
                 // then at least one of them will be in the ab
@@ -977,7 +975,7 @@ public class SerializableTransaction extends SnapshotTransaction {
             }
 
             private ListenableFuture<LongLongMap> getCommitTimestampsForTransactionsStartedAfterMe(
-                    TableReference tableRef, AsyncTransactionService asyncTransactionService, LongSet startTimestamps) {
+                    TableReference tableRef, LongSet startTimestamps) {
                 if (startTimestamps.isEmpty()) {
                     return Futures.immediateFuture(LongLongMaps.immutable.empty());
                 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManager.java
@@ -593,7 +593,9 @@ public class SerializableTransactionManager extends SnapshotTransactionManager {
                 transactionConfig,
                 conflictTracer,
                 tableLevelMetricsController,
-                knowledge);
+                knowledge,
+                commitTimestampLoaderFactory.createCommitTimestampLoader(
+                        startTimestampSupplier, immutableTimestamp, Optional.of(immutableTsLock)));
     }
 
     @VisibleForTesting

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -306,7 +306,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     /**
      * @param immutableTimestamp If we find a row written before the immutableTimestamp we don't need to grab a read
-     * lock for it because we know that no writers exist.
+     *                           lock for it because we know that no writers exist.
      * @param preCommitCondition This check must pass for this transaction to commit.
      */
     /* package */ SnapshotTransaction(
@@ -1438,7 +1438,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     /**
      * This includes deleted writes as zero length byte arrays, be sure to strip them out.
-     * <p>
+     *
      * For the selectedColumns parameter, empty set means all columns. This is unfortunate, but follows the semantics of
      * {@link RangeRequest}.
      */
@@ -1941,7 +1941,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     /**
      * Returns true iff the transaction is known to have successfully committed.
-     * <p>
+     *
      * Be careful when using this method! A transaction that the client thinks has failed could actually have
      * committed as far as the key-value service is concerned.
      */
@@ -2669,7 +2669,7 @@ public class SnapshotTransaction extends AbstractTransaction
     /**
      * This will attempt to put the commitTimestamp into the DB.
      *
-     * @throws TransactionLockTimeoutException If our locks timed out while trying to commit.
+     * @throws TransactionLockTimeoutException  If our locks timed out while trying to commit.
      * @throws TransactionCommitFailedException failed when committing in a way that isn't retriable
      */
     private void putCommitTimestamp(long commitTimestamp, LockToken locksToken, TransactionService transactionService)

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -308,6 +308,7 @@ import java.util.stream.Collectors;
             LongSupplier startTimestampSupplier,
             LockToken immutableTsLock,
             PreCommitCondition condition) {
+        Optional<LockToken> immutableTimestampLock = Optional.of(immutableTsLock);
         return new SnapshotTransaction(
                 metricsManager,
                 transactionKeyValueServiceManager.getTransactionKeyValueService(startTimestampSupplier),
@@ -319,7 +320,7 @@ import java.util.stream.Collectors;
                 conflictDetectionManager,
                 sweepStrategyManager,
                 immutableTimestamp,
-                Optional.of(immutableTsLock),
+                immutableTimestampLock,
                 condition,
                 constraintModeSupplier.get(),
                 cleaner.getTransactionReadTimeoutMillis(),
@@ -336,7 +337,7 @@ import java.util.stream.Collectors;
                 tableLevelMetricsController,
                 knowledge,
                 commitTimestampLoaderFactory.createCommitTimestampLoader(
-                        startTimestampSupplier, immutableTimestamp, Optional.of(immutableTsLock)));
+                        startTimestampSupplier, immutableTimestamp, immutableTimestampLock));
     }
 
     @Override
@@ -354,6 +355,7 @@ import java.util.stream.Collectors;
         checkOpen();
         long immutableTs = getApproximateImmutableTimestamp();
         LongSupplier startTimestampSupplier = getStartTimestampSupplier();
+        Optional<LockToken> immutableTimestampLock = Optional.empty();
         SnapshotTransaction transaction = new SnapshotTransaction(
                 metricsManager,
                 transactionKeyValueServiceManager.getTransactionKeyValueService(startTimestampSupplier),
@@ -365,7 +367,7 @@ import java.util.stream.Collectors;
                 conflictDetectionManager,
                 sweepStrategyManager,
                 immutableTs,
-                Optional.empty(),
+                immutableTimestampLock,
                 condition,
                 constraintModeSupplier.get(),
                 cleaner.getTransactionReadTimeoutMillis(),
@@ -382,7 +384,7 @@ import java.util.stream.Collectors;
                 tableLevelMetricsController,
                 knowledge,
                 commitTimestampLoaderFactory.createCommitTimestampLoader(
-                        startTimestampSupplier, immutableTs, Optional.empty()));
+                        startTimestampSupplier, immutableTs, immutableTimestampLock));
         return runTaskThrowOnConflictWithCallback(
                 txn -> task.execute(txn, condition),
                 new ReadTransaction(transaction, sweepStrategyManager),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -400,7 +400,7 @@ import java.util.stream.Collectors;
     /**
      * Frees resources used by this SnapshotTransactionManager, and invokes any callbacks registered to run on close.
      * This includes the cleaner, the key value service (and attendant thread pools), and possibly the lock service.
-     * <p>
+     *
      * Concurrency: If this method races with registerClosingCallback(closingCallback), then closingCallback
      * may be called (but is not necessarily called). Callbacks registered before the invocation of close() are
      * guaranteed to be executed (because we use a synchronized list) as long as no exceptions arise. If an exception

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoaderTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoaderTest.java
@@ -32,7 +32,7 @@ import com.palantir.atlasdb.transaction.knowledge.ImmutableTransactionKnowledgeC
 import com.palantir.atlasdb.transaction.knowledge.KnownAbandonedTransactions;
 import com.palantir.atlasdb.transaction.knowledge.KnownConcludedTransactions;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
-import com.palantir.atlasdb.transaction.service.AsyncTransactionService;
+import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionStatus;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
@@ -45,13 +45,13 @@ import org.eclipse.collections.api.factory.primitive.LongLists;
 import org.eclipse.collections.api.map.primitive.LongLongMap;
 import org.junit.jupiter.api.Test;
 
-public class CommitTimestampLoaderTest {
+public class DefaultCommitTimestampLoaderTest {
     private static final TableReference TABLE_REF = TableReference.fromString("table");
     private final TimestampCache timestampCache = mock(TimestampCache.class);
     private final TransactionConfig transactionConfig = mock(TransactionConfig.class);
     private final MetricsManager metricsManager = MetricsManagers.createForTests();
     private final TimelockService timelockService = mock(TimelockService.class);
-    private final AsyncTransactionService transactionService = mock(AsyncTransactionService.class);
+    private final TransactionService transactionService = mock(TransactionService.class);
 
     private final KnownAbandonedTransactions knownAbandonedTransactions = mock(KnownAbandonedTransactions.class);
 
@@ -77,7 +77,8 @@ public class CommitTimestampLoaderTest {
         setup(startTs, commitTs);
 
         // no immutableTs lock for read-only transaction
-        CommitTimestampLoader commitTimestampLoader = getCommitTsLoader(Optional.empty(), transactionTs, commitTs - 1);
+        DefaultCommitTimestampLoader commitTimestampLoader =
+                getCommitTsLoader(Optional.empty(), transactionTs, commitTs - 1);
 
         assertCanGetCommitTs(startTs, commitTs, commitTimestampLoader);
     }
@@ -91,12 +92,12 @@ public class CommitTimestampLoaderTest {
         setup(startTs, commitStatus, true);
 
         // no immutableTs lock for read-only transaction
-        CommitTimestampLoader commitTimestampLoader =
+        DefaultCommitTimestampLoader commitTimestampLoader =
                 getCommitTsLoader(Optional.empty(), transactionTs, transactionTs + 1);
 
         assertThatExceptionOfType(ExecutionException.class)
                 .isThrownBy(() -> commitTimestampLoader
-                        .getCommitTimestamps(TABLE_REF, LongLists.immutable.of(startTs), false, transactionService)
+                        .getCommitTimestamps(TABLE_REF, LongLists.immutable.of(startTs), false)
                         .get())
                 .withRootCauseInstanceOf(SafeIllegalStateException.class)
                 .withMessageContaining("Sweep has swept some entries with a commit TS after us");
@@ -111,7 +112,7 @@ public class CommitTimestampLoaderTest {
         setup(startTs, commitTs);
 
         // no immutableTs lock for read-only transaction
-        CommitTimestampLoader commitTimestampLoader =
+        DefaultCommitTimestampLoader commitTimestampLoader =
                 getCommitTsLoader(Optional.empty(), transactionTs, transactionTs + 1);
 
         assertCanGetCommitTs(startTs, commitTs, commitTimestampLoader);
@@ -128,7 +129,7 @@ public class CommitTimestampLoaderTest {
         LockToken lock = mock(LockToken.class);
 
         // no immutableTs lock for read-only transaction
-        CommitTimestampLoader commitTimestampLoader =
+        DefaultCommitTimestampLoader commitTimestampLoader =
                 getCommitTsLoader(Optional.of(lock), transactionTs, transactionTs + 1);
 
         // the transaction will eventually throw at commit time. In this test we are only concerned with per read
@@ -147,7 +148,8 @@ public class CommitTimestampLoaderTest {
         LockToken lock = mock(LockToken.class);
 
         // no immutableTs lock for read-only transaction
-        CommitTimestampLoader commitTimestampLoader = getCommitTsLoader(Optional.of(lock), transactionTs, commitTs + 1);
+        DefaultCommitTimestampLoader commitTimestampLoader =
+                getCommitTsLoader(Optional.of(lock), transactionTs, commitTs + 1);
         assertCanGetCommitTs(startTs, commitTs, commitTimestampLoader);
     }
 
@@ -161,7 +163,7 @@ public class CommitTimestampLoaderTest {
         long startTsUnknown = 7l;
         TransactionStatus commitUnknown = TransactionStatus.unknown();
 
-        CommitTimestampLoader commitTimestampLoader =
+        DefaultCommitTimestampLoader commitTimestampLoader =
                 getCommitTsLoader(Optional.empty(), transactionTs, transactionTs - 1);
 
         setup(startTsKnown, commitTsKnown);
@@ -180,19 +182,19 @@ public class CommitTimestampLoaderTest {
         verifyNoMoreInteractions(timestampCache);
     }
 
-    private void assertCanGetCommitTs(long startTs, long commitTs, CommitTimestampLoader commitTimestampLoader)
+    private void assertCanGetCommitTs(long startTs, long commitTs, DefaultCommitTimestampLoader commitTimestampLoader)
             throws InterruptedException, ExecutionException {
         LongLongMap loadedCommitTs = commitTimestampLoader
-                .getCommitTimestamps(TABLE_REF, LongLists.immutable.of(startTs), false, transactionService)
+                .getCommitTimestamps(TABLE_REF, LongLists.immutable.of(startTs), false)
                 .get();
         assertThat(loadedCommitTs.size()).isEqualTo(1);
         assertThat(loadedCommitTs.get(startTs)).isEqualTo(commitTs);
     }
 
-    private CommitTimestampLoader getCommitTsLoader(
+    private DefaultCommitTimestampLoader getCommitTsLoader(
             Optional<LockToken> lock, long transactionTs, long lastSeenCommitTs) {
         createKnowledgeComponents(lastSeenCommitTs);
-        CommitTimestampLoader commitTimestampLoader = new CommitTimestampLoader(
+        return new DefaultCommitTimestampLoader(
                 timestampCache,
                 lock, // commitTsLoader does not care if the lock expires.
                 () -> transactionTs,
@@ -200,8 +202,8 @@ public class CommitTimestampLoaderTest {
                 metricsManager,
                 timelockService,
                 1l,
-                createKnowledgeComponents(lastSeenCommitTs));
-        return commitTimestampLoader;
+                createKnowledgeComponents(lastSeenCommitTs),
+                transactionService);
     }
 
     private TransactionKnowledgeComponents createKnowledgeComponents(long lastSeenCommitTs) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoaderTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoaderTest.java
@@ -193,7 +193,6 @@ public class DefaultCommitTimestampLoaderTest {
 
     private DefaultCommitTimestampLoader getCommitTsLoader(
             Optional<LockToken> lock, long transactionTs, long lastSeenCommitTs) {
-        createKnowledgeComponents(lastSeenCommitTs);
         return new DefaultCommitTimestampLoader(
                 timestampCache,
                 lock, // commitTsLoader does not care if the lock expires.

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -59,7 +59,6 @@ import com.palantir.atlasdb.keyvalue.impl.KvsManager;
 import com.palantir.atlasdb.keyvalue.impl.TransactionManagerManager;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.table.description.ValueType;
-import com.palantir.atlasdb.transaction.ImmutableTransactionConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.PreCommitCondition;
@@ -177,10 +176,12 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                         transactionKeyValueServiceManager.getKeyValueService().orElseThrow(),
                         MoreExecutors.newDirectExecutorService()),
                 true,
-                () -> ImmutableTransactionConfig.builder().build(),
+                transactionConfigSupplier,
                 ConflictTracer.NO_OP,
                 new SimpleTableLevelMetricsController(metricsManager),
-                knowledge) {
+                knowledge,
+                commitTimestampLoaderFactory.createCommitTimestampLoader(
+                        startTimestampSupplier, 0L, options.immutableLockToken)) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, byte[]::clone);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -213,7 +213,9 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         transactionConfig,
                         ConflictTracer.NO_OP,
                         tableLevelMetricsController,
-                        knowledge),
+                        knowledge,
+                        commitTimestampLoaderFactory.createCommitTimestampLoader(
+                                startTimestampSupplier, immutableTimestamp, Optional.of(immutableTsLock))),
                 pathTypeTracker);
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AbstractSnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AbstractSnapshotTransactionTest.java
@@ -3318,7 +3318,6 @@ public abstract class AbstractSnapshotTransactionTest extends AtlasDbTestCase {
             LockImmutableTimestampResponse res,
             LockWatchManagerInternal mockLockWatchManager,
             PathTypeTracker pathTypeTracker) {
-        long immutableTimestamp = res.getImmutableTimestamp();
         LongSupplier startTimestampSupplier = Suppliers.ofInstance(transactionTs)::get;
         TransactionKeyValueService wrappedTransactionKeyValueService = transactionKeyValueServiceWrapper.apply(
                 txnKeyValueServiceManager.getTransactionKeyValueService(startTimestampSupplier), pathTypeTracker);
@@ -3352,8 +3351,9 @@ public abstract class AbstractSnapshotTransactionTest extends AtlasDbTestCase {
                 ConflictTracer.NO_OP,
                 tableLevelMetricsController,
                 knowledge,
+                // For tests this is fine - this keeps a reference to res, which is strictly speaking inefficient.
                 createCommitTimestampLoader(
-                        transactionTs, () -> immutableTimestamp, Optional.of(res.getLock()), timelockService));
+                        transactionTs, res::getImmutableTimestamp, Optional.of(res.getLock()), timelockService));
     }
 
     private Transaction getSnapshotTransactionWith(


### PR DESCRIPTION
## General
_This PR is part of a series: see the prototype #7000 or the internal RFC for what all of the pieces together are expected to look like. I have tried to separate this feature into reasonably sized components as otherwise it'd probably have a 5k delta or so!_

**Before this PR**:
`CommitTimestampLoader` is a concrete class that lives within `SnapshotTransaction` - while it is only used by that, we want to change this.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`CommitTimestampLoader` is an interface that has been removed from the `SnapshotTransaction` creation path.
==COMMIT_MSG==

**Priority**: High P2. Nothing super urgent, though part of a high priority workstream.

**Concerns / possible downsides (what feedback would you like?)**:
- Is it ok to require the Apache `LongIterable` / `LongLongMap` on our API? I think we need this for later pieces (see #7000 for why), so not sure we get to dodge this, short of using the unperformant boxy versions.

**Is documentation needed?**: No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing specific

**What was existing testing like? What have you done to improve it?**: There are existing tests for DefaultCommitTimestampLoader, and I'm leaning on the existing Snapshot and SerializableTransaction tests to check I haven't massively broken anything

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
This is intended to be a refactor - nothing should change.

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: I don't think so? Not really a scale thing though I do flag that there are places where this increases complexity in the interim, with the eventual goal of excising it.

## Development Process
**Where should we start reviewing?**: CommitTimestampLoader

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
