### PR TITLE
[Antithesis] Randomise number of threads used in workflows

### DIFF
--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
@@ -417,8 +417,13 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
         // We add 1 to the random number to avoid creating an executor with 0 threads, and to include the maxThreadCount
         // as a possible result (given that the bound is exclusive).
         int numberOfThreads = SECURE_RANDOM.nextInt(maxThreadCount) + 1;
+        String executorName = workflowFactoryClass.getSimpleName() + suffix;
+        log.info(
+                "{} executor created with {} threads",
+                SafeArg.of("executorName", executorName),
+                SafeArg.of("numberOfThreads", numberOfThreads));
         return lifecycle
-                .executorService(workflowFactoryClass.getSimpleName() + suffix)
+                .executorService(executorName)
                 .minThreads(numberOfThreads)
                 .maxThreads(numberOfThreads)
                 .build();

--- a/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
+++ b/atlasdb-workload-server-distribution/src/main/java/com/palantir/atlasdb/workload/WorkloadServerLauncher.java
@@ -147,12 +147,14 @@ public class WorkloadServerLauncher extends Application<WorkloadServerConfigurat
                 Refreshable.only(configuration.runtime().atlas()),
                 USER_AGENT,
                 metricsManager);
-        List<WorkflowAndInvariants<Workflow>> allWorkflowsAndInvariants =
-                createAllWorkflowsAndInvariants(configuration, environment, transactionStoreFactory);
 
         new AntithesisWorkflowValidatorRunner(new DefaultWorkflowRunner(
                         MoreExecutors.listeningDecorator(antithesisWorkflowRunnerExecutorService)))
-                .run(() -> selectWorkflowsToRun(configuration, allWorkflowsAndInvariants));
+                .run(() -> selectWorkflowsToRun(
+                        configuration,
+                        // We intentionally add randomness when creating the workflows (e.g., the executor pool size)
+                        // and so we must create the workflows under the fuzzer
+                        createAllWorkflowsAndInvariants(configuration, environment, transactionStoreFactory)));
 
         log.info("Finished running desired workflows successfully");
         log.info("antithesis: terminate");

--- a/changelog/@unreleased/pr-7019.v2.yml
+++ b/changelog/@unreleased/pr-7019.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Workload server now randomly determines the max possible concurrency
+    for a given executor service, bound by the configured max. In practice, this means
+    we randomise the max concurrent reads/writes a given workflow does.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7019


### PR DESCRIPTION
## General
**Before this PR**:
We hard code the number of threads, and use this as the max possible concurrency. This prevents us from exploring state spaces with fewer concurrent reads/writes.
**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Workload server now randomly determines the max possible concurrency for a given executor service, bound by the configured max. In practice, this means we randomise the max concurrent reads/writes a given workflow does.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
Is 1 too low of a bound?
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
Nah
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
N/a
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
N/A
**Does this PR need a schema migration?**
N/A
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That 1 is an acceptable lower bound
**What was existing testing like? What have you done to improve it?**:

_**Pending** - I'll add something shortly_

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Antithesis finds more bugs, or we can see a different number of executors selected
**_TODO: Log the number of threads chosen_**


**Has the safety of all log arguments been decided correctly?**:
Yeah
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Logs not emitted
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
N/A
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
N/A
## Development Process
**Where should we start reviewing?**:
Only one file
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
