### PR TITLE
[KeyValueSnapshotReader Phase I] Part 3: TransactionKeyValueService No Longer Supports Synchronous Get

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -47,6 +47,18 @@ acceptedBreaks:
     - code: "java.method.addedToInterface"
       new: "method boolean com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager::isInitialized()"
       justification: "Adding async init to TransactionKeyValueServiceManager"
+  "0.1050.0":
+    com.palantir.atlasdb:atlasdb-api:
+    - code: "java.method.removed"
+      old: "method java.util.Map<com.palantir.atlasdb.keyvalue.api.Cell, com.palantir.atlasdb.keyvalue.api.Value>\
+        \ com.palantir.atlasdb.cell.api.AutoDelegate_TransactionKeyValueService::get(com.palantir.atlasdb.keyvalue.api.TableReference,\
+        \ java.util.Map<com.palantir.atlasdb.keyvalue.api.Cell, java.lang.Long>)"
+      justification: "TransactionKeyValueService is largely internal"
+    - code: "java.method.removed"
+      old: "method java.util.Map<com.palantir.atlasdb.keyvalue.api.Cell, com.palantir.atlasdb.keyvalue.api.Value>\
+        \ com.palantir.atlasdb.cell.api.TransactionKeyValueService::get(com.palantir.atlasdb.keyvalue.api.TableReference,\
+        \ java.util.Map<com.palantir.atlasdb.keyvalue.api.Cell, java.lang.Long>)"
+      justification: "TransactionKeyValueService is largely internal"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueService.java
@@ -35,7 +35,7 @@ import java.util.Map;
 
 /**
  * Key-Value API to be used with user data tables.
- *
+ * <p>
  * Close cousin of {@link com.palantir.atlasdb.keyvalue.api.KeyValueService}
  * but severely restricts the API available to transactions.
  */
@@ -62,8 +62,6 @@ public interface TransactionKeyValueService {
 
     @MustBeClosed
     ClosableIterator<RowResult<Value>> getRange(TableReference tableRef, RangeRequest rangeRequest, long timestamp);
-
-    Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell);
 
     ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell);
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/TransactionKeyValueService.java
@@ -35,9 +35,9 @@ import java.util.Map;
 
 /**
  * Key-Value API to be used with user data tables.
- * <p>
- * Close cousin of {@link com.palantir.atlasdb.keyvalue.api.KeyValueService}
- * but severely restricts the API available to transactions.
+ *
+ * Close cousin of {@link com.palantir.atlasdb.keyvalue.api.KeyValueService} but severely restricts the API available
+ * to transactions.
  */
 @AutoDelegate
 public interface TransactionKeyValueService {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DelegatingTransactionKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DelegatingTransactionKeyValueService.java
@@ -81,11 +81,6 @@ public final class DelegatingTransactionKeyValueService implements TransactionKe
     }
 
     @Override
-    public Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell) {
-        return delegate.get(tableRef, timestampByCell);
-    }
-
-    @Override
     public ListenableFuture<Map<Cell, Value>> getAsync(TableReference tableRef, Map<Cell, Long> timestampByCell) {
         return delegate.getAsync(tableRef, timestampByCell);
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/KeyValueServices.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/KeyValueServices.java
@@ -22,10 +22,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.UnsignedBytes;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.palantir.atlasdb.cell.api.AutoDelegate_TransactionKeyValueService;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -211,27 +207,5 @@ public final class KeyValueServices {
         // Return results in the same order as the provided rows.
         Iterable<RowColumnRangeIterator> orderedRanges = Iterables.transform(rows, rowsColumnRanges::get);
         return new LocalRowColumnRangeIterator(Iterators.concat(orderedRanges.iterator()));
-    }
-
-    /**
-     * Constructs an {@link TransactionKeyValueService} such that methods are blocking and return immediate futures.
-     *
-     * @param transactionKeyValueService on which to call synchronous requests
-     * @return {@link TransactionKeyValueService} which delegates to synchronous methods
-     */
-    public static TransactionKeyValueService synchronousAsAsyncTransactionKeyValueService(
-            TransactionKeyValueService transactionKeyValueService) {
-        return new AutoDelegate_TransactionKeyValueService() {
-            @Override
-            public TransactionKeyValueService delegate() {
-                return transactionKeyValueService;
-            }
-
-            @Override
-            public ListenableFuture<Map<Cell, Value>> getAsync(
-                    TableReference tableRef, Map<Cell, Long> timestampByCell) {
-                return Futures.immediateFuture(transactionKeyValueService.get(tableRef, timestampByCell));
-            }
-        };
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -821,7 +821,7 @@ public class SnapshotTransaction extends AbstractTransaction
                     protected Map.Entry<Cell, Value> computeNext() {
                         if (!peekableRawResults.hasNext()
                                 || !Arrays.equals(
-                                peekableRawResults.peek().getKey().getRowName(), nextRowName)) {
+                                        peekableRawResults.peek().getKey().getRowName(), nextRowName)) {
                             return endOfData();
                         }
                         return peekableRawResults.next();
@@ -1286,7 +1286,7 @@ public class SnapshotTransaction extends AbstractTransaction
                 postFiltered.entrySet(),
                 Predicates.compose(Predicates.in(prePostFilterCells.keySet()), MapEntries.getKeyFunction()));
         Collection<Map.Entry<Cell, byte[]>> localWritesInRange = getLocalWritesForRange(
-                tableRef, rangeRequest.getStartInclusive(), endRowExclusive, rangeRequest.getColumnNames())
+                        tableRef, rangeRequest.getStartInclusive(), endRowExclusive, rangeRequest.getColumnNames())
                 .entrySet();
         return mergeInLocalWrites(
                 tableRef, postFilteredCells.iterator(), localWritesInRange.iterator(), rangeRequest.isReverse());
@@ -1323,9 +1323,9 @@ public class SnapshotTransaction extends AbstractTransaction
             int preFilterBatchSize)
             throws K {
         try (ClosableIterator<RowResult<byte[]>> postFilterIterator =
-                     postFilterIterator(tableRef, range, preFilterBatchSize, Value.GET_VALUE)) {
+                postFilterIterator(tableRef, range, preFilterBatchSize, Value.GET_VALUE)) {
             Iterator<RowResult<byte[]>> localWritesInRange = Cells.createRowView(getLocalWritesForRange(
-                    tableRef, range.getStartInclusive(), range.getEndExclusive(), range.getColumnNames())
+                            tableRef, range.getStartInclusive(), range.getEndExclusive(), range.getColumnNames())
                     .entrySet());
             Iterator<RowResult<byte[]>> mergeIterators =
                     mergeInLocalWritesRows(postFilterIterator, localWritesInRange, range.isReverse(), tableRef);
@@ -2179,7 +2179,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     private <T> T timedAndTraced(String timerName, Supplier<T> supplier) {
         try (Timer.Context timer = getTimer(timerName).time();
-             CloseableTracer tracer = CloseableTracer.startSpan(timerName)) {
+                CloseableTracer tracer = CloseableTracer.startSpan(timerName)) {
             return supplier.get();
         }
     }
@@ -2191,7 +2191,7 @@ public class SnapshotTransaction extends AbstractTransaction
     private boolean hasWrites() {
         return !localWriteBuffer.getLocalWrites().isEmpty()
                 && localWriteBuffer.getLocalWrites().values().stream()
-                .anyMatch(writesForTable -> !writesForTable.isEmpty());
+                        .anyMatch(writesForTable -> !writesForTable.isEmpty());
     }
 
     protected boolean hasReads() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -303,7 +303,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     /**
      * @param immutableTimestamp If we find a row written before the immutableTimestamp we don't need to grab a read
-     * lock for it because we know that no writers exist.
+     *                           lock for it because we know that no writers exist.
      * @param preCommitCondition This check must pass for this transaction to commit.
      */
     /* package */ SnapshotTransaction(
@@ -619,7 +619,7 @@ public class SnapshotTransaction extends AbstractTransaction
     /**
      * Provides comparator to sort cells by columns (sorted lexicographically on byte ordering) and then in the order
      * of input rows.
-     */
+     * */
     @VisibleForTesting
     static Comparator<Cell> columnOrderThenPreserveInputRowOrder(Iterable<byte[]> rows) {
         return Cell.COLUMN_COMPARATOR.thenComparing(
@@ -640,7 +640,7 @@ public class SnapshotTransaction extends AbstractTransaction
      * possibility of needing a second batch of fetching.
      * If the batch hint is large, split batch size across rows to avoid loading too much data, while accepting that
      * second fetches may be needed to get everyone their data.
-     */
+     * */
     private static int getPerRowBatchSize(BatchColumnRangeSelection columnRangeSelection, int distinctRowCount) {
         return Math.max(
                 Math.min(MIN_BATCH_SIZE_FOR_DISTRIBUTED_LOAD, columnRangeSelection.getBatchHint()),
@@ -821,7 +821,7 @@ public class SnapshotTransaction extends AbstractTransaction
                     protected Map.Entry<Cell, Value> computeNext() {
                         if (!peekableRawResults.hasNext()
                                 || !Arrays.equals(
-                                        peekableRawResults.peek().getKey().getRowName(), nextRowName)) {
+                                peekableRawResults.peek().getKey().getRowName(), nextRowName)) {
                             return endOfData();
                         }
                         return peekableRawResults.next();
@@ -1286,7 +1286,7 @@ public class SnapshotTransaction extends AbstractTransaction
                 postFiltered.entrySet(),
                 Predicates.compose(Predicates.in(prePostFilterCells.keySet()), MapEntries.getKeyFunction()));
         Collection<Map.Entry<Cell, byte[]>> localWritesInRange = getLocalWritesForRange(
-                        tableRef, rangeRequest.getStartInclusive(), endRowExclusive, rangeRequest.getColumnNames())
+                tableRef, rangeRequest.getStartInclusive(), endRowExclusive, rangeRequest.getColumnNames())
                 .entrySet();
         return mergeInLocalWrites(
                 tableRef, postFilteredCells.iterator(), localWritesInRange.iterator(), rangeRequest.isReverse());
@@ -1323,9 +1323,9 @@ public class SnapshotTransaction extends AbstractTransaction
             int preFilterBatchSize)
             throws K {
         try (ClosableIterator<RowResult<byte[]>> postFilterIterator =
-                postFilterIterator(tableRef, range, preFilterBatchSize, Value.GET_VALUE)) {
+                     postFilterIterator(tableRef, range, preFilterBatchSize, Value.GET_VALUE)) {
             Iterator<RowResult<byte[]>> localWritesInRange = Cells.createRowView(getLocalWritesForRange(
-                            tableRef, range.getStartInclusive(), range.getEndExclusive(), range.getColumnNames())
+                    tableRef, range.getStartInclusive(), range.getEndExclusive(), range.getColumnNames())
                     .entrySet());
             Iterator<RowResult<byte[]>> mergeIterators =
                     mergeInLocalWritesRows(postFilterIterator, localWritesInRange, range.isReverse(), tableRef);
@@ -1440,7 +1440,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     /**
      * This includes deleted writes as zero length byte arrays, be sure to strip them out.
-     * <p>
+     *
      * For the selectedColumns parameter, empty set means all columns. This is unfortunate, but follows the semantics of
      * {@link RangeRequest}.
      */
@@ -1943,7 +1943,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     /**
      * Returns true iff the transaction is known to have successfully committed.
-     * <p>
+     *
      * Be careful when using this method! A transaction that the client thinks has failed could actually have
      * committed as far as the key-value service is concerned.
      */
@@ -2179,7 +2179,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     private <T> T timedAndTraced(String timerName, Supplier<T> supplier) {
         try (Timer.Context timer = getTimer(timerName).time();
-                CloseableTracer tracer = CloseableTracer.startSpan(timerName)) {
+             CloseableTracer tracer = CloseableTracer.startSpan(timerName)) {
             return supplier.get();
         }
     }
@@ -2191,7 +2191,7 @@ public class SnapshotTransaction extends AbstractTransaction
     private boolean hasWrites() {
         return !localWriteBuffer.getLocalWrites().isEmpty()
                 && localWriteBuffer.getLocalWrites().values().stream()
-                        .anyMatch(writesForTable -> !writesForTable.isEmpty());
+                .anyMatch(writesForTable -> !writesForTable.isEmpty());
     }
 
     protected boolean hasReads() {
@@ -2677,7 +2677,7 @@ public class SnapshotTransaction extends AbstractTransaction
     /**
      * This will attempt to put the commitTimestamp into the DB.
      *
-     * @throws TransactionLockTimeoutException If our locks timed out while trying to commit.
+     * @throws TransactionLockTimeoutException  If our locks timed out while trying to commit.
      * @throws TransactionCommitFailedException failed when committing in a way that isn't retriable
      */
     private void putCommitTimestamp(long commitTimestamp, LockToken locksToken, TransactionService transactionService)

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingTransactionKeyValueServiceImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingTransactionKeyValueServiceImpl.java
@@ -114,13 +114,6 @@ public final class TrackingTransactionKeyValueServiceImpl
     }
 
     @Override
-    public Map<Cell, Value> get(TableReference tableRef, Map<Cell, Long> timestampByCell) {
-        Map<Cell, Value> result = delegate.get(tableRef, timestampByCell);
-        tracker.recordReadForTable(tableRef, "get", MeasuringUtils.sizeOf(result));
-        return result;
-    }
-
-    @Override
     public Map<Cell, Long> getLatestTimestamps(TableReference tableRef, Map<Cell, Long> timestampByCell) {
         Map<Cell, Long> result = delegate.getLatestTimestamps(tableRef, timestampByCell);
         tracker.recordReadForTable(tableRef, "getLatestTimestamps", MeasuringUtils.sizeOfMeasurableLongMap(result));

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingTransactionKeyValueServiceForwardingTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingTransactionKeyValueServiceForwardingTest.java
@@ -164,12 +164,6 @@ public final class TrackingTransactionKeyValueServiceForwardingTest {
     }
 
     @Test
-    public void getForwardsDelegateResult() {
-        when(delegate.get(tableReference, timestampByCellMap)).thenReturn(valueByCellMap);
-        assertThat(trackingKvs.get(tableReference, timestampByCellMap)).isSameAs(valueByCellMap);
-    }
-
-    @Test
     public void getRowsColumnRangeWrapsAndForwardsDelegateResult() {
         int cellBatchHint = 12;
         ColumnRangeSelection columnRangeSelection = mock(ColumnRangeSelection.class);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingTransactionKeyValueServiceReadInfoTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingTransactionKeyValueServiceReadInfoTest.java
@@ -166,7 +166,8 @@ public final class TrackingTransactionKeyValueServiceReadInfoTest {
         trackingKvs
                 .getRowsColumnRange(tableReference, rows, batchColumnRangeSelection, TIMESTAMP)
                 .values()
-                .forEach(iterator -> iterator.forEachRemaining(_unused -> {}));
+                .forEach(iterator -> iterator.forEachRemaining(_unused -> {
+                }));
 
         validateReadInfoForLazyRead(size);
     }
@@ -183,20 +184,10 @@ public final class TrackingTransactionKeyValueServiceReadInfoTest {
 
         trackingKvs
                 .getRowsColumnRange(tableReference, rows, columnRangeSelection, cellBatchHint, TIMESTAMP)
-                .forEachRemaining(_unused -> {});
+                .forEachRemaining(_unused -> {
+                });
 
         validateReadInfoForLazyRead(size);
-    }
-
-    @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
-    @MethodSource("sizes")
-    public void readInfoIsCorrectAfterGetCall(int size) {
-        setup(size);
-        when(tkvs.get(tableReference, timestampByCellMap)).thenReturn(valueByCellMapOfSize);
-
-        trackingKvs.get(tableReference, timestampByCellMap);
-
-        validateReadInfoForReadForTable("get", size);
     }
 
     @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)
@@ -222,7 +213,8 @@ public final class TrackingTransactionKeyValueServiceReadInfoTest {
         when(tkvs.getRange(tableReference, rangeRequest, TIMESTAMP))
                 .thenReturn(ClosableIterators.wrapWithEmptyClose(backingValueRowResultListOfSize.iterator()));
 
-        trackingKvs.getRange(tableReference, rangeRequest, TIMESTAMP).forEachRemaining(_unused -> {});
+        trackingKvs.getRange(tableReference, rangeRequest, TIMESTAMP).forEachRemaining(_unused -> {
+        });
 
         validateReadInfoForLazyRead(size);
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingTransactionKeyValueServiceReadInfoTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingTransactionKeyValueServiceReadInfoTest.java
@@ -166,8 +166,7 @@ public final class TrackingTransactionKeyValueServiceReadInfoTest {
         trackingKvs
                 .getRowsColumnRange(tableReference, rows, batchColumnRangeSelection, TIMESTAMP)
                 .values()
-                .forEach(iterator -> iterator.forEachRemaining(_unused -> {
-                }));
+                .forEach(iterator -> iterator.forEachRemaining(_unused -> {}));
 
         validateReadInfoForLazyRead(size);
     }
@@ -184,8 +183,7 @@ public final class TrackingTransactionKeyValueServiceReadInfoTest {
 
         trackingKvs
                 .getRowsColumnRange(tableReference, rows, columnRangeSelection, cellBatchHint, TIMESTAMP)
-                .forEachRemaining(_unused -> {
-                });
+                .forEachRemaining(_unused -> {});
 
         validateReadInfoForLazyRead(size);
     }
@@ -213,8 +211,7 @@ public final class TrackingTransactionKeyValueServiceReadInfoTest {
         when(tkvs.getRange(tableReference, rangeRequest, TIMESTAMP))
                 .thenReturn(ClosableIterators.wrapWithEmptyClose(backingValueRowResultListOfSize.iterator()));
 
-        trackingKvs.getRange(tableReference, rangeRequest, TIMESTAMP).forEachRemaining(_unused -> {
-        });
+        trackingKvs.getRange(tableReference, rangeRequest, TIMESTAMP).forEachRemaining(_unused -> {});
 
         validateReadInfoForLazyRead(size);
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -19,7 +19,6 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.cache.TimestampCache;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
 import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.debug.ConflictTracer;
@@ -54,7 +53,6 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
 
     private final Map<TableReference, ConflictHandler> conflictHandlerOverrides = new HashMap<>();
     private final WrapperWithTracker<CallbackAwareTransaction> transactionWrapper;
-    private final WrapperWithTracker<TransactionKeyValueService> transactionKeyValueServiceWrapper;
     private Optional<Long> unreadableTs = Optional.empty();
 
     public TestTransactionManagerImpl(
@@ -81,7 +79,6 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 sweepQueue,
                 deleteExecutor,
                 WrapperWithTracker.TRANSACTION_NO_OP,
-                WrapperWithTracker.TRANSACTION_KEY_VALUE_SERVICE_NO_OP,
                 knowledge);
     }
 
@@ -97,7 +94,6 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             MultiTableSweepQueueWriter sweepQueue,
             ExecutorService deleteExecutor,
             WrapperWithTracker<CallbackAwareTransaction> transactionWrapper,
-            WrapperWithTracker<TransactionKeyValueService> transactionKeyValueServiceWrapper,
             TransactionKnowledgeComponents knowledge) {
         this(
                 metricsManager,
@@ -111,7 +107,6 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 sweepQueue,
                 deleteExecutor,
                 transactionWrapper,
-                transactionKeyValueServiceWrapper,
                 knowledge);
     }
 
@@ -127,7 +122,6 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             MultiTableSweepQueueWriter sweepQueue,
             ExecutorService deleteExecutor,
             WrapperWithTracker<CallbackAwareTransaction> transactionWrapper,
-            WrapperWithTracker<TransactionKeyValueService> transactionKeyValueServiceWrapper,
             TransactionKnowledgeComponents knowledge) {
         super(
                 metricsManager,
@@ -154,7 +148,6 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 Optional.empty(),
                 knowledge);
         this.transactionWrapper = transactionWrapper;
-        this.transactionKeyValueServiceWrapper = transactionKeyValueServiceWrapper;
     }
 
     @Override
@@ -187,9 +180,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
         return transactionWrapper.apply(
                 new SerializableTransaction(
                         metricsManager,
-                        transactionKeyValueServiceWrapper.apply(
-                                transactionKeyValueServiceManager.getTransactionKeyValueService(startTimestampSupplier),
-                                pathTypeTracker),
+                        transactionKeyValueServiceManager.getTransactionKeyValueService(startTimestampSupplier),
                         timelockService,
                         lockWatchManager,
                         transactionService,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrapperWithTracker.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/WrapperWithTracker.java
@@ -16,13 +16,8 @@
 
 package com.palantir.atlasdb.transaction.impl;
 
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
-
 interface WrapperWithTracker<T> {
     WrapperWithTracker<CallbackAwareTransaction> TRANSACTION_NO_OP = (delegate, synchronousTracker) -> delegate;
-
-    WrapperWithTracker<TransactionKeyValueService> TRANSACTION_KEY_VALUE_SERVICE_NO_OP =
-            (delegate, synchronousTracker) -> delegate;
 
     T apply(T delegate, PathTypeTracker pathTypeTracker);
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AsyncSnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AsyncSnapshotTransactionTest.java
@@ -17,6 +17,6 @@ package com.palantir.atlasdb.transaction.impl;
 
 public class AsyncSnapshotTransactionTest extends AbstractSnapshotTransactionTest {
     public AsyncSnapshotTransactionTest() {
-        super(ASYNC, GetAsyncCallbackAwareDelegate::new, VerifyingTransactionKeyValueServiceDelegate::new);
+        super(ASYNC, GetAsyncCallbackAwareDelegate::new);
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SyncSnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SyncSnapshotTransactionTest.java
@@ -17,6 +17,6 @@ package com.palantir.atlasdb.transaction.impl;
 
 public class SyncSnapshotTransactionTest extends AbstractSnapshotTransactionTest {
     public SyncSnapshotTransactionTest() {
-        super(SYNC, WrapperWithTracker.TRANSACTION_NO_OP, WrapperWithTracker.TRANSACTION_KEY_VALUE_SERVICE_NO_OP);
+        super(SYNC, WrapperWithTracker.TRANSACTION_NO_OP);
     }
 }


### PR DESCRIPTION
## General
_This PR is part of a series: see the prototype https://github.com/palantir/atlasdb/pull/7000 or the internal RFC for what all of the pieces together are expected to look like. I have tried to separate this feature into reasonably sized components as otherwise it'd probably have a ~5k~ 10K delta or so!_

**Before this PR**: 
`TransactionKeyValueService` supports both `get()` and `getAsync()`. These have the same signature, except `get()` returns a `Map<Cell, Value>` while `getAsync()` returns a `ListenableFuture<Map<Cell, Value>>`.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`TransactionKeyValueService` only supports `getAsync()`. Users of `get()` should just call `AtlasFuture.getUnchecked(...)` or similar on the future returned from `getAsync()`.
==COMMIT_MSG==

**Priority**: High P2 - nothing in particular but the workstream is a high priority.

**Concerns / possible downsides (what feedback would you like?)**:
- Is the overhead of managing futures too much? I think not (this is Atlas client side, so not necessarily an extremely hot code path).

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: **YES** - but this interface is only used by internal migration tooling and Atlas itself

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That `getAsync()` and `get()` have the same semantics, short of how the computation is orchestrated. I think this is reasonable.

**What was existing testing like? What have you done to improve it?**: Not much: in fact removing this functionality simplifies the tests slightly.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: No `NoSuchMethodError` or similar things thrown from prod code

**Has the safety of all log arguments been decided correctly?**: N/A

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: `NoSuchMethodError` for `get` thrown

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Recall

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: I don't think so, though see the concerns section

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: Not any more than now

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: I doubt it.

## Development Process
**Where should we start reviewing?**: TransactionKeyValueService? 

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
