### PR TITLE
[Antithesis] Retry Verification Artifacts

### DIFF
--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/invariant/Invariant.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/invariant/Invariant.java
@@ -17,11 +17,9 @@
 package com.palantir.atlasdb.workload.invariant;
 
 import com.palantir.atlasdb.workload.workflow.WorkflowHistory;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
- * Check for an invariant given the provided {@link WorkflowHistory},
- * and call the provided consumer after checking if any violations are detected.
+ * Check for an invariant given the provided {@link WorkflowHistory}, and returns an object indicating any violations.
  */
-public interface Invariant<Violations> extends BiConsumer<WorkflowHistory, Consumer<Violations>> {}
+public interface Invariant<Violations> extends Function<WorkflowHistory, Violations> {}

--- a/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/invariant/InvariantReporter.java
+++ b/atlasdb-workload-server-api/src/main/java/com/palantir/atlasdb/workload/invariant/InvariantReporter.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.workload.invariant;
 
-import com.palantir.atlasdb.workload.workflow.WorkflowHistory;
 import java.util.function.Consumer;
 import org.immutables.value.Value;
 
@@ -28,8 +27,4 @@ public interface InvariantReporter<ViolationsT> {
 
     @Value.Parameter
     Consumer<ViolationsT> consumer();
-
-    default void report(WorkflowHistory history) {
-        invariant().accept(history, consumer());
-    }
 }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/DurableWritesInvariant.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/DurableWritesInvariant.java
@@ -24,17 +24,15 @@ import com.palantir.atlasdb.workload.workflow.WorkflowHistory;
 import io.vavr.Tuple;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 public enum DurableWritesInvariant implements Invariant<Map<TableAndWorkloadCell, MismatchedValue>> {
     INSTANCE;
 
     @Override
-    public void accept(
-            WorkflowHistory workflowHistory, Consumer<Map<TableAndWorkloadCell, MismatchedValue>> invariantListener) {
+    public Map<TableAndWorkloadCell, MismatchedValue> apply(WorkflowHistory workflowHistory) {
         ValidationStore expectedState = InMemoryValidationStore.create(workflowHistory.history());
         ReadableTransactionStore storeToValidate = workflowHistory.transactionStore();
-        Map<TableAndWorkloadCell, MismatchedValue> cellsThatDoNotMatch = expectedState
+        return expectedState
                 .values()
                 .map((writtenCell, expectedValue) -> {
                     Optional<MismatchedValue> maybeMismatchedValue = Optional.empty();
@@ -49,6 +47,5 @@ public enum DurableWritesInvariant implements Invariant<Map<TableAndWorkloadCell
                 .filterValues(Optional::isPresent)
                 .mapValues(Optional::get)
                 .toJavaMap();
-        invariantListener.accept(cellsThatDoNotMatch);
     }
 }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SerializableInvariant.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SerializableInvariant.java
@@ -33,17 +33,15 @@ import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransac
 import com.palantir.atlasdb.workload.workflow.WorkflowHistory;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 import one.util.streamex.StreamEx;
 
 public enum SerializableInvariant implements TransactionInvariant {
     INSTANCE;
 
     @Override
-    public void accept(
-            WorkflowHistory workflowHistory, Consumer<List<InvalidWitnessedTransaction>> invalidWitnessedTransactions) {
+    public List<InvalidWitnessedTransaction> apply(WorkflowHistory workflowHistory) {
         SerializableInvariantVisitor visitor = new SerializableInvariantVisitor();
-        List<InvalidWitnessedTransaction> transactions = StreamEx.of(workflowHistory.history())
+        return StreamEx.of(workflowHistory.history())
                 .mapPartial(witnessedTransaction -> {
                     List<InvalidWitnessedTransactionAction> invalidTransactions = StreamEx.of(
                                     witnessedTransaction.actions())
@@ -57,7 +55,6 @@ public enum SerializableInvariant implements TransactionInvariant {
                     return Optional.of(InvalidWitnessedTransaction.of(witnessedTransaction, invalidTransactions));
                 })
                 .toList();
-        invalidWitnessedTransactions.accept(transactions);
     }
 
     private static final class SerializableInvariantVisitor

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SnapshotInvariant.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/invariant/SnapshotInvariant.java
@@ -26,7 +26,6 @@ import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactionA
 import com.palantir.atlasdb.workload.workflow.WorkflowHistory;
 import io.vavr.collection.Map;
 import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * This invariant checks that the snapshot isolation property is maintained.
@@ -49,8 +48,7 @@ public enum SnapshotInvariant implements TransactionInvariant {
     INSTANCE;
 
     @Override
-    public void accept(
-            WorkflowHistory workflowHistory, Consumer<List<InvalidWitnessedTransaction>> invalidWitnessedTransactions) {
+    public List<InvalidWitnessedTransaction> apply(WorkflowHistory workflowHistory) {
         ImmutableList.Builder<InvalidWitnessedTransaction> invalidTransactionsBuilder = new ImmutableList.Builder<>();
         VersionedTableView<TableAndWorkloadCell, ValueAndMaybeTimestamp> tableView = new VersionedTableView<>();
         for (WitnessedTransaction witnessedTransaction : workflowHistory.history()) {
@@ -80,6 +78,6 @@ public enum SnapshotInvariant implements TransactionInvariant {
                         InvalidWitnessedTransaction.of(witnessedTransaction, invalidTransactionActions));
             }
         }
-        invalidWitnessedTransactions.accept(invalidTransactionsBuilder.build());
+        return invalidTransactionsBuilder.build();
     }
 }

--- a/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
+++ b/atlasdb-workload-server/src/main/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflows.java
@@ -134,14 +134,14 @@ public final class TransientRowsWorkflows {
 
     private static Invariant<List<CrossCellInconsistency>> createSummaryRowInvariant(
             TransientRowsWorkflowConfiguration configuration) {
-        return (workflowHistory, notifier) -> {
+        return workflowHistory -> {
             List<CrossCellInconsistency> violations = new ArrayList<>();
             ReadableTransactionStore store = workflowHistory.transactionStore();
 
             violations.addAll(findInconsistencyInTransactionHistory(workflowHistory.history()));
             violations.addAll(findInconsistencyInFinalIndexState(configuration, store));
 
-            notifier.accept(violations);
+            return violations;
         };
     }
 

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/DurableWritesInvariantMetricReporterTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/DurableWritesInvariantMetricReporterTest.java
@@ -73,7 +73,7 @@ public final class DurableWritesInvariantMetricReporterTest {
                                 WorkloadTestHelpers.VALUE_ONE))
                         .build()))
                 .build();
-        reporter.report(workflowHistory);
+        reporter.consumer().accept(reporter.invariant().apply(workflowHistory));
         assertThat(getViolationCount(WorkloadTestHelpers.WORKFLOW, WorkloadTestHelpers.TABLE_1))
                 .isEqualTo(1);
         assertThat(getViolationCount(WorkloadTestHelpers.WORKFLOW, WorkloadTestHelpers.TABLE_2))

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/SerializableInvariantTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/invariant/SerializableInvariantTest.java
@@ -33,7 +33,6 @@ import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedSingleCellRe
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransaction;
 import com.palantir.atlasdb.workload.workflow.ImmutableWorkflowHistory;
 import com.palantir.atlasdb.workload.workflow.WorkflowHistory;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -49,7 +48,6 @@ public final class SerializableInvariantTest {
 
     @Test
     public void handlesLocalWrites() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .read(5, 10)
@@ -61,13 +59,11 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
-        assertThat(invalidTransactions).isEmpty();
+        assertThat(SerializableInvariant.INSTANCE.apply(workflowHistory)).isEmpty();
     }
 
     @Test
     public void noInvalidTransactionsWhenSerializable() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .write(5, 10, 15)
@@ -87,13 +83,11 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
-        assertThat(invalidTransactions).isEmpty();
+        assertThat(SerializableInvariant.INSTANCE.apply(workflowHistory)).isEmpty();
     }
 
     @Test
     public void catchesWriteSkew() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .write(5, 10, 15)
@@ -114,9 +108,9 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
+
         InvalidWitnessedTransactionAction invalidWitnessedTransactionAction =
-                getSingularFinalInvalidAction(invalidTransactions, transactions);
+                getSingularFinalInvalidAction(SerializableInvariant.INSTANCE.apply(workflowHistory), transactions);
 
         assertThat(invalidWitnessedTransactionAction)
                 .isInstanceOfSatisfying(
@@ -134,7 +128,6 @@ public final class SerializableInvariantTest {
 
     @Test
     public void handlesDeletes() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .write(5, 10, 15)
@@ -153,13 +146,11 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
-        assertThat(invalidTransactions).isEmpty();
+        assertThat(SerializableInvariant.INSTANCE.apply(workflowHistory)).isEmpty();
     }
 
     @Test
     public void readsEmptyRowRangeIfNoCellsInRange() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .write(5, 10, 15)
@@ -178,13 +169,11 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
-        assertThat(invalidTransactions).isEmpty();
+        assertThat(SerializableInvariant.INSTANCE.apply(workflowHistory)).isEmpty();
     }
 
     @Test
     public void readsEmptyRowRangeIfNoCellsInRow() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .write(5, 10, 15)
@@ -198,13 +187,11 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
-        assertThat(invalidTransactions).isEmpty();
+        assertThat(SerializableInvariant.INSTANCE.apply(workflowHistory)).isEmpty();
     }
 
     @Test
     public void readsRowRangeToExhaustion() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .write(5, 10, 15)
@@ -221,13 +208,11 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
-        assertThat(invalidTransactions).isEmpty();
+        assertThat(SerializableInvariant.INSTANCE.apply(workflowHistory)).isEmpty();
     }
 
     @Test
     public void incorporatesLocalWritesIntoRowColumnRangeQueries() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .write(5, 10, 15)
@@ -258,13 +243,11 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
-        assertThat(invalidTransactions).isEmpty();
+        assertThat(SerializableInvariant.INSTANCE.apply(workflowHistory)).isEmpty();
     }
 
     @Test
     public void identifiesUnexpectedMissingCellInRowColumnRangeRead() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .write(5, 10, 15)
@@ -282,9 +265,10 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
+        List<InvalidWitnessedTransaction> invalidWitnessedTransactions =
+                SerializableInvariant.INSTANCE.apply(workflowHistory);
         InvalidWitnessedTransactionAction invalidWitnessedTransactionAction =
-                getSingularFinalInvalidAction(invalidTransactions, transactions);
+                getSingularFinalInvalidAction(invalidWitnessedTransactions, transactions);
         assertThat(invalidWitnessedTransactionAction)
                 .isInstanceOfSatisfying(InvalidWitnessedRowColumnRangeReadTransactionAction.class, action -> assertThat(
                                 action.expectedColumnsAndValues())
@@ -294,7 +278,6 @@ public final class SerializableInvariantTest {
 
     @Test
     public void identifiesUnexpectedAdditionalCellInRowColumnRangeRead() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .write(5, 10, 15)
@@ -312,9 +295,10 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
+        List<InvalidWitnessedTransaction> invalidWitnessedTransactions =
+                SerializableInvariant.INSTANCE.apply(workflowHistory);
         InvalidWitnessedTransactionAction invalidWitnessedTransactionAction =
-                getSingularFinalInvalidAction(invalidTransactions, transactions);
+                getSingularFinalInvalidAction(invalidWitnessedTransactions, transactions);
         assertThat(invalidWitnessedTransactionAction)
                 .isInstanceOfSatisfying(InvalidWitnessedRowColumnRangeReadTransactionAction.class, action -> assertThat(
                                 action.expectedColumnsAndValues())
@@ -323,7 +307,6 @@ public final class SerializableInvariantTest {
 
     @Test
     public void identifiesIncorrectCellValuesInRowColumnRangeRead() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .write(5, 10, 15)
@@ -340,9 +323,10 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
+        List<InvalidWitnessedTransaction> invalidWitnessedTransactions =
+                SerializableInvariant.INSTANCE.apply(workflowHistory);
         InvalidWitnessedTransactionAction invalidWitnessedTransactionAction =
-                getSingularFinalInvalidAction(invalidTransactions, transactions);
+                getSingularFinalInvalidAction(invalidWitnessedTransactions, transactions);
         assertThat(invalidWitnessedTransactionAction)
                 .isInstanceOfSatisfying(InvalidWitnessedRowColumnRangeReadTransactionAction.class, action -> assertThat(
                                 action.expectedColumnsAndValues())
@@ -351,7 +335,6 @@ public final class SerializableInvariantTest {
 
     @Test
     public void identifiesIncorrectOrderingInRowColumnRangeRead() {
-        List<InvalidWitnessedTransaction> invalidTransactions = new ArrayList<>();
         List<WitnessedTransaction> transactions = new WitnessedTransactionsBuilder("table")
                 .startTransaction()
                 .write(5, 20, 34)
@@ -368,9 +351,10 @@ public final class SerializableInvariantTest {
                 .history(transactions)
                 .transactionStore(readableTransactionStore)
                 .build();
-        SerializableInvariant.INSTANCE.accept(workflowHistory, invalidTransactions::addAll);
+        List<InvalidWitnessedTransaction> invalidWitnessedTransactions =
+                SerializableInvariant.INSTANCE.apply(workflowHistory);
         InvalidWitnessedTransactionAction invalidWitnessedTransactionAction =
-                getSingularFinalInvalidAction(invalidTransactions, transactions);
+                getSingularFinalInvalidAction(invalidWitnessedTransactions, transactions);
         assertThat(invalidWitnessedTransactionAction)
                 .isInstanceOfSatisfying(InvalidWitnessedRowColumnRangeReadTransactionAction.class, action -> assertThat(
                                 action.expectedColumnsAndValues())

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunnerTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/runner/AntithesisWorkflowValidatorRunnerTest.java
@@ -136,7 +136,8 @@ public class AntithesisWorkflowValidatorRunnerTest {
     public void runPropagatesExceptionsThrownFromReporters() {
         when(invariantOne.apply(any())).thenReturn("wrong");
         doThrow(new RuntimeException()).when(reporterOne).accept(any());
-        assertThatThrownBy(() -> AntithesisWorkflowValidatorRunner.createForTests(workflowRunner).run(workflowAndInvariants))
+        assertThatThrownBy(() -> AntithesisWorkflowValidatorRunner.createForTests(workflowRunner)
+                        .run(workflowAndInvariants))
                 .isInstanceOf(RuntimeException.class);
     }
 
@@ -158,11 +159,11 @@ public class AntithesisWorkflowValidatorRunnerTest {
         });
 
         doAnswer(_invocation -> {
-            assertThat(slowWorkflowIsDone.get())
-                    .as("the invariant was checked, even though the slow workflow was not done yet")
-                    .isTrue();
-            return "sehr gut";
-        })
+                    assertThat(slowWorkflowIsDone.get())
+                            .as("the invariant was checked, even though the slow workflow was not done yet")
+                            .isTrue();
+                    return "sehr gut";
+                })
                 .when(invariantOne)
                 .apply(any());
         when(invariantTwo.apply(any())).thenReturn("+1");

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflowsTest.java
@@ -41,7 +41,6 @@ import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedTransactionA
 import com.palantir.atlasdb.workload.transaction.witnessed.WitnessedWriteTransactionAction;
 import com.palantir.atlasdb.workload.util.AtlasDbUtils;
 import com.palantir.common.concurrent.PTExecutors;
-import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.List;
@@ -125,18 +124,14 @@ public class TransientRowsWorkflowsTest {
 
     @Test
     public void invariantDoesNotReportViolationsUnderNormalOperation() {
-        OnceSettableAtomicReference<List<CrossCellInconsistency>> reference = new OnceSettableAtomicReference<>();
-        invariant.accept(transientRowsWorkflow.run(), reference::set);
-        assertThat(reference.get()).isEmpty();
+        assertThat(invariant.apply(transientRowsWorkflow.run())).isEmpty();
     }
 
     @Test
     public void invariantReportsViolationsFromFinalStateWhenCellsAreMissing() {
-        OnceSettableAtomicReference<List<CrossCellInconsistency>> reference = new OnceSettableAtomicReference<>();
         WorkflowHistory history = transientRowsWorkflow.run();
         transactionStore.readWrite(txn -> txn.delete(TABLE_NAME, ImmutableWorkloadCell.of(ITERATION_COUNT - 1, 1)));
-        invariant.accept(history, reference::set);
-        assertThat(reference.get())
+        assertThat(invariant.apply(history))
                 .containsExactly(CrossCellInconsistency.builder()
                         .putInconsistentValues(
                                 TableAndWorkloadCell.of(
@@ -154,13 +149,11 @@ public class TransientRowsWorkflowsTest {
 
     @Test
     public void invariantReportsViolationsFromFinalStateWhenExtraCellsArePresent() {
-        OnceSettableAtomicReference<List<CrossCellInconsistency>> reference = new OnceSettableAtomicReference<>();
         transactionStore.readWrite(txn -> txn.write(
                 TABLE_NAME,
                 ImmutableWorkloadCell.of(ITERATION_COUNT - 2, TransientRowsWorkflows.COLUMN),
                 TransientRowsWorkflows.VALUE));
         WorkflowHistory history = transientRowsWorkflow.run();
-        invariant.accept(history, reference::set);
         CrossCellInconsistency inconsistency = CrossCellInconsistency.builder()
                 .putInconsistentValues(
                         TableAndWorkloadCell.of(
@@ -173,13 +166,12 @@ public class TransientRowsWorkflowsTest {
                                 ImmutableWorkloadCell.of(TransientRowsWorkflows.SUMMARY_ROW, ITERATION_COUNT - 2)),
                         Optional.empty())
                 .build();
-        assertThat(reference.get()).containsExactly(inconsistency);
+        assertThat(invariant.apply(history)).containsExactly(inconsistency);
         assertThat(inconsistencies.get()).containsExactly(inconsistency);
     }
 
     @Test
     public void invariantReportsViolationsFromTransactionHistory() {
-        OnceSettableAtomicReference<List<CrossCellInconsistency>> reference = new OnceSettableAtomicReference<>();
         WorkflowHistory history = transientRowsWorkflow.run();
         WorkflowHistory falseHistory = ImmutableWorkflowHistory.builder()
                 .transactionStore(history.transactionStore())
@@ -193,9 +185,8 @@ public class TransientRowsWorkflowsTest {
                                 .build())
                         .collect(Collectors.toList()))
                 .build();
-        invariant.accept(falseHistory, reference::set);
 
-        assertThat(reference.get())
+        assertThat(invariant.apply(history))
                 .hasSize(ITERATION_COUNT - 1)
                 .allSatisfy(TransientRowsWorkflowsTest::inconsistencyInvolvesPairOfPrimaryAndSummaryCells);
     }
@@ -205,7 +196,7 @@ public class TransientRowsWorkflowsTest {
         WitnessedSingleCellReadTransactionAction readWitness = WitnessedSingleCellReadTransactionAction.of(
                 TABLE_NAME, ImmutableWorkloadCell.of(5, TransientRowsWorkflows.COLUMN), Optional.empty());
         WorkflowHistory history = getWorkflowHistory(ImmutableList.of(readWitness));
-        assertThatLoggableExceptionThrownBy(() -> invariant.accept(history, inconsistencies -> {}))
+        assertThatLoggableExceptionThrownBy(() -> invariant.apply(history))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Expected to find a read of the summary row")
                 .hasExactlyArgs(SafeArg.of("actions", ImmutableList.of(readWitness)));
@@ -216,7 +207,7 @@ public class TransientRowsWorkflowsTest {
         List<WitnessedTransactionAction> actions = ImmutableList.of(WitnessedSingleCellReadTransactionAction.of(
                 TABLE_NAME, ImmutableWorkloadCell.of(TransientRowsWorkflows.SUMMARY_ROW, 3), Optional.empty()));
         WorkflowHistory history = getWorkflowHistory(actions);
-        assertThatLoggableExceptionThrownBy(() -> invariant.accept(history, inconsistencies -> {}))
+        assertThatLoggableExceptionThrownBy(() -> invariant.apply(history))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Expected to find a read of a corresponding normal row")
                 .hasExactlyArgs(SafeArg.of("actions", actions));
@@ -224,44 +215,36 @@ public class TransientRowsWorkflowsTest {
 
     @Test
     public void invariantRecordsNoViolationIfCorrespondingCellsBothEmpty() {
-        OnceSettableAtomicReference<List<CrossCellInconsistency>> reference = new OnceSettableAtomicReference<>();
         List<WitnessedTransactionAction> actions =
                 getReadWitnessesForSingleTransaction(2, Optional.empty(), Optional.empty());
         WorkflowHistory history = getWorkflowHistory(actions);
-        invariant.accept(history, reference::set);
-        assertThat(reference.get()).isEmpty();
+        assertThat(invariant.apply(history)).isEmpty();
     }
 
     @Test
     public void invariantRecordsNoViolationIfCorrespondingCellsBothPresent() {
-        OnceSettableAtomicReference<List<CrossCellInconsistency>> reference = new OnceSettableAtomicReference<>();
         List<WitnessedTransactionAction> actions = getReadWitnessesForSingleTransaction(
                 2, Optional.of(TransientRowsWorkflows.VALUE), Optional.of(TransientRowsWorkflows.VALUE));
         WorkflowHistory history = getWorkflowHistory(actions);
-        invariant.accept(history, reference::set);
-        assertThat(reference.get()).isEmpty();
+        assertThat(invariant.apply(history)).isEmpty();
     }
 
     @Test
     public void invariantRecordsViolationsIfSummaryIsPresentAndPrimaryIsAbsent() {
-        OnceSettableAtomicReference<List<CrossCellInconsistency>> reference = new OnceSettableAtomicReference<>();
         List<WitnessedTransactionAction> actions =
                 getReadWitnessesForSingleTransaction(2, Optional.of(TransientRowsWorkflows.VALUE), Optional.empty());
         WorkflowHistory history = getWorkflowHistory(actions);
-        invariant.accept(history, reference::set);
-        assertThat(reference.get())
+        assertThat(invariant.apply(history))
                 .hasSize(1)
                 .allSatisfy(TransientRowsWorkflowsTest::inconsistencyInvolvesPairOfPrimaryAndSummaryCells);
     }
 
     @Test
     public void invariantRecordsViolationsIfSummaryIsAbsentAndPrimaryIsPresent() {
-        OnceSettableAtomicReference<List<CrossCellInconsistency>> reference = new OnceSettableAtomicReference<>();
         List<WitnessedTransactionAction> actions =
                 getReadWitnessesForSingleTransaction(2, Optional.empty(), Optional.of(TransientRowsWorkflows.VALUE));
         WorkflowHistory history = getWorkflowHistory(actions);
-        invariant.accept(history, reference::set);
-        assertThat(reference.get())
+        assertThat(invariant.apply(history))
                 .hasSize(1)
                 .allSatisfy(TransientRowsWorkflowsTest::inconsistencyInvolvesPairOfPrimaryAndSummaryCells);
     }
@@ -324,25 +307,6 @@ public class TransientRowsWorkflowsTest {
             }
         } else {
             return action;
-        }
-    }
-
-    private static final class OnceSettableAtomicReference<T> {
-        private final AtomicReference<T> delegate;
-
-        private OnceSettableAtomicReference() {
-            this.delegate = new AtomicReference<>();
-        }
-
-        private T get() {
-            return Preconditions.checkNotNull(delegate.get(), "Underlying atomic reference has not been set!");
-        }
-
-        private void set(T value) {
-            Preconditions.checkNotNull(value, "Expecting values set to a once-settable atomic reference to be nonnull");
-            if (!delegate.compareAndSet(null, value)) {
-                throw new SafeIllegalStateException("Value already set");
-            }
         }
     }
 }

--- a/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflowsTest.java
+++ b/atlasdb-workload-server/src/test/java/com/palantir/atlasdb/workload/workflow/TransientRowsWorkflowsTest.java
@@ -186,7 +186,7 @@ public class TransientRowsWorkflowsTest {
                         .collect(Collectors.toList()))
                 .build();
 
-        assertThat(invariant.apply(history))
+        assertThat(invariant.apply(falseHistory))
                 .hasSize(ITERATION_COUNT - 1)
                 .allSatisfy(TransientRowsWorkflowsTest::inconsistencyInvolvesPairOfPrimaryAndSummaryCells);
     }


### PR DESCRIPTION
## General
**Before this PR**: The current Antithesis retry logic will retry even if exceptions are thrown during the execution of the reporting function. @LucasIME pointed out on the previous PR that this is not ideal, because it precludes reporters that throw exceptions, and also might do unnecessary work if there's accidentally a bug in the reporter.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Antithesis retry logic now **only** retries failures in checking the invariant, not in reporting the violations produced by checking an invariant.
==COMMIT_MSG==

**Priority**: low P2

**Concerns / possible downsides (what feedback would you like?)**:
- Technically this breaks the API of `InvariantReporter`!

**Is documentation needed?**: No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: **YES** described above, though `InvariantReporter` is an internal API so I'm not too worried.

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Workload Server is not deployed in a blue-green configuration.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: N/A

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Reporters throwing isn't something we want to retry. So far these are primarily logging or writing metrics so they shouldn't throw.

**What was existing testing like? What have you done to improve it?**: Added a test for the specific case, updated existing tests to match new behaviour

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Invariants continue to work

**Has the safety of all log arguments been decided correctly?**: N/A

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: Invariants break

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
Not deployed to production.

## Development Process
**Where should we start reviewing?**: Invariant / InvariantReporter, then the AntithesisWorkflowValidatorRunnerTest.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
