### PR TITLE
improvement: Fix flakiness on CassandraClientPoolTest resilientToRollingRestarts method

### DIFF
--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -264,8 +264,13 @@ public final class CassandraClientPoolTest {
 
     @Test
     public void resilientToRollingRestarts() {
-        CassandraClientPool cassandraClientPool =
-                clientPoolWithServersInCurrentPool(ImmutableSet.of(CASS_SERVER_1, CASS_SERVER_2));
+        when(config.autoRefreshNodes()).thenReturn(false);
+        CassandraClientPool cassandraClientPool = clientPoolWithServersInConfigAndCurrentPool(
+                Set.of(
+                        InetSocketAddress.createUnresolved(HOSTNAME_1, DEFAULT_PORT),
+                        InetSocketAddress.createUnresolved(HOSTNAME_2, DEFAULT_PORT)),
+                ImmutableSet.of(CASS_SERVER_1, CASS_SERVER_2));
+
         AtomicReference<CassandraServer> downHost = new AtomicReference<>(CASS_SERVER_1);
         cassandraClientPool
                 .getCurrentPools()
@@ -641,6 +646,11 @@ public final class CassandraClientPoolTest {
 
     private CassandraClientPoolImpl clientPoolWithInitialProxies(Set<InetSocketAddress> proxies) {
         return clientPoolWith(proxies, ImmutableSet.of(), Optional.empty());
+    }
+
+    private CassandraClientPoolImpl clientPoolWithServersInConfigAndCurrentPool(
+            Set<InetSocketAddress> addresses, Set<CassandraServer> servers) {
+        return clientPoolWith(addresses, servers, Optional.empty());
     }
 
     private CassandraClientPoolImpl clientPoolWithServersInCurrentPool(Set<CassandraServer> servers) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -266,10 +266,7 @@ public final class CassandraClientPoolTest {
     public void resilientToRollingRestarts() {
         when(config.autoRefreshNodes()).thenReturn(false);
         CassandraClientPool cassandraClientPool = clientPoolWithServersInConfigAndCurrentPool(
-                Set.of(
-                        InetSocketAddress.createUnresolved(HOSTNAME_1, DEFAULT_PORT),
-                        InetSocketAddress.createUnresolved(HOSTNAME_2, DEFAULT_PORT)),
-                ImmutableSet.of(CASS_SERVER_1, CASS_SERVER_2));
+                Set.of(HOST_1, HOST_2), ImmutableSet.of(CASS_SERVER_1, CASS_SERVER_2));
 
         AtomicReference<CassandraServer> downHost = new AtomicReference<>(CASS_SERVER_1);
         cassandraClientPool

--- a/changelog/@unreleased/pr-7036.v2.yml
+++ b/changelog/@unreleased/pr-7036.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: CassandraClientPoolTest resilientToRollingRestarts() method shouldn't
+    be flaky anymore.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7036


### PR DESCRIPTION
## General
**Before this PR**:

This test was previously flaky ([example](https://app.circleci.com/pipelines/github/palantir/atlasdb/15834/workflows/162fd35c-e6ca-4056-8535-8f6cf896c876/jobs/84453/tests)), [failing to assert that the node we forced the failure on was present on the blacklist](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java#L277).

There were a few problems that caused the test to behave in such way:

1. CassandraClientPoolImpl has a [scheduled task that keeps trying to refresh its own pool](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java#L275-L309)
2. That tries to [set the pool values to the current server list from config](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java#L402)
3. But our CassandraService used in these tests is mocked. And the value from the config is only set on [setupThriftServers](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java#L759-L763), which is called from [clientPoolWith](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java#L656-L658), which is [always set to an empty set on the clientPoolWithServersInCurrentPool](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java#L646-L648) on the [method we were using for test setup](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java#L268).
4. That means that we were prone to the following race:
5. We run [runNoopWithRetryOnHost](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java#L276) and the `CASS_SERVER_1` added to the blacklist, but haven't yet checked the assertion
6. Background task refresh pool task runs, trying to update pool to a an empty list (since we haven't provided the servers addresses)
7. [absentServers here](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java#L418) is then all the servers in our currentPool, since desiredServers is an empty map. So we then call [Cassandra.removePool here](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java#L420)
8. But the problem is that when you remove a server from the cassandra pool, [it also gets removed from the blacklist](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java#L507). So now our blacklist is empty
9. We then try to run the assertion [here](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java#L277) but the blacklist is already empty, so we fail

The relevant change is this PR is only to set the hosts to be returned by `cassandra.getCurrentServerListFromConfig` to match what we're actually using in the tests, so it doesn't get reset by the background task.

nit: `when(config.autoRefreshNodes()).thenReturn(false);` was not necessarily needed, since it was already returning `false`. But adding it for clarity, since when investigating the behaviour wasn't obvious to me: [despite the default value for such config being True](https://github.com/palantir/atlasdb/blob/c40656a1424dce596e22813bf73603f4f938e353/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java#L290-L293), if you don't provide the return for a mocked a boolean method, it will return `false`.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
CassandraClientPoolTest resilientToRollingRestarts() method shouldn't be flaky anymore.
==COMMIT_MSG==


