### PR TITLE
ignore AutoService warnings locally

### DIFF
--- a/atlasdb-cassandra/build.gradle
+++ b/atlasdb-cassandra/build.gradle
@@ -141,3 +141,12 @@ recommendedProductDependencies {
         maximumVersion = '6.x.x'
     }
 }
+// AutoServiceProcessor can incorrectly throw error for local, incremental builds
+tasks.withType(JavaCompile).configureEach {
+  doFirst {
+    def isLocal = !System.getenv().containsKey("CI")
+    if (isLocal) {
+      options.compilerArgs << '-Averify=false'
+    }
+  }
+}

--- a/atlasdb-dbkvs/build.gradle
+++ b/atlasdb-dbkvs/build.gradle
@@ -51,3 +51,12 @@ dependencies {
   compileOnly 'org.immutables:value::annotations'
   compileOnly project(":atlasdb-processors")
 }
+// AutoServiceProcessor can incorrectly throw error for local, incremental builds
+tasks.withType(JavaCompile).configureEach {
+  doFirst {
+    def isLocal = !System.getenv().containsKey("CI")
+    if (isLocal) {
+      options.compilerArgs << '-Averify=false'
+    }
+  }
+}

--- a/changelog/@unreleased/pr-7063.v2.yml
+++ b/changelog/@unreleased/pr-7063.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: ignore AutoService warnings locally
+  links:
+  - https://github.com/palantir/atlasdb/pull/7063


### PR DESCRIPTION
## General
**Before this PR**:
`@SuppressWarnings("AutoService")` sometimes does not get picked up by the compiler on incremental builds, which causes local builds to fail.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
ignore AutoService warnings locally
==COMMIT_MSG==


@jeremyk-91


<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
