### PR TITLE
templatized distributed timelock config

### DIFF
--- a/atlasdb-workload-server-antithesis/var/docker-compose.yml
+++ b/atlasdb-workload-server-antithesis/var/docker-compose.yml
@@ -57,7 +57,9 @@ services:
 
   timelock1.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/timelock1.palantir.pt:8421/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
+    environment:
+      HOSTNAME: timelock1.palantir.pt:8421
+    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/$${HOSTNAME}/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"
@@ -69,7 +71,9 @@ services:
 
   timelock2.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/timelock2.palantir.pt:8421/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
+    environment:
+      HOSTNAME: timelock2.palantir.pt:8421
+    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/$${HOSTNAME}/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"
@@ -81,7 +85,9 @@ services:
 
   timelock3.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/timelock3.palantir.pt:8421/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
+    environment:
+      HOSTNAME: timelock3.palantir.pt:8421
+    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/$${HOSTNAME}/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"

--- a/atlasdb-workload-server-antithesis/var/docker-compose.yml
+++ b/atlasdb-workload-server-antithesis/var/docker-compose.yml
@@ -57,7 +57,8 @@ services:
 
   timelock1.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    command: [ bash, -c, 'cp var/conf/timelock.distributed.yml var/conf/timelock.yml  
+    command: [ bash, -c, 'HOSTNAME="timelock1.palantir.pt:8421"
+                          && sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"
@@ -69,7 +70,8 @@ services:
 
   timelock2.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    command: [ bash, -c, 'cp var/conf/timelock.distributed.yml var/conf/timelock.yml  
+    command: [ bash, -c, 'HOSTNAME="timelock2.palantir.pt:8421"
+                          && sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"
@@ -81,7 +83,8 @@ services:
 
   timelock3.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    command: [bash, -c, 'cp var/conf/timelock.distributed.yml var/conf/timelock.yml  
+    command: [ bash, -c, 'HOSTNAME="timelock3.palantir.pt:8421"
+                          && sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"

--- a/atlasdb-workload-server-antithesis/var/docker-compose.yml
+++ b/atlasdb-workload-server-antithesis/var/docker-compose.yml
@@ -57,8 +57,9 @@ services:
 
   timelock1.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    command: [ bash, -c, 'HOSTNAME="timelock1.palantir.pt:8421"
-                          && sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
+    environment:
+      - HOSTNAME="timelock1.palantir.pt:8421"
+    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"
@@ -70,8 +71,9 @@ services:
 
   timelock2.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    command: [ bash, -c, 'HOSTNAME="timelock2.palantir.pt:8421"
-                          && sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
+    environment:
+      - HOSTNAME="timelock2.palantir.pt:8421"
+    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"
@@ -83,8 +85,9 @@ services:
 
   timelock3.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    command: [ bash, -c, 'HOSTNAME="timelock3.palantir.pt:8421"
-                          && sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
+    environment:
+      - HOSTNAME="timelock3.palantir.pt:8421"
+    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"

--- a/atlasdb-workload-server-antithesis/var/docker-compose.yml
+++ b/atlasdb-workload-server-antithesis/var/docker-compose.yml
@@ -57,9 +57,7 @@ services:
 
   timelock1.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    environment:
-      - HOSTNAME="timelock1.palantir.pt:8421"
-    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
+    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/timelock1.palantir.pt:8421/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"
@@ -71,9 +69,7 @@ services:
 
   timelock2.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    environment:
-      - HOSTNAME="timelock2.palantir.pt:8421"
-    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
+    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/timelock2.palantir.pt:8421/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"
@@ -85,9 +81,7 @@ services:
 
   timelock3.palantir.pt:
     image: palantirtechnologies/timelock-server-distribution:unspecified
-    environment:
-      - HOSTNAME="timelock3.palantir.pt:8421"
-    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/$HOSTNAME/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
+    command: [ bash, -c, 'sed "s/{{HOSTNAME}}/timelock3.palantir.pt:8421/g" var/conf/timelock.distributed.yml > var/conf/timelock.yml
                           && service/bin/init.sh console' ]
     ports:
       - "8421"

--- a/timelock-server-distribution/var/conf/timelock.distributed.yml
+++ b/timelock-server-distribution/var/conf/timelock.distributed.yml
@@ -2,13 +2,12 @@ install:
   paxos:
     data-directory: "var/data/paxos"
     is-new-service: false
-  timestampBoundPersistence:
+  timestampBoundPersistence: ~ # Null value, https://yaml.org/type/null.html
 
 runtime:
   cluster-config-not-live-reloaded:
     cluster:
       uris:
-        - "localhost:8421"
         - "timelock1.palantir.pt:8421"
         - "timelock2.palantir.pt:8421"
         - "timelock3.palantir.pt:8421"
@@ -16,9 +15,9 @@ runtime:
         keyStorePath: "var/security/keyStore.jks"
         keyStorePassword: "keystore"
         trustStorePath: "var/security/trustStore.jks"
-    local-server: "localhost:8421"
+    local-server: {{HOSTNAME}}
     enableNonstandardAndPossiblyDangerousTopology: true
-  paxos:
+  paxos: ~ # Null value, https://yaml.org/type/null.html
   permitted-backup-token: "test-auth"
 
 server:


### PR DESCRIPTION
## General
**Before this PR**:
For the sake of simplicity we'd refer to localhost when setting up the distributed timelock cluster on Antithesis setup. I have a suspicion that could explain some of the problems we're seeing with our setup (like some nodes never being able to finish SSL handshakes, others reporting `Remote potential leader is claiming to be you! `, etc...)

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
We now just render the desired hostname for each of the timelock containers on the Antithesis simulation
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:
