### PR TITLE
[KeyValueSnapshotReader Phase II] Part 9: Introducing KeyValueSnapshotReader

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/snapshot/KeyValueSnapshotReader.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/snapshot/KeyValueSnapshotReader.java
@@ -32,12 +32,12 @@ import java.util.Set;
  * each cell that would be visible at the provided timestamp(s) and filtering out versions that have been aborted or
  * not committed yet. For legacy reasons, this does NOT remove empty values: these must be filtered out before returning
  * to the user.
- * <p>
+ *
  * If used in the context of a transaction, users are responsible for validating that snapshots read are still
  * guaranteed to be consistent (for example, transactions may need to validate their pre-commit conditions or check
  * that sweep has not progressed). Some methods may have partial, intermediate validation required as part of servicing
  * a read; this class will carry out this intermediate validation.
- * <p>
+ *
  * Although this interface performs user-level reads, internal writes may be performed (for example, as part of the
  * read protocol, to abort a long-running transaction).
  */

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/snapshot/KeyValueSnapshotReader.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/snapshot/KeyValueSnapshotReader.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.api.snapshot;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+
+/**
+ * Reads state of a {@link com.palantir.atlasdb.keyvalue.api.KeyValueService} in accordance with the provided
+ * AtlasDB timestamp, following the AtlasDB read protocol. This includes reading the most recent committed value for
+ * each cell that would be visible at the provided timestamp(s) and filtering out versions that have been aborted or
+ * not committed yet.
+ *
+ * If used in the context of a transaction, users are responsible for validating that snapshots read are still
+ * guaranteed to be consistent (for example, transactions may need to validate their pre-commit conditions or check
+ * that sweep has not progressed). Some methods may have partial, intermediate validation required as part of servicing
+ * a read; this class will carry out this intermediate validation.
+ *
+ * Although this interface performs user-level reads, internal writes may be performed (for example, as part of the
+ * read protocol, to abort a long-running transaction).
+ */
+public interface KeyValueSnapshotReader {
+    ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableReference, Set<Cell> cells);
+
+    // TODO (jkong): This one is kind of awful, but it's used to avoid allocations and I'm not keen to add too many.
+    NavigableMap<byte[], RowResult<byte[]>> getRows(
+            TableReference tableReference,
+            Iterable<byte[]> rows,
+            ColumnSelection columnSelection,
+            ImmutableMap.Builder<Cell, byte[]> resultCollector);
+}

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/snapshot/KeyValueSnapshotReader.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/snapshot/KeyValueSnapshotReader.java
@@ -30,20 +30,21 @@ import java.util.Set;
  * Reads state of a {@link com.palantir.atlasdb.keyvalue.api.KeyValueService} in accordance with the provided
  * AtlasDB timestamp, following the AtlasDB read protocol. This includes reading the most recent committed value for
  * each cell that would be visible at the provided timestamp(s) and filtering out versions that have been aborted or
- * not committed yet.
- *
+ * not committed yet. For legacy reasons, this does NOT remove empty values: these must be filtered out before returning
+ * to the user.
+ * <p>
  * If used in the context of a transaction, users are responsible for validating that snapshots read are still
  * guaranteed to be consistent (for example, transactions may need to validate their pre-commit conditions or check
  * that sweep has not progressed). Some methods may have partial, intermediate validation required as part of servicing
  * a read; this class will carry out this intermediate validation.
- *
+ * <p>
  * Although this interface performs user-level reads, internal writes may be performed (for example, as part of the
  * read protocol, to abort a long-running transaction).
  */
 public interface KeyValueSnapshotReader {
     ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableReference, Set<Cell> cells);
 
-    // TODO (jkong): This one is kind of awful, but it's used to avoid allocations and I'm not keen to add too many.
+    // TODO (jkong): This should be removed as it's an awful API, but needs to be done with a lot of caution.
     NavigableMap<byte[], RowResult<byte[]>> getRows(
             TableReference tableReference,
             Iterable<byte[]> rows,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1568,7 +1568,7 @@ public class SnapshotTransaction extends AbstractTransaction
                                         + " or in the very rare case, could be due to transactions which constantly "
                                         + "conflict but never commit. These values will be cleaned up eventually, but"
                                         + " if the issue persists, ensure that sweep is caught up.",
-                                SafeArg.of("table", tableReference),
+                                LoggingArgs.tableRef(tableReference),
                                 SafeArg.of("maxIterations", MAX_POST_FILTERING_ITERATIONS));
                     }
                     snapshotEventRecorder.recordCellsReturned(tableReference, resultsAccumulator.size());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -228,8 +228,8 @@ public class SnapshotTransaction extends AbstractTransaction
     private static final int BATCH_SIZE_GET_FIRST_PAGE = 1000;
     private static final long TXN_LENGTH_THRESHOLD = Duration.ofMinutes(30).toMillis();
 
-    @VisibleForTesting
-    static final int MAX_POST_FILTERING_ITERATIONS = 200;
+    // TODO (jkong): Remove once this class is no longer responsible for post-filtering
+    public static final int MAX_POST_FILTERING_ITERATIONS = 200;
 
     @VisibleForTesting
     static final int MIN_BATCH_SIZE_FOR_DISTRIBUTED_LOAD = 100;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -104,6 +104,7 @@ import com.palantir.atlasdb.transaction.api.expectations.TransactionReadInfo;
 import com.palantir.atlasdb.transaction.api.expectations.TransactionWriteMetadataInfo;
 import com.palantir.atlasdb.transaction.api.metrics.KeyValueSnapshotMetricRecorder;
 import com.palantir.atlasdb.transaction.api.precommit.PreCommitRequirementValidator;
+import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReader;
 import com.palantir.atlasdb.transaction.expectations.ExpectationsMetrics;
 import com.palantir.atlasdb.transaction.impl.ImmutableTimestampLockManager.SummarizedLockCheckResult;
 import com.palantir.atlasdb.transaction.impl.expectations.CellCountValidator;
@@ -119,6 +120,7 @@ import com.palantir.atlasdb.transaction.impl.precommit.DefaultPreCommitRequireme
 import com.palantir.atlasdb.transaction.impl.precommit.DefaultReadSnapshotValidator;
 import com.palantir.atlasdb.transaction.impl.precommit.ReadSnapshotValidator;
 import com.palantir.atlasdb.transaction.impl.precommit.ReadSnapshotValidator.ValidationState;
+import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReader;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.AsyncTransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -311,6 +313,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     private final KeyValueSnapshotMetricRecorder snapshotEventRecorder;
     private final ReadSentinelHandler readSentinelHandler;
+    private final KeyValueSnapshotReader keyValueSnapshotReader;
 
     /**
      * @param immutableTimestamp If we find a row written before the immutableTimestamp we don't need to grab a read
@@ -380,6 +383,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
         TransactionMetrics transactionMetrics = TransactionMetrics.of(metricsManager.getTaggedRegistry());
 
+        // TODO (jkong): Move to use dependency injection!
         this.snapshotEventRecorder =
                 new DefaultKeyValueSnapshotMetricRecorder(snapshotTransactionMetricFactory, transactionMetrics);
         this.transactionOutcomeMetrics =
@@ -397,6 +401,16 @@ public class SnapshotTransaction extends AbstractTransaction
                 transactionService,
                 readSentinelBehavior,
                 new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor));
+        this.keyValueSnapshotReader = new DefaultKeyValueSnapshotReader(
+                transactionKeyValueService,
+                transactionService,
+                commitTimestampLoader,
+                allowHiddenTableAccess,
+                readSentinelHandler,
+                startTimestamp,
+                readSnapshotValidator,
+                deleteExecutor,
+                snapshotEventRecorder);
     }
 
     protected TransactionScopedCache getCache() {
@@ -450,13 +464,7 @@ public class SnapshotTransaction extends AbstractTransaction
                         tableRef,
                         rows,
                         columnSelection,
-                        cells -> AtlasFutures.getUnchecked(getInternal(
-                                "getRows",
-                                tableRef,
-                                cells,
-                                cells.size(),
-                                transactionKeyValueService,
-                                immediateTransactionService)),
+                        cells -> AtlasFutures.getUnchecked(getInternal("getRows", tableRef, cells, cells.size())),
                         unCachedRows -> getRowsInternal(tableRef, unCachedRows, columnSelection));
     }
 
@@ -469,20 +477,16 @@ public class SnapshotTransaction extends AbstractTransaction
             return AbstractTransaction.EMPTY_SORTED_ROWS;
         }
         hasReads = true;
-        ImmutableSortedMap.Builder<Cell, byte[]> result = ImmutableSortedMap.naturalOrder();
-        Map<Cell, Value> rawResults =
-                new HashMap<>(transactionKeyValueService.getRows(tableRef, rows, columnSelection, getStartTimestamp()));
+        ImmutableSortedMap.Builder<Cell, byte[]> resultCollector = ImmutableSortedMap.naturalOrder();
         NavigableMap<Cell, byte[]> writes = localWriteBuffer.getLocalWrites().get(tableRef);
         if (writes != null && !writes.isEmpty()) {
             for (byte[] row : rows) {
-                extractLocalWritesForRow(result, writes, row, columnSelection);
+                extractLocalWritesForRow(resultCollector, writes, row, columnSelection);
             }
         }
 
-        // We don't need to do work postFiltering if we have a write locally.
-        rawResults.keySet().removeAll(result.buildOrThrow().keySet());
-
-        NavigableMap<byte[], RowResult<byte[]>> results = filterRowResults(tableRef, rawResults, result);
+        NavigableMap<byte[], RowResult<byte[]>> results =
+                keyValueSnapshotReader.getRows(tableRef, rows, columnSelection, resultCollector);
         long getRowsMillis = TimeUnit.NANOSECONDS.toMillis(timer.stop());
         if (perfLogger.isDebugEnabled()) {
             perfLogger.debug(
@@ -943,17 +947,7 @@ public class SnapshotTransaction extends AbstractTransaction
     @Override
     @Idempotent
     public Map<Cell, byte[]> get(TableReference tableRef, Set<Cell> cells) {
-        return getCache()
-                .get(
-                        tableRef,
-                        cells,
-                        uncached -> getInternal(
-                                "get",
-                                tableRef,
-                                uncached,
-                                uncached.size(),
-                                transactionKeyValueService,
-                                immediateTransactionService));
+        return getCache().get(tableRef, cells, uncached -> getInternal("get", tableRef, uncached, uncached.size()));
     }
 
     @Override
@@ -969,9 +963,7 @@ public class SnapshotTransaction extends AbstractTransaction
                         "getWithExpectedNumberOfCells",
                         tableRef,
                         cacheLookupResult.missedCells(),
-                        numberOfCellsExpectingValuePostCache,
-                        transactionKeyValueService,
-                        immediateTransactionService);
+                        numberOfCellsExpectingValuePostCache);
             }));
         } catch (MoreCellsPresentThanExpectedException e) {
             return Result.err(e);
@@ -982,26 +974,12 @@ public class SnapshotTransaction extends AbstractTransaction
     @Idempotent
     public ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableRef, Set<Cell> cells) {
         return scopeToTransaction(getCache()
-                .getAsync(
-                        tableRef,
-                        cells,
-                        uncached -> getInternal(
-                                "getAsync",
-                                tableRef,
-                                uncached,
-                                uncached.size(),
-                                transactionKeyValueService,
-                                defaultTransactionService)));
+                .getAsync(tableRef, cells, uncached -> getInternal("getAsync", tableRef, uncached, uncached.size())));
     }
 
     @VisibleForTesting
     ListenableFuture<Map<Cell, byte[]>> getInternal(
-            String operationName,
-            TableReference tableRef,
-            Set<Cell> cells,
-            long numberOfExpectedPresentCells,
-            TransactionKeyValueService asyncKeyValueService,
-            AsyncTransactionService asyncTransactionService) {
+            String operationName, TableReference tableRef, Set<Cell> cells, long numberOfExpectedPresentCells) {
         Timer.Context timer =
                 snapshotTransactionMetricFactory.getTimer(operationName).time();
         checkGetPreconditions(tableRef);
@@ -1027,12 +1005,10 @@ public class SnapshotTransaction extends AbstractTransaction
 
         // We don't need to read any cells that were written locally.
         long expectedNumberOfPresentCellsToFetch = numberOfExpectedPresentCells - numberOfNonDeleteLocalWrites;
+        Set<Cell> cellsToFetch = Sets.difference(cells, result.keySet());
+        ListenableFuture<Map<Cell, byte[]>> initialResults = keyValueSnapshotReader.getAsync(tableRef, cellsToFetch);
         return Futures.transform(
-                getFromKeyValueService(
-                        tableRef,
-                        Sets.difference(cells, result.keySet()),
-                        asyncKeyValueService,
-                        asyncTransactionService),
+                initialResults,
                 fromKeyValueService -> {
                     result.putAll(fromKeyValueService);
 
@@ -1066,10 +1042,7 @@ public class SnapshotTransaction extends AbstractTransaction
         }
         hasReads = true;
 
-        ListenableFuture<Map<Cell, byte[]>> result =
-                getFromKeyValueService(tableRef, cells, transactionKeyValueService, immediateTransactionService);
-
-        Map<Cell, byte[]> unfiltered = Futures.getUnchecked(result);
+        Map<Cell, byte[]> unfiltered = AtlasFutures.getUnchecked(keyValueSnapshotReader.getAsync(tableRef, cells));
         Map<Cell, byte[]> filtered = Maps.filterValues(unfiltered, Predicates.not(Value::isTombstone));
 
         TraceStatistics.incEmptyValues(unfiltered.size() - filtered.size());
@@ -1078,26 +1051,6 @@ public class SnapshotTransaction extends AbstractTransaction
         validatePreCommitRequirementsOnReadIfNecessary(tableRef, getStartTimestamp(), allPossibleCellsReadAndPresent);
 
         return filtered;
-    }
-
-    /**
-     * This will load the given keys from the underlying key value service and apply postFiltering so we have snapshot
-     * isolation.  If the value in the key value service is the empty array this will be included here and needs to be
-     * filtered out.
-     */
-    private ListenableFuture<Map<Cell, byte[]>> getFromKeyValueService(
-            TableReference tableRef,
-            Set<Cell> cells,
-            TransactionKeyValueService asyncKeyValueService,
-            AsyncTransactionService asyncTransactionService) {
-        Map<Cell, Long> toRead = Cells.constantValueMap(cells, getStartTimestamp());
-        ListenableFuture<Collection<Map.Entry<Cell, byte[]>>> postFilteredResults = Futures.transformAsync(
-                asyncKeyValueService.getAsync(tableRef, toRead),
-                rawResults -> getWithPostFilteringAsync(
-                        tableRef, rawResults, Value.GET_VALUE, asyncKeyValueService, asyncTransactionService),
-                MoreExecutors.directExecutor());
-
-        return Futures.transform(postFilteredResults, ImmutableMap::copyOf, MoreExecutors.directExecutor());
     }
 
     private static byte[] getNextStartRowName(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/snapshot/DefaultKeyValueSnapshotReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/snapshot/DefaultKeyValueSnapshotReader.java
@@ -1,0 +1,390 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl.snapshot;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Streams;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.palantir.atlasdb.AtlasDbConstants;
+import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.futures.AtlasFutures;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
+import com.palantir.atlasdb.keyvalue.api.RowResult;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.keyvalue.impl.Cells;
+import com.palantir.atlasdb.keyvalue.impl.RowResults;
+import com.palantir.atlasdb.logging.LoggingArgs;
+import com.palantir.atlasdb.tracing.TraceStatistics;
+import com.palantir.atlasdb.transaction.api.CommitTimestampLoader;
+import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
+import com.palantir.atlasdb.transaction.api.metrics.KeyValueSnapshotMetricRecorder;
+import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReader;
+import com.palantir.atlasdb.transaction.impl.DeleteExecutor;
+import com.palantir.atlasdb.transaction.impl.ReadSentinelHandler;
+import com.palantir.atlasdb.transaction.impl.SnapshotTransaction;
+import com.palantir.atlasdb.transaction.impl.TransactionConstants;
+import com.palantir.atlasdb.transaction.impl.precommit.ReadSnapshotValidator;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.common.annotation.Output;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.factory.primitive.LongSets;
+import org.eclipse.collections.api.map.primitive.LongLongMap;
+import org.eclipse.collections.api.set.primitive.ImmutableLongSet;
+import org.eclipse.collections.api.set.primitive.LongSet;
+import org.jetbrains.annotations.NotNull;
+
+public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotReader {
+    private static final SafeLogger log = SafeLoggerFactory.get(DefaultKeyValueSnapshotReader.class);
+
+    // TODO (jkong): Move canonical value of constant here, once post-filtering is removed from SnapshotTransaction
+    private static final int MAX_POST_FILTERING_ITERATIONS = SnapshotTransaction.MAX_POST_FILTERING_ITERATIONS;
+
+    private final TransactionKeyValueService transactionKeyValueService;
+    private final TransactionService transactionService;
+    private final CommitTimestampLoader commitTimestampLoader;
+    private final boolean allowHiddenTableAccess;
+    private final ReadSentinelHandler readSentinelHandler;
+    private final LongSupplier startTimestampSupplier;
+    private final ReadSnapshotValidator readSnapshotValidator;
+    private final DeleteExecutor deleteExecutor;
+    private final KeyValueSnapshotMetricRecorder metricRecorder;
+
+    public DefaultKeyValueSnapshotReader(
+            TransactionKeyValueService transactionKeyValueService,
+            TransactionService transactionService,
+            CommitTimestampLoader commitTimestampLoader,
+            boolean allowHiddenTableAccess,
+            ReadSentinelHandler readSentinelHandler,
+            LongSupplier startTimestampSupplier,
+            ReadSnapshotValidator readSnapshotValidator,
+            DeleteExecutor deleteExecutor,
+            KeyValueSnapshotMetricRecorder metricRecorder) {
+        this.transactionKeyValueService = transactionKeyValueService;
+        this.transactionService = transactionService;
+        this.commitTimestampLoader = commitTimestampLoader;
+        this.allowHiddenTableAccess = allowHiddenTableAccess;
+        this.readSentinelHandler = readSentinelHandler;
+        this.startTimestampSupplier = startTimestampSupplier;
+        this.readSnapshotValidator = readSnapshotValidator;
+        this.deleteExecutor = deleteExecutor;
+        this.metricRecorder = metricRecorder;
+    }
+
+    @Override
+    public ListenableFuture<Map<Cell, byte[]>> getAsync(TableReference tableReference, Set<Cell> cells) {
+        return getInternal(tableReference, cells);
+    }
+
+    @Override
+    public NavigableMap<byte[], RowResult<byte[]>> getRows(
+            TableReference tableReference,
+            Iterable<byte[]> rows,
+            ColumnSelection columnSelection,
+            ImmutableMap.Builder<Cell, byte[]> resultCollector) {
+        Map<Cell, Value> rawResults = new HashMap<>(transactionKeyValueService.getRows(
+                tableReference, rows, columnSelection, startTimestampSupplier.getAsLong()));
+        // We don't need to do work postFiltering if we have a write locally.
+        rawResults.keySet().removeAll(resultCollector.buildOrThrow().keySet());
+        return filterRowResults(tableReference, rawResults, resultCollector);
+    }
+
+    @NotNull
+    private ListenableFuture<Map<Cell, byte[]>> getInternal(TableReference tableReference, Set<Cell> cells) {
+        Map<Cell, Long> timestampsByCell = Cells.constantValueMap(cells, startTimestampSupplier.getAsLong());
+        ListenableFuture<Collection<Map.Entry<Cell, byte[]>>> postFilteredResults = Futures.transformAsync(
+                transactionKeyValueService.getAsync(tableReference, timestampsByCell),
+                rawResults -> getWithPostFilteringAsync(tableReference, rawResults, Value.GET_VALUE),
+                MoreExecutors.directExecutor());
+
+        return Futures.transform(postFilteredResults, ImmutableMap::copyOf, MoreExecutors.directExecutor());
+    }
+
+    private <T> ListenableFuture<Collection<Map.Entry<Cell, T>>> getWithPostFilteringAsync(
+            TableReference tableRef, Map<Cell, Value> rawResults, Function<Value, T> transformer) {
+        long bytes = 0;
+        for (Map.Entry<Cell, Value> entry : rawResults.entrySet()) {
+            bytes += entry.getValue().getContents().length + Cells.getApproxSizeOfCell(entry.getKey());
+        }
+        if (bytes > TransactionConstants.WARN_LEVEL_FOR_QUEUED_BYTES && log.isWarnEnabled()) {
+            log.warn(
+                    "A single get had quite a few bytes: {} for table {}. The number of results was {}. "
+                            + "Enable debug logging for more information.",
+                    SafeArg.of("numBytes", bytes),
+                    LoggingArgs.tableRef(tableRef),
+                    SafeArg.of("numResults", rawResults.size()));
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "The first 10 results of your request were {}.",
+                        UnsafeArg.of("results", Iterables.limit(rawResults.entrySet(), 10)),
+                        new SafeRuntimeException("This exception and stack trace are provided for debugging purposes"));
+            }
+            metricRecorder.recordManyBytesReadForTable(tableRef, bytes);
+        }
+
+        metricRecorder.recordCellsRead(tableRef, rawResults.size());
+
+        Collection<Map.Entry<Cell, T>> resultsAccumulator = new ArrayList<>();
+
+        if (AtlasDbConstants.HIDDEN_TABLES.contains(tableRef)) {
+            Preconditions.checkState(allowHiddenTableAccess, "hidden tables cannot be read in this transaction");
+            // hidden tables are used outside of the transaction protocol, and in general have invalid timestamps,
+            // so do not apply post-filtering as post-filtering would rollback (actually delete) the data incorrectly
+            // this case is hit when reading a hidden table from console
+            for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
+                resultsAccumulator.add(Maps.immutableEntry(e.getKey(), transformer.apply(e.getValue())));
+            }
+            return Futures.immediateFuture(resultsAccumulator);
+        }
+
+        return Futures.transformAsync(
+                Futures.immediateFuture(rawResults),
+                resultsToPostFilter ->
+                        getWithPostFilteringIterate(tableRef, resultsToPostFilter, resultsAccumulator, transformer),
+                MoreExecutors.directExecutor());
+    }
+
+    private <T> ListenableFuture<Collection<Map.Entry<Cell, T>>> getWithPostFilteringIterate(
+            TableReference tableReference,
+            Map<Cell, Value> resultsToPostFilter,
+            Collection<Map.Entry<Cell, T>> resultsAccumulator,
+            Function<Value, T> transformer) {
+        return Futures.transformAsync(
+                Futures.immediateFuture(resultsToPostFilter),
+                results -> {
+                    int iterations = 0;
+                    Map<Cell, Value> remainingResultsToPostFilter = results;
+                    while (!remainingResultsToPostFilter.isEmpty()) {
+                        remainingResultsToPostFilter = AtlasFutures.getUnchecked(getWithPostFilteringInternal(
+                                tableReference, remainingResultsToPostFilter, resultsAccumulator, transformer));
+                        Preconditions.checkState(
+                                ++iterations < MAX_POST_FILTERING_ITERATIONS,
+                                "Unable to filter cells to find correct result after "
+                                        + "reaching max iterations. This is likely due to aborted cells lying around,"
+                                        + " or in the very rare case, could be due to transactions which constantly "
+                                        + "conflict but never commit. These values will be cleaned up eventually, but"
+                                        + " if the issue persists, ensure that sweep is caught up.",
+                                SafeArg.of("table", tableReference),
+                                SafeArg.of("maxIterations", MAX_POST_FILTERING_ITERATIONS));
+                    }
+                    metricRecorder.recordCellsReturned(tableReference, resultsAccumulator.size());
+                    return Futures.immediateFuture(resultsAccumulator);
+                },
+                MoreExecutors.directExecutor());
+    }
+
+    private <T> ListenableFuture<Map<Cell, Value>> getWithPostFilteringInternal(
+            TableReference tableRef,
+            Map<Cell, Value> rawResults,
+            @Output Collection<Map.Entry<Cell, T>> resultsCollector,
+            Function<Value, T> transformer) {
+        Set<Cell> orphans = readSentinelHandler.findAndMarkOrphanedSweepSentinelsForDeletion(
+                tableRef, rawResults);
+        LongSet valuesStartTimestamps = getStartTimestampsForValues(rawResults.values());
+
+        return Futures.transformAsync(
+                getCommitTimestamps(tableRef, valuesStartTimestamps),
+                commitTimestamps -> collectCellsToPostFilter(
+                        tableRef, rawResults, resultsCollector, transformer, commitTimestamps, orphans),
+                MoreExecutors.directExecutor());
+    }
+
+    private <T> ListenableFuture<Map<Cell, Value>> collectCellsToPostFilter(
+            TableReference tableRef,
+            Map<Cell, Value> rawResults,
+            @Output Collection<Map.Entry<Cell, T>> resultsCollector,
+            Function<Value, T> transformer,
+            LongLongMap commitTimestamps,
+            Set<Cell> knownOrphans) {
+        Map<Cell, Long> keysToReload = Maps.newHashMapWithExpectedSize(0);
+        Map<Cell, Long> keysToDelete = Maps.newHashMapWithExpectedSize(0);
+        ImmutableSet.Builder<Cell> keysAddedBuilder = ImmutableSet.builder();
+
+        for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
+            Cell key = e.getKey();
+            Value value = e.getValue();
+
+            if (isSweepSentinel(value) && !knownOrphans.contains(key)) {
+                metricRecorder.recordFilteredSweepSentinel(tableRef);
+
+                // This means that this transaction started too long ago. When we do garbage collection,
+                // we clean up old values, and this transaction started at a timestamp before the garbage collection.
+                readSentinelHandler.handleReadSentinel();
+            } else {
+                long theirCommitTimestamp =
+                        commitTimestamps.getIfAbsent(value.getTimestamp(), TransactionConstants.FAILED_COMMIT_TS);
+                if (theirCommitTimestamp == TransactionConstants.FAILED_COMMIT_TS) {
+                    keysToReload.put(key, value.getTimestamp());
+
+                    // This is from a failed transaction so we can roll it back and then reload it.
+                    keysToDelete.put(key, value.getTimestamp());
+                    metricRecorder.recordFilteredUncommittedTransaction(tableRef);
+                } else if (theirCommitTimestamp > startTimestampSupplier.getAsLong()) {
+                    // The value's commit timestamp is after our start timestamp.
+                    // This means the value is from a transaction which committed
+                    // after our transaction began. We need to try reading at an
+                    // earlier timestamp.
+                    keysToReload.put(key, value.getTimestamp());
+                    metricRecorder.recordFilteredTransactionCommittingAfterOurStart(tableRef);
+                } else {
+                    // The value has a commit timestamp less than our start timestamp, and is visible and valid.
+                    if (value.getContents().length != 0) {
+                        resultsCollector.add(Maps.immutableEntry(key, transformer.apply(value)));
+                        keysAddedBuilder.add(key);
+                    }
+                }
+            }
+        }
+        Set<Cell> keysAddedToResults = keysAddedBuilder.build();
+
+        if (!keysToDelete.isEmpty()) {
+            // if we can't roll back the failed transactions, we should just try again
+            if (!rollbackFailedTransactions(tableRef, keysToDelete, commitTimestamps)) {
+                return Futures.immediateFuture(getRemainingResults(rawResults, keysAddedToResults));
+            }
+        }
+
+        if (!keysToReload.isEmpty()) {
+            // TODO (jkong): Consider removing when a decision on validating pre-commit requirements mid-read is made
+            return Futures.transform(
+                    transactionKeyValueService.getAsync(tableRef, keysToReload),
+                    nextRawResults -> {
+                        boolean allPossibleCellsReadAndPresent = nextRawResults.size() == keysToReload.size();
+                        readSnapshotValidator.throwIfPreCommitRequirementsNotMetOnRead(
+                                tableRef, startTimestampSupplier.getAsLong(), allPossibleCellsReadAndPresent);
+                        return getRemainingResults(nextRawResults, keysAddedToResults);
+                    },
+                    MoreExecutors.directExecutor());
+        }
+        return Futures.immediateFuture(ImmutableMap.of());
+    }
+
+    private Map<Cell, Value> getRemainingResults(Map<Cell, Value> rawResults, Set<Cell> keysAddedToResults) {
+        Map<Cell, Value> remainingResults = new HashMap<>(rawResults);
+        remainingResults.keySet().removeAll(keysAddedToResults);
+        return remainingResults;
+    }
+
+    private LongSet getStartTimestampsForValues(Iterable<Value> values) {
+        return LongSets.immutable.withAll(Streams.stream(values).mapToLong(Value::getTimestamp));
+    }
+
+    private ListenableFuture<LongLongMap> getCommitTimestamps(TableReference tableRef, LongIterable startTimestamps) {
+        return commitTimestampLoader.getCommitTimestamps(tableRef, startTimestamps);
+    }
+
+    /**
+     * This will attempt to rollback the passed transactions.  If all are rolled back correctly this method will also
+     * delete the values for the transactions that have been rolled back.
+     *
+     * @return false if we cannot roll back the failed transactions because someone beat us to it
+     */
+    private boolean rollbackFailedTransactions(
+            TableReference tableRef, Map<Cell, Long> keysToDelete, LongLongMap commitTimestamps) {
+        ImmutableLongSet timestamps = LongSets.immutable.ofAll(keysToDelete.values());
+        boolean allRolledBack = timestamps.allSatisfy(startTs -> {
+            if (commitTimestamps.containsKey(startTs)) {
+                long commitTs = commitTimestamps.get(startTs);
+                if (commitTs != TransactionConstants.FAILED_COMMIT_TS) {
+                    throw new SafeIllegalArgumentException(
+                            "Cannot rollback already committed transaction",
+                            SafeArg.of("startTs", startTs),
+                            SafeArg.of("commitTs", commitTs));
+                }
+                return true;
+            }
+            log.warn("Rolling back transaction: {}", SafeArg.of("startTs", startTs));
+            return rollbackOtherTransaction(startTs);
+        });
+
+        if (allRolledBack) {
+            deleteExecutor.scheduleForDeletion(tableRef, keysToDelete);
+        }
+        return allRolledBack;
+    }
+
+    private boolean rollbackOtherTransaction(long startTs) {
+        try {
+            transactionService.putUnlessExists(startTs, TransactionConstants.FAILED_COMMIT_TS);
+            metricRecorder.recordRolledBackOtherTransaction();
+            return true;
+        } catch (KeyAlreadyExistsException e) {
+            log.debug(
+                    "This isn't a bug but it should be very infrequent. Two transactions tried to roll back someone"
+                            + " else's request with start: {}",
+                    SafeArg.of("startTs", startTs),
+                    new TransactionFailedRetriableException(
+                            "Two transactions tried to roll back someone else's request with start: " + startTs, e));
+            return false;
+        }
+    }
+
+    private NavigableMap<byte[], RowResult<byte[]>> filterRowResults(
+            TableReference tableRef, Map<Cell, Value> rawResults, ImmutableMap.Builder<Cell, byte[]> resultCollector) {
+        ImmutableMap<Cell, byte[]> collected = resultCollector
+                .putAll(getWithPostFilteringSync(tableRef, rawResults, Value.GET_VALUE))
+                .buildOrThrow();
+        Map<Cell, byte[]> filterDeletedValues = removeEmptyColumns(collected, tableRef);
+        return RowResults.viewOfSortedMap(Cells.breakCellsUpByRow(filterDeletedValues));
+    }
+
+    private <T> Collection<Map.Entry<Cell, T>> getWithPostFilteringSync(
+            TableReference tableRef, Map<Cell, Value> rawResults, Function<Value, T> transformer) {
+        return AtlasFutures.getUnchecked(getWithPostFilteringAsync(tableRef, rawResults, transformer));
+    }
+
+    private Map<Cell, byte[]> removeEmptyColumns(Map<Cell, byte[]> unfiltered, TableReference tableReference) {
+        Map<Cell, byte[]> filtered = Maps.filterValues(unfiltered, Predicates.not(Value::isTombstone));
+
+        int emptyValues = unfiltered.size() - filtered.size();
+        metricRecorder.recordFilteredEmptyValues(tableReference, emptyValues);
+        TraceStatistics.incEmptyValues(emptyValues);
+
+        return filtered;
+    }
+
+    private static boolean isSweepSentinel(Value value) {
+        return value.getTimestamp() == Value.INVALID_VALUE_TIMESTAMP;
+    }
+
+    interface CellGetter {
+        ListenableFuture<Map<Cell, Value>> get(TableReference tableRef, Map<Cell, Long> timestampByCell);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/snapshot/DefaultKeyValueSnapshotReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/snapshot/DefaultKeyValueSnapshotReader.java
@@ -69,7 +69,6 @@ import org.eclipse.collections.api.factory.primitive.LongSets;
 import org.eclipse.collections.api.map.primitive.LongLongMap;
 import org.eclipse.collections.api.set.primitive.ImmutableLongSet;
 import org.eclipse.collections.api.set.primitive.LongSet;
-import org.jetbrains.annotations.NotNull;
 
 public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotReader {
     private static final SafeLogger log = SafeLoggerFactory.get(DefaultKeyValueSnapshotReader.class);
@@ -126,7 +125,6 @@ public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotRead
         return filterRowResults(tableReference, rawResults, resultCollector);
     }
 
-    @NotNull
     private ListenableFuture<Map<Cell, byte[]>> getInternal(TableReference tableReference, Set<Cell> cells) {
         Map<Cell, Long> timestampsByCell = Cells.constantValueMap(cells, startTimestampSupplier.getAsLong());
         ListenableFuture<Collection<Map.Entry<Cell, byte[]>>> postFilteredResults = Futures.transformAsync(
@@ -215,8 +213,7 @@ public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotRead
             Map<Cell, Value> rawResults,
             @Output Collection<Map.Entry<Cell, T>> resultsCollector,
             Function<Value, T> transformer) {
-        Set<Cell> orphans = readSentinelHandler.findAndMarkOrphanedSweepSentinelsForDeletion(
-                tableRef, rawResults);
+        Set<Cell> orphans = readSentinelHandler.findAndMarkOrphanedSweepSentinelsForDeletion(tableRef, rawResults);
         LongSet valuesStartTimestamps = getStartTimestampsForValues(rawResults.values());
 
         return Futures.transformAsync(
@@ -382,9 +379,5 @@ public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotRead
 
     private static boolean isSweepSentinel(Value value) {
         return value.getTimestamp() == Value.INVALID_VALUE_TIMESTAMP;
-    }
-
-    interface CellGetter {
-        ListenableFuture<Map<Cell, Value>> get(TableReference tableRef, Map<Cell, Long> timestampByCell);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/snapshot/DefaultKeyValueSnapshotReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/snapshot/DefaultKeyValueSnapshotReader.java
@@ -65,10 +65,10 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import org.eclipse.collections.api.LongIterable;
-import org.eclipse.collections.api.factory.primitive.LongSets;
 import org.eclipse.collections.api.map.primitive.LongLongMap;
 import org.eclipse.collections.api.set.primitive.ImmutableLongSet;
 import org.eclipse.collections.api.set.primitive.LongSet;
+import org.eclipse.collections.impl.factory.primitive.LongSets;
 
 public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotReader {
     private static final SafeLogger log = SafeLoggerFactory.get(DefaultKeyValueSnapshotReader.class);
@@ -199,7 +199,7 @@ public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotRead
                                         + " or in the very rare case, could be due to transactions which constantly "
                                         + "conflict but never commit. These values will be cleaned up eventually, but"
                                         + " if the issue persists, ensure that sweep is caught up.",
-                                SafeArg.of("table", tableReference),
+                                LoggingArgs.tableRef(tableReference),
                                 SafeArg.of("maxIterations", MAX_POST_FILTERING_ITERATIONS));
                     }
                     metricRecorder.recordCellsReturned(tableReference, resultsAccumulator.size());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AbstractSnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AbstractSnapshotTransactionTest.java
@@ -1787,9 +1787,7 @@ public abstract class AbstractSnapshotTransactionTest extends AtlasDbTestCase {
                         eq("getWithExpectedNumberOfCells"),
                         eq(TABLE_SWEPT_THOROUGH),
                         eq(Set.of(TEST_CELL, TEST_CELL_2, TEST_CELL_3)),
-                        eq(2L),
-                        any(),
-                        any());
+                        eq(2L));
     }
 
     @Test
@@ -1826,9 +1824,7 @@ public abstract class AbstractSnapshotTransactionTest extends AtlasDbTestCase {
                         eq("getWithExpectedNumberOfCells"),
                         eq(TABLE_SWEPT_THOROUGH),
                         eq(Set.of(TEST_CELL_2, TEST_CELL_3)), // Don't expect to ask for cell1 because it's cached
-                        eq(1L),
-                        any(),
-                        any());
+                        eq(1L));
     }
 
     @Test
@@ -1865,9 +1861,7 @@ public abstract class AbstractSnapshotTransactionTest extends AtlasDbTestCase {
                         eq("getWithExpectedNumberOfCells"),
                         eq(TABLE_SWEPT_THOROUGH),
                         eq(Set.of(TEST_CELL_2, TEST_CELL_3)), // Don't expect to ask for cell1 because it's cached
-                        eq(2L),
-                        any(),
-                        any());
+                        eq(2L));
     }
 
     @Test
@@ -1902,12 +1896,7 @@ public abstract class AbstractSnapshotTransactionTest extends AtlasDbTestCase {
         verify(spiedTimeLockService, never()).refreshLockLeases(any());
         verify(spiedSnapshotTransaction)
                 .getInternal(
-                        eq("getWithExpectedNumberOfCells"),
-                        eq(TABLE_SWEPT_THOROUGH),
-                        eq(ImmutableSet.of()),
-                        anyLong(),
-                        any(),
-                        any());
+                        eq("getWithExpectedNumberOfCells"), eq(TABLE_SWEPT_THOROUGH), eq(ImmutableSet.of()), anyLong());
     }
 
     @Test
@@ -1946,8 +1935,7 @@ public abstract class AbstractSnapshotTransactionTest extends AtlasDbTestCase {
 
         verify(spiedTimeLockService, never()).refreshLockLeases(any());
         verify(spiedSnapshotTransaction, never())
-                .getInternal(
-                        eq("getWithExpectedNumberOfCells"), eq(TABLE_SWEPT_THOROUGH), any(), anyLong(), any(), any());
+                .getInternal(eq("getWithExpectedNumberOfCells"), eq(TABLE_SWEPT_THOROUGH), any(), anyLong());
     }
 
     @Test
@@ -1986,9 +1974,7 @@ public abstract class AbstractSnapshotTransactionTest extends AtlasDbTestCase {
                         eq("getWithExpectedNumberOfCells"),
                         eq(TABLE_SWEPT_THOROUGH),
                         eq(Set.of(TEST_CELL, TEST_CELL_2)),
-                        eq(1L),
-                        any(),
-                        any());
+                        eq(1L));
     }
 
     @Test

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AbstractSnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AbstractSnapshotTransactionTest.java
@@ -2984,7 +2984,7 @@ public abstract class AbstractSnapshotTransactionTest extends AtlasDbTestCase {
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageStartingWith("Unable to filter cells")
                 .hasExactlyArgs(
-                        SafeArg.of("table", TABLE_NO_SWEEP),
+                        UnsafeArg.of("tableRef", TABLE_NO_SWEEP.toString()),
                         SafeArg.of("maxIterations", SnapshotTransaction.MAX_POST_FILTERING_ITERATIONS));
     }
 


### PR DESCRIPTION
## General
**Before this PR**:
`KeyValueSnapshotReader` (KVSR) does not exist.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
KVSR exists, and calls to `get` and `getRows` go through it.
==COMMIT_MSG==

**Priority**: High P2

**Concerns / possible downsides (what feedback would you like?)**:
- The `getRows` API is weird. I do want to change it, but I think that should happen separately - I'd want us to reason through the allocation path and satisfy ourselves that we won't be causing (too many) additional allocations.
- There's some duplication across KVSR and `SnapshotTransaction` because the other endpoints like getRowsColumnRange need the post-filtering logic still. This will go away at the end of Phase III, but until then this duplication exists. It is navigable through code search and this code is not frequently changed, and I'm not sure we can split this out more easily.

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: I don't think so

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That the SnapshotTransaction tests provide good enough coverage.

**What was existing testing like? What have you done to improve it?**: SnapshotTransaction is well tested.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: User calls still work

**Has the safety of all log arguments been decided correctly?**: I checked these, yes.

**Will this change significantly affect our spending on metrics or logs?**: No.

**How would I tell that this PR does not work in production? (monitors, etc.)**: User calls don't work, service status/500s alerting.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Some of the duplication won't last.

## Development Process
**Where should we start reviewing?**: KeyValueSnapshotReader

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: It was hard to remove smaller components.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju
