### PR TITLE
[PDS-510479] Table names must go through LoggingArgs

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1615,7 +1615,7 @@ public class SnapshotTransaction extends AbstractTransaction
                                         + " or in the very rare case, could be due to transactions which constantly "
                                         + "conflict but never commit. These values will be cleaned up eventually, but"
                                         + " if the issue persists, ensure that sweep is caught up.",
-                                SafeArg.of("table", tableReference),
+                                LoggingArgs.tableRef(tableReference),
                                 SafeArg.of("maxIterations", MAX_POST_FILTERING_ITERATIONS));
                     }
                     snapshotEventRecorder.recordCellsReturned(tableReference, resultsAccumulator.size());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AbstractSnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AbstractSnapshotTransactionTest.java
@@ -2998,7 +2998,7 @@ public abstract class AbstractSnapshotTransactionTest extends AtlasDbTestCase {
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageStartingWith("Unable to filter cells")
                 .hasExactlyArgs(
-                        SafeArg.of("table", TABLE_NO_SWEEP),
+                        UnsafeArg.of("tableRef", TABLE_NO_SWEEP.toString()),
                         SafeArg.of("maxIterations", SnapshotTransaction.MAX_POST_FILTERING_ITERATIONS));
     }
 

--- a/changelog/@unreleased/pr-7077.v2.yml
+++ b/changelog/@unreleased/pr-7077.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`SnapshotTransaction`''s filtering limit now respects table logging
+    safety correctly.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/7077


### PR DESCRIPTION
## General
**Before this PR**: If the filtering limit in SnapshotTransaction is hit, we log a table as safe even when it should not be.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`SnapshotTransaction`'s filtering limit now respects table logging safety correctly.
==COMMIT_MSG==

**Priority**: P0

**Concerns / possible downsides (what feedback would you like?)**:
- Did I get this right?
- I checked for other usages of `SafeArg.of("tab`. Other uses are either benign (`tableCount`), in an unused method, or in the workload server.

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Not much

**What was existing testing like? What have you done to improve it?**: No

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Table names are now correctly filtered out if not relevant

**Has the safety of all log arguments been decided correctly?**: I think they are now.

**Will this change significantly affect our spending on metrics or logs?**: No.

**How would I tell that this PR does not work in production? (monitors, etc.)**: Table names still not properly filtered out

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Not aware of this.

## Development Process
**Where should we start reviewing?**: small

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: n/a

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
