### PR TITLE
Add future to be notified when async init finishes.

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/KeyValueService.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.keyvalue.api;
 
 import com.google.common.collect.Multimap;
 import com.google.errorprone.annotations.MustBeClosed;
+import com.palantir.async.initializer.AsyncInitializing;
 import com.palantir.atlasdb.metrics.Timed;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.common.annotation.Idempotent;
@@ -36,7 +37,7 @@ import java.util.Set;
  * A service which stores key-value pairs.
  */
 @AutoDelegate
-public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
+public interface KeyValueService extends AutoCloseable, AsyncKeyValueService, AsyncInitializing {
     /**
      * Performs non-destructive cleanup when the KVS is no longer needed.
      */
@@ -661,16 +662,6 @@ public interface KeyValueService extends AutoCloseable, AsyncKeyValueService {
     ////////////////////////////////////////////////////////////
     // SPECIAL CASING SOME KVSs
     ////////////////////////////////////////////////////////////
-
-    /**
-     * Returns true iff the KeyValueService has been initialized and is ready to use. Note that this check ignores the
-     * cluster's availability - use {@link #getClusterAvailabilityStatus()} if you wish to verify that we can talk to
-     * the backing store.
-     */
-    @DoDelegate
-    default boolean isInitialized() {
-        return true;
-    }
 
     /**
      * Whether or not read performance degrades significantly when many deleted cells are in the requested range.

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueService.java
@@ -25,7 +25,4 @@ public interface CassandraKeyValueService extends KeyValueService {
     TracingQueryRunner getTracingQueryRunner();
 
     CassandraClientPool getClientPool();
-
-    @Override
-    boolean isInitialized();
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -499,8 +499,8 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
     }
 
     @Override
-    public boolean isInitialized() {
-        return wrapper.isInitialized();
+    public ListenableFuture<?> isInitializedAsync() {
+        return wrapper.isInitializedAsync();
     }
 
     protected void initialize(boolean asyncInitialize) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DualWriteKeyValueService.java
@@ -17,7 +17,9 @@ package com.palantir.atlasdb.keyvalue.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.CandidateCellForSweeping;
@@ -275,8 +277,9 @@ public class DualWriteKeyValueService implements KeyValueService {
     }
 
     @Override
-    public boolean isInitialized() {
-        return delegate1.isInitialized() && delegate2.isInitialized();
+    public ListenableFuture<?> isInitializedAsync() {
+        return Futures.whenAllSucceed(delegate1.isInitializedAsync(), delegate2.isInitializedAsync())
+                .run(() -> {}, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/ProfilingKeyValueService.java
@@ -438,6 +438,11 @@ public final class ProfilingKeyValueService implements KeyValueService {
     }
 
     @Override
+    public ListenableFuture<?> isInitializedAsync() {
+        return maybeLog(delegate::isInitializedAsync, logTime("isInitializedAsync"));
+    }
+
+    @Override
     public void compactInternally(TableReference tableRef, boolean inMaintenanceMode) {
         long startTime = System.currentTimeMillis();
         maybeLog(() -> delegate.compactInternally(tableRef, inMaintenanceMode), (logger, stopwatch) -> {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/TracingKeyValueService.java
@@ -156,6 +156,11 @@ public final class TracingKeyValueService extends ForwardingObject implements Ke
     }
 
     @Override
+    public ListenableFuture<?> isInitializedAsync() {
+        return delegate().isInitializedAsync();
+    }
+
+    @Override
     public void createTable(TableReference tableRef, byte[] tableMetadata) {
         //noinspection unused - try-with-resources closes trace
         try (CloseableTracer trace = startLocalTrace("atlasdb-kvs.createTable", tableRef)) {

--- a/atlasdb-commons/build.gradle
+++ b/atlasdb-commons/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'
+    annotationProcessor project(":atlasdb-processors")
+    compileOnly project(":atlasdb-processors")
 
     testAnnotationProcessor 'org.immutables:value'
     testCompileOnly 'org.immutables:value::annotations'

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializer.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.async.initializer;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.exception.NotInitializedException;
@@ -37,7 +38,7 @@ public abstract class AsyncInitializer {
 
     private final ScheduledExecutorService singleThreadedExecutor = createExecutorService();
     private final AtomicBoolean isInitializing = new AtomicBoolean(false);
-    private AsyncInitializationState state = new AsyncInitializationState();
+    private final AsyncInitializationState state = new AsyncInitializationState();
     private int numberOfInitializationAttempts = 1;
     private Long initializationStartTime;
 
@@ -189,6 +190,10 @@ public abstract class AsyncInitializer {
     // Not final for tests.
     public boolean isInitialized() {
         return state.isDone();
+    }
+
+    public ListenableFuture<?> isInitializedAsync() {
+        return state.getFuture();
     }
 
     /**

--- a/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializing.java
+++ b/atlasdb-commons/src/main/java/com/palantir/async/initializer/AsyncInitializing.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.async.initializer;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.processors.DoDelegate;
+
+public interface AsyncInitializing {
+    @DoDelegate
+    default boolean isInitialized() {
+        ListenableFuture<?> initializedAsync = isInitializedAsync();
+        return initializedAsync.isDone() && !initializedAsync.isCancelled();
+    }
+
+    @DoDelegate
+    default ListenableFuture<?> isInitializedAsync() {
+        return Futures.immediateVoidFuture();
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/async/initializer/AsyncInitializerTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/async/initializer/AsyncInitializerTest.java
@@ -272,11 +272,17 @@ public class AsyncInitializerTest {
 
         private AlwaysFailingInitializerAssert isInitialized() {
             assertThat(actual.isInitialized()).isTrue();
+            assertThat(actual.isInitializedAsync().isDone()
+                            && !actual.isInitializedAsync().isCancelled())
+                    .isTrue();
             return this;
         }
 
         private AlwaysFailingInitializerAssert isNotInitialized() {
             assertThat(actual.isInitialized()).isFalse();
+            assertThat(actual.isInitializedAsync().isDone()
+                            && !actual.isInitializedAsync().isCancelled())
+                    .isFalse();
             return this;
         }
 


### PR DESCRIPTION
## General
**Before this PR**:
In order to either block until initialization is done OR be notified when it is ready, users need to poll #isInitialized, wasting a thread.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add future to be notified when async init finishes.
==COMMIT_MSG==

**Priority**:

P1

**Concerns / possible downsides (what feedback would you like?)**:
* I have replaced manual state tracking with just a future (which more accurately models what is happening, and reuses things.
* it's unclear if refactoring an interface for async initialization is a good call at this stage, however this code is rather intertwined together.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
* #isInitialized was moved to a subinterface.

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
* This code now contains somewhat annoying level of concurrency. We have AsyncInitializer which is used by initialization code to synchronize it's uses. Then user's can get access to the internal future, which should track the state.
* Synchronization in AsyncInitializer is used to ensure that the initializer does the right thing.
* So I think the implementation is still correct.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
