### PR TITLE
Fix duplicate key error in RetryableCassandraRequest

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -79,6 +79,14 @@ acceptedBreaks:
     - code: "java.method.addedToInterface"
       new: "method boolean com.palantir.atlasdb.cell.api.TransactionKeyValueService::isValid(long)"
       justification: "internal API"
+  "0.1073.0":
+    com.palantir.atlasdb:atlasdb-api:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException::<init>(java.util.List<java.lang.Exception>,\
+        \ ===java.util.Map<java.lang.String, java.lang.Integer>===)"
+      new: "parameter void com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException::<init>(java.util.List<java.lang.Exception>,\
+        \ ===java.util.List<com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException.AttemptedTarget>===)"
+      justification: "Only added recently"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/RetryLimitReachedExceptionTest.java
+++ b/atlasdb-api/src/test/java/com/palantir/atlasdb/keyvalue/api/RetryLimitReachedExceptionTest.java
@@ -17,10 +17,10 @@
 package com.palantir.atlasdb.keyvalue.api;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException.AttemptedTarget;
 import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.logsafe.SafeArg;
-import java.util.Map;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -33,30 +33,30 @@ public class RetryLimitReachedExceptionTest {
     @Test
     public void noMatches() {
         RetryLimitReachedException exception = new RetryLimitReachedException(
-                ImmutableList.of(RUNTIME, ATLAS_DEPENDENCY, GENERIC), ImmutableMap.of("host1", 1));
+                ImmutableList.of(RUNTIME, ATLAS_DEPENDENCY, GENERIC), ImmutableList.of(AttemptedTarget.of("name1", 1)));
         Assertions.assertThat(exception.suppressed(IllegalStateException.class)).isFalse();
     }
 
     @Test
     public void exactMatch() {
         RetryLimitReachedException exception = new RetryLimitReachedException(
-                ImmutableList.of(RUNTIME, ATLAS_DEPENDENCY, GENERIC), ImmutableMap.of("host1", 1));
+                ImmutableList.of(RUNTIME, ATLAS_DEPENDENCY, GENERIC), ImmutableList.of(AttemptedTarget.of("name1", 1)));
         Assertions.assertThat(exception.suppressed(RuntimeException.class)).isTrue();
     }
 
     @Test
     public void superMatch() {
         RetryLimitReachedException exception = new RetryLimitReachedException(
-                ImmutableList.of(ATLAS_DEPENDENCY, GENERIC), ImmutableMap.of("host1", 1));
+                ImmutableList.of(ATLAS_DEPENDENCY, GENERIC), ImmutableList.of(AttemptedTarget.of("name1", 1)));
         Assertions.assertThat(exception.suppressed(RuntimeException.class)).isTrue();
     }
 
     @Test
     public void testArgs() {
-        Map<String, Integer> hostsTried = ImmutableMap.of("host1", 1);
+        List<AttemptedTarget> attemptedTargets = ImmutableList.of(AttemptedTarget.of("name1", 1));
         RetryLimitReachedException exception =
-                new RetryLimitReachedException(ImmutableList.of(RUNTIME, ATLAS_DEPENDENCY, GENERIC), hostsTried);
-        Assertions.assertThat(exception.getArgs()).contains(SafeArg.of("hostsToNumAttemptsTried", hostsTried));
+                new RetryLimitReachedException(ImmutableList.of(RUNTIME, ATLAS_DEPENDENCY, GENERIC), attemptedTargets);
+        Assertions.assertThat(exception.getArgs()).contains(SafeArg.of("attemptedTargets", attemptedTargets));
         Assertions.assertThat(exception.getArgs()).contains(SafeArg.of("numRetries", 3));
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RetryableCassandraRequest.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/RetryableCassandraRequest.java
@@ -16,6 +16,7 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException;
+import com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException.AttemptedTarget;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.exception.AtlasDbDependencyException;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import one.util.streamex.EntryStream;
 
 public class RetryableCassandraRequest<V, K extends Exception> {
@@ -84,7 +86,7 @@ public class RetryableCassandraRequest<V, K extends Exception> {
         throw new RetryLimitReachedException(
                 encounteredExceptions,
                 EntryStream.of(triedHosts)
-                        .mapKeys(CassandraServer::cassandraHostName)
-                        .toMap());
+                        .mapKeyValue((server, attempts) -> AttemptedTarget.of(server.toString(), attempts))
+                        .collect(Collectors.toList()));
     }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/ResilientCommitTimestampAtomicTableTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/atomic/ResilientCommitTimestampAtomicTableTest.java
@@ -37,6 +37,7 @@ import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
 import com.palantir.atlasdb.keyvalue.api.KeyAlreadyExistsException;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException;
+import com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException.AttemptedTarget;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.transaction.encoding.BaseProgressEncodingStrategy;
@@ -480,7 +481,8 @@ public class ResilientCommitTimestampAtomicTableTest {
         }
 
         public void failPutsWithAtlasdbDependencyException() {
-            putException = Optional.of(new RetryLimitReachedException(ImmutableList.of(), ImmutableMap.of("host1", 1)));
+            putException = Optional.of(new RetryLimitReachedException(
+                    ImmutableList.of(), ImmutableList.of(AttemptedTarget.of("name1", 1))));
         }
 
         public int maximumConcurrentTouches() {


### PR DESCRIPTION
https://github.com/palantir/atlasdb/pull/6943 made the incorrect assumption that Cassandra server host names are unique.

We are seeing internal errors coming from AtlasDB in our internal authentication product.

```
java.lang.IllegalStateException: {throwable0_message}
	at one.util.streamex.AbstractStreamEx.addToMap(AbstractStreamEx.java:101)
	at one.util.streamex.EntryStream.lambda$toMapConsumer$1(EntryStream.java:95)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.concurrent.ConcurrentHashMap$EntrySpliterator.forEachRemaining(ConcurrentHashMap.java:3652)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at one.util.streamex.AbstractStreamEx.forEach(AbstractStreamEx.java:360)
	at one.util.streamex.EntryStream.toMap(EntryStream.java:1269)
	at com.palantir.atlasdb.keyvalue.cassandra.RetryableCassandraRequest.throwLimitReached(RetryableCassandraRequest.java:88)
	at com.palantir.atlasdb.keyvalue.cassandra.CassandraRequestExceptionHandler.logAndThrowException(CassandraRequestExceptionHandler.java:124)
	at com.palantir.atlasdb.keyvalue.cassandra.CassandraRequestExceptionHandler.handleExceptionFromRequest(CassandraRequestExceptionHandler.java:86)
	at com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolImpl.runWithRetryOnServer(CassandraClientPoolImpl.java:622)
```