### PR TITLE
Prefer AssertJ

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
@@ -20,8 +20,8 @@ import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceTe
 import static com.palantir.atlasdb.keyvalue.cassandra.CassandraKeyValueServiceTestUtils.insertGenericMetadataIntoLegacyCell;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
@@ -561,8 +561,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 MultiCheckAndSetRequest.multipleCells(TEST_TABLE, TEST_CELL.getRowName(), expected, updates);
 
         MultiCheckAndSetException ex =
-                assertThrows(MultiCheckAndSetException.class, () -> keyValueService.multiCheckAndSet(request));
-
+                catchThrowableOfType(() -> keyValueService.multiCheckAndSet(request), MultiCheckAndSetException.class);
         assertThat(ex.getExpectedValues()).containsExactlyEntriesOf(expected);
         assertThat(ex.getActualValues()).isEmpty();
     }
@@ -647,11 +646,10 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 MultiCheckAndSetRequest.newCells(TEST_TABLE, firstTestCell.getRowName(), firstPut));
         verifyMultiCheckAndSet(firstPut);
 
-        MultiCheckAndSetException ex = assertThrows(
-                MultiCheckAndSetException.class,
+        MultiCheckAndSetException ex = catchThrowableOfType(
                 () -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                        TEST_TABLE, firstTestCell.getRowName(), ImmutableMap.of(firstTestCell, secondVal))));
-
+                        TEST_TABLE, firstTestCell.getRowName(), ImmutableMap.of(firstTestCell, secondVal))),
+                MultiCheckAndSetException.class);
         verifyMultiCheckAndSet(firstPut);
         assertThat(ex.getExpectedValues()).isEmpty();
         assertThat(ex.getActualValues()).containsExactlyEntriesOf(firstPut);
@@ -684,10 +682,10 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                         TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))))
                 .isInstanceOf(MultiCheckAndSetException.class);
 
-        MultiCheckAndSetException ex = assertThrows(
-                MultiCheckAndSetException.class,
+        MultiCheckAndSetException ex = catchThrowableOfType(
                 () -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                        TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))));
+                        TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))),
+                MultiCheckAndSetException.class);
         assertThat(ex.getExpectedValues()).isEmpty();
         assertThat(ex.getActualValues()).containsExactlyEntriesOf(ImmutableMap.of(nextTestCell, val(0, 1)));
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraTopologyValidatorTest.java
@@ -733,8 +733,10 @@ public final class CassandraTopologyValidatorTest {
                                 .build())
                 .build();
 
-        assertThat(topologies.hostIds()).isEqualTo(Sets.union(UUIDS, MAYBE_SAME_AS_FIRST_CLUSTER));
-        assertThat(topologies.serversInConsensus()).isEqualTo(Sets.union(oldServers, newServers));
+        assertThat(topologies.hostIds())
+                .containsExactlyInAnyOrderElementsOf(Sets.union(UUIDS, MAYBE_SAME_AS_FIRST_CLUSTER));
+        assertThat(topologies.serversInConsensus())
+                .containsExactlyInAnyOrderElementsOf(Sets.union(oldServers, newServers));
     }
 
     @Test
@@ -752,8 +754,10 @@ public final class CassandraTopologyValidatorTest {
                 NonSoftFailureHostIdResult.wrap(HostIdResult.success(ImmutableSet.of("one", "five")))));
 
         assertThat(newTopologies.serversInConsensus())
-                .isEqualTo(Sets.union(original.serversInConsensus(), newTopologies.serversInConsensus()));
-        assertThat(newTopologies.hostIds()).isEqualTo(Sets.union(original.hostIds(), newTopologies.hostIds()));
+                .containsExactlyInAnyOrderElementsOf(
+                        Sets.union(original.serversInConsensus(), newTopologies.serversInConsensus()));
+        assertThat(newTopologies.hostIds())
+                .containsExactlyInAnyOrderElementsOf(Sets.union(original.hostIds(), newTopologies.hostIds()));
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingServiceTest.java
@@ -344,7 +344,7 @@ public class KvTableMappingServiceTest {
         int queryIterations = 100;
         for (int iteration = 0; iteration < queryIterations; iteration++) {
             assertThat(tableMapping.mapToShortTableNames(ImmutableMap.of(FQ_TABLE2, 2, FQ_TABLE3, 3)))
-                    .isEqualTo(ImmutableMap.of(mappedTableTwo, 2, mappedTableThree, 3));
+                    .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(mappedTableTwo, 2, mappedTableThree, 3));
         }
 
         // Once on startup (where it's empty), and once on the first query, but not after that.

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/LastSweptTimestampUpdaterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/metrics/LastSweptTimestampUpdaterTest.java
@@ -16,7 +16,7 @@
 
 package com.palantir.atlasdb.sweep.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -100,8 +100,10 @@ public class LastSweptTimestampUpdaterTest {
     @MethodSource("numberOfShards")
     public void taskThrowsOnInvalidRefreshMillis(int shards) {
         setup(shards);
-        assertThrows(SafeIllegalArgumentException.class, () -> lastSweptTimestampUpdater.schedule(0L));
-        assertThrows(SafeIllegalArgumentException.class, () -> lastSweptTimestampUpdater.schedule(-REFRESH_MILLIS));
+        assertThatThrownBy(() -> lastSweptTimestampUpdater.schedule(0L))
+                .isInstanceOf(SafeIllegalArgumentException.class);
+        assertThatThrownBy(() -> lastSweptTimestampUpdater.schedule(-REFRESH_MILLIS))
+                .isInstanceOf(SafeIllegalArgumentException.class);
     }
 
     @ParameterizedTest(name = PARAMETERIZED_TEST_NAME)


### PR DESCRIPTION
Replica of the excavator https://github.com/palantir/atlasdb/pull/7058/files with some corrections.

Prefer assertJ instead of jupiter assertions. The excavator didn't work because in here

```
MultiCheckAndSetException ex =
                assertThatThrownBy(() -> keyValueService.multiCheckAndSet(request)).isInstanceOf(MultiCheckAndSetException.class);
```

assertThatThrownBy does not return the exception captured. Instead we should use catchThrowableOfType which already verifies the instance of automatically and return the exception.

