### PR TITLE
Wait for only pending gets to commit

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultCommitTimestampLoader.java
@@ -132,7 +132,7 @@ public final class DefaultCommitTimestampLoader implements CommitTimestampLoader
 
         // Before we do the reads, we need to make sure the committer is done writing.
         if (shouldWaitForCommitterToComplete) {
-            waitForCommitterToComplete(tableRef, startTimestamps);
+            waitForCommitterToComplete(tableRef, pendingGets);
         }
 
         return Futures.transform(


### PR DESCRIPTION
## General
**Before this PR**:
We wait for already committed transactions to commit again.

**After this PR**:
We don't wait for already committed transactions to commit again. 

We don't need to call waitForCommitterToComplete(tableRef, pendingGets) with startTimestamps because some of them have already been committed, and their commit timestamps are stored in the cache. The ones we might need to wait for are already populated inside pendingGets. We can simply wait for this set instead.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P3

**Concerns / possible downsides (what feedback would you like?)**:
This touches a critical path of transaction logic so need to be reviewed carefully?

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
NA

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
Nothing made

**What was existing testing like? What have you done to improve it?**:
No new tests required

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
No

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
No

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Nothing should change (maybe small performance improvement?)

**Has the safety of all log arguments been decided correctly?**:
NA

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Nothing should change (maybe small performance improvement?)

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Library callback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
NA

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:
Single line

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
Singe line

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
