### PR TITLE
[PDS-514961 related] Perform Coordination Table Reads at SERIAL

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProvider.java
@@ -38,7 +38,7 @@ public final class ReadConsistencyProvider {
 
     public ConsistencyLevel getConsistency(TableReference tableReference) {
         if (AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.contains(tableReference)) {
-            return ConsistencyLevel.LOCAL_SERIAL;
+            return ConsistencyLevel.SERIAL;
         }
         return defaultReadConsistency.get();
     }

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/ReadConsistencyProviderTest.java
@@ -47,16 +47,16 @@ public class ReadConsistencyProviderTest {
     }
 
     @Test
-    public void consistencyForAtomicSerialTablesIsLocalSerial() {
+    public void consistencyForAtomicSerialTablesIsSerial() {
         AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.forEach(tableReference ->
-                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_SERIAL));
+                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.SERIAL));
     }
 
     @Test
-    public void consistencyForAtomicSerialTablesRemainsLocalSeriallEvenAfterBroadConsistencyDowngrade() {
+    public void consistencyForAtomicSerialTablesRemainsSerialEvenAfterBroadConsistencyDowngrade() {
         provider.lowerConsistencyLevelToOne();
         AtlasDbConstants.SERIAL_CONSISTENCY_ATOMIC_TABLES.forEach(tableReference ->
-                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.LOCAL_SERIAL));
+                assertThat(provider.getConsistency(tableReference)).isEqualTo(ConsistencyLevel.SERIAL));
     }
 
     @Test


### PR DESCRIPTION
## General
**Before this PR**: The coordination table is written to at `SERIAL` (this is a bit convoluted: but we don't specify the consistency level in AtlasDB code, and the default in Cassandra code is `SERIAL`). We read from the coordination table at `LOCAL_SERIAL`. 

However, in setups with multiple datacenters, this may be unsafe. Consider a situation where we run 2 datacenters with RF3. Suppose the database contains some value V.

Suppose we have a CAS (V to W) performed at `SERIAL` which is partially applied: the round of Paxos succeeds on three nodes of DC1 and one node of DC2, but the subsequent update fails. Next, we perform a read at `LOCAL_SERIAL`, and we pick a DC2 coordinator and service the read using the two nodes of DC2 that were not participating in the Paxos round. This will not find any trace of the Paxos round, and so we will return V.

We can then perform another read at `LOCAL_SERIAL`, but this time either pick a DC1 coordinator, or pick a DC2 coordinator but include the node that participated in the quorum write. They will be aware of the Paxos and complete it; assuming that completes successfully, we will return W.

Read repairs will eventually mean that the cluster does settle on W, but this breaks strict-serializability: the write definitely happened before our first read. (With three datacenters, we can even have permanent disagreement!)

This bug is almost certainly _not_ the root cause of PDS-514961, and it's unlikely we have performed transactions table migrations recently (since we started running multi-DC setups), so my intuition would indicate that we have _not_ seen corruption stemming from this source: even if we were to find value disagreements in terms of how far the timestamp bound was extended for, there would not actually be disagreement on which transactions table to put data into. That said, given plans to use the coordination service more heavily, we should fix this.

**After this PR**:
==COMMIT_MSG==
Reads of the Cassandra implementation of the coordination service (and in general atomic tables) takes place at `SERIAL` rather than `LOCAL_SERIAL`. These previously happened at `LOCAL_SERIAL`, which is vulnerable to a correctness bug in multi-DC setups.
==COMMIT_MSG==

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
- Would there be a bad performance impact? Reads of the coordination store might become more expensive, though I doubt this is frequent - it's also cached (see `CoordinationServiceImpl`).

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes, the previous nodes may still be vulnerable to the bug but that's fine

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That coordination table reads are cached. This assumption already exists, however.

**What was existing testing like? What have you done to improve it?**: There are some tests for the consistency level that were updated. There isn't bandwidth to create a full reproduction of the issue discussed above, I think.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Things remain quiet

**Has the safety of all log arguments been decided correctly?**: N/A

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: _Either_ we see performance regressions _or_ there ends up being a corruption of the coordination store

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: As long as the performance doesn't implode, see above.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No: doing a large number of database calls would be expensive. (The cache and coalescing supplier should mitigate concurrent CAS, but that's not touched in this PR.)

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: If this working as intended causes perf problems, we should look at having a different database or upscaling.

## Development Process
**Where should we start reviewing?**: Small.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: It's not.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
