### PR TITLE
Report conflicting table as arg in transaction conflict exceptions

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -87,6 +87,37 @@ acceptedBreaks:
       new: "parameter void com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException::<init>(java.util.List<java.lang.Exception>,\
         \ ===java.util.List<com.palantir.atlasdb.keyvalue.api.RetryLimitReachedException.AttemptedTarget>===)"
       justification: "Only added recently"
+  "0.1079.0":
+    com.palantir.atlasdb:atlasdb-api:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method com.palantir.atlasdb.transaction.api.TransactionConflictException\
+        \ com.palantir.atlasdb.transaction.api.TransactionConflictException::create(com.palantir.atlasdb.keyvalue.api.TableReference,\
+        \ long, java.util.Collection<com.palantir.atlasdb.transaction.api.TransactionConflictException.CellConflict>,\
+        \ java.util.Collection<com.palantir.atlasdb.transaction.api.TransactionConflictException.CellConflict>,\
+        \ long)"
+      new: "method com.palantir.atlasdb.transaction.api.TransactionConflictException\
+        \ com.palantir.atlasdb.transaction.api.TransactionConflictException::create(com.palantir.atlasdb.keyvalue.api.TableReference,\
+        \ long, java.util.Collection<com.palantir.atlasdb.transaction.api.TransactionConflictException.CellConflict>,\
+        \ java.util.Collection<com.palantir.atlasdb.transaction.api.TransactionConflictException.CellConflict>,\
+        \ long, java.util.List<com.palantir.logsafe.Arg<?>>)"
+      justification: "Transaction conflict exceptions are only intended to be instantiated\
+        \ internally"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException\
+        \ com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException::create(com.palantir.atlasdb.keyvalue.api.TableReference,\
+        \ long, long)"
+      new: "method com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException\
+        \ com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException::create(com.palantir.atlasdb.keyvalue.api.TableReference,\
+        \ long, long, java.util.List<com.palantir.logsafe.Arg<?>>)"
+      justification: "Transaction conflict exceptions are only intended to be instantiated\
+        \ internally"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException::<init>(java.lang.String,\
+        \ com.palantir.atlasdb.keyvalue.api.TableReference)"
+      new: "method void com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException::<init>(java.lang.String,\
+        \ com.palantir.atlasdb.keyvalue.api.TableReference, java.util.List<com.palantir.logsafe.Arg<?>>)"
+      justification: "Transaction conflict exceptions are only intended to be instantiated\
+        \ internally"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -89,6 +89,14 @@ acceptedBreaks:
       justification: "Only added recently"
   "0.1079.0":
     com.palantir.atlasdb:atlasdb-api:
+    - code: "java.class.nowFinal"
+      old: "class com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException"
+      new: "class com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException"
+      justification: "Intentional break"
+    - code: "java.class.nowImplementsInterface"
+      old: "class com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException"
+      new: "class com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException"
+      justification: "Intentional break"
     - code: "java.method.numberOfParametersChanged"
       old: "method com.palantir.atlasdb.transaction.api.TransactionConflictException\
         \ com.palantir.atlasdb.transaction.api.TransactionConflictException::create(com.palantir.atlasdb.keyvalue.api.TableReference,\

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionConflictException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionConflictException.java
@@ -102,7 +102,8 @@ public final class TransactionConflictException extends TransactionFailedRetriab
 
     @Override
     public @Safe String getLogMessage() {
-        return "Transaction conflict";
+        return "There was a write-write transaction conflict. This transaction wrote a cell to which a concurrent"
+                + " transaction wrote a different value.";
     }
 
     @Override

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionConflictException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionConflictException.java
@@ -21,7 +21,6 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Safe;
-import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.SafeLoggable;
 import java.io.Serializable;
 import java.util.Collection;
@@ -92,12 +91,13 @@ public final class TransactionConflictException extends TransactionFailedRetriab
             String message,
             Collection<CellConflict> spanningWrites,
             Collection<CellConflict> dominatingWrites,
-            TableReference conflictingTable) {
+            TableReference conflictingTable,
+            List<Arg<?>> args) {
         super(message);
         this.spanningWrites = ImmutableList.copyOf(spanningWrites);
         this.dominatingWrites = ImmutableList.copyOf(dominatingWrites);
         this.conflictingTable = conflictingTable;
-        this.args = List.of(SafeArg.of("conflictingTable", conflictingTable));
+        this.args = List.copyOf(args);
     }
 
     @Override
@@ -134,7 +134,8 @@ public final class TransactionConflictException extends TransactionFailedRetriab
             long timestamp,
             Collection<CellConflict> spanningWrites,
             Collection<CellConflict> dominatingWrites,
-            long elapsedMillis) {
+            long elapsedMillis,
+            List<Arg<?>> args) {
         StringBuilder sb = new StringBuilder();
         sb.append("Transaction Conflict after ")
                 .append(elapsedMillis)
@@ -155,7 +156,7 @@ public final class TransactionConflictException extends TransactionFailedRetriab
             formatConflicts(dominatingWrites, sb);
             sb.append('\n');
         }
-        return new TransactionConflictException(sb.toString(), spanningWrites, dominatingWrites, tableRef);
+        return new TransactionConflictException(sb.toString(), spanningWrites, dominatingWrites, tableRef, args);
     }
 
     private static void formatConflicts(Collection<CellConflict> conflicts, StringBuilder sb) {

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
@@ -21,7 +21,7 @@ import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeLoggable;
 import java.util.List;
 
-public class TransactionSerializableConflictException extends TransactionFailedRetriableException
+public final class TransactionSerializableConflictException extends TransactionFailedRetriableException
         implements SafeLoggable {
     private static final long serialVersionUID = 1L;
 
@@ -47,7 +47,8 @@ public class TransactionSerializableConflictException extends TransactionFailedR
 
     @Override
     public @Safe String getLogMessage() {
-        return "Transaction serializable conflict";
+        return "There was a read-write conflict. This transaction read a cell to which a concurrent transaction wrote a"
+                + " different value.";
     }
 
     @Override

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.transaction.api;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Safe;
-import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.SafeLoggable;
 import java.util.List;
 
@@ -29,20 +28,21 @@ public class TransactionSerializableConflictException extends TransactionFailedR
     private final TableReference conflictingTable;
     private final List<Arg<?>> args;
 
-    public TransactionSerializableConflictException(String message, TableReference conflictingTable) {
+    public TransactionSerializableConflictException(
+            String message, TableReference conflictingTable, List<Arg<?>> args) {
         super(message);
         this.conflictingTable = conflictingTable;
-        this.args = List.of(SafeArg.of("conflictingTable", conflictingTable));
+        this.args = List.copyOf(args);
     }
 
     public static TransactionSerializableConflictException create(
-            TableReference tableRef, long timestamp, long elapsedMillis) {
+            TableReference tableRef, long timestamp, long elapsedMillis, List<Arg<?>> args) {
         String msg = String.format(
                 "There was a read-write conflict on table %s.  This means that this table was marked as Serializable"
                         + " and another transaction wrote a different value than this transaction read.  startTs: %d "
                         + " elapsedMillis: %d",
                 tableRef.getQualifiedName(), timestamp, elapsedMillis);
-        return new TransactionSerializableConflictException(msg, tableRef);
+        return new TransactionSerializableConflictException(msg, tableRef, args);
     }
 
     @Override

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionSerializableConflictException.java
@@ -16,15 +16,23 @@
 package com.palantir.atlasdb.transaction.api;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.SafeLoggable;
+import java.util.List;
 
-public class TransactionSerializableConflictException extends TransactionFailedRetriableException {
+public class TransactionSerializableConflictException extends TransactionFailedRetriableException
+        implements SafeLoggable {
     private static final long serialVersionUID = 1L;
 
     private final TableReference conflictingTable;
+    private final List<Arg<?>> args;
 
     public TransactionSerializableConflictException(String message, TableReference conflictingTable) {
         super(message);
         this.conflictingTable = conflictingTable;
+        this.args = List.of(SafeArg.of("conflictingTable", conflictingTable));
     }
 
     public static TransactionSerializableConflictException create(
@@ -35,6 +43,16 @@ public class TransactionSerializableConflictException extends TransactionFailedR
                         + " elapsedMillis: %d",
                 tableRef.getQualifiedName(), timestamp, elapsedMillis);
         return new TransactionSerializableConflictException(msg, tableRef);
+    }
+
+    @Override
+    public @Safe String getLogMessage() {
+        return "Transaction serializable conflict";
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return args;
     }
 
     public TableReference getConflictingTable() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadValidationCommitTimestampLoader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ReadValidationCommitTimestampLoader.java
@@ -21,10 +21,12 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.transaction.api.CommitTimestampLoader;
 import com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException;
 import com.palantir.atlasdb.transaction.impl.SerializableTransaction.PartitionedTimestamps;
 import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetrics;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.eclipse.collections.api.LongIterable;
 import org.eclipse.collections.api.map.primitive.LongLongMap;
@@ -124,7 +126,8 @@ public final class ReadValidationCommitTimestampLoader implements CommitTimestam
                             "An uncommitted conflicting read was written after our start timestamp for table "
                                     + tableRef + ".  This case can cause deadlock and is very likely to be a "
                                     + "read write conflict.",
-                            tableRef);
+                            tableRef,
+                            List.of(LoggingArgs.tableRef(tableRef)));
                 },
                 MoreExecutors.directExecutor());
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -949,7 +949,10 @@ public class SerializableTransaction extends SnapshotTransaction {
         transactionOutcomeMetrics.markReadWriteConflict(tableRef);
         log.info("Serializable conflict", LoggingArgs.tableRef(tableRef));
         throw TransactionSerializableConflictException.create(
-                tableRef, getTimestamp(), System.currentTimeMillis() - timeCreated);
+                tableRef,
+                getTimestamp(),
+                System.currentTimeMillis() - timeCreated,
+                List.of(LoggingArgs.tableRef(tableRef)));
     }
 
     private BatchingVisitable<Map.Entry<Cell, byte[]>> wrapWithColumnRangeChecking(
@@ -957,7 +960,7 @@ public class SerializableTransaction extends SnapshotTransaction {
             BatchColumnRangeSelection columnRangeSelection,
             byte[] row,
             BatchingVisitable<Map.Entry<Cell, byte[]>> visitable) {
-        return new BatchingVisitable<Map.Entry<Cell, byte[]>>() {
+        return new BatchingVisitable<>() {
             @Override
             public <K extends Exception> boolean batchAccept(
                     int batchSize, AbortingVisitor<? super List<Map.Entry<Cell, byte[]>>, K> visitor) throws K {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2230,7 +2230,7 @@ public class SnapshotTransaction extends AbstractTransaction
                         spanningWrites,
                         dominatingWrites,
                         System.currentTimeMillis() - timeCreated,
-                        List.of(LoggingArgs.tableRef("tableRef", tableRef)));
+                        List.of(LoggingArgs.tableRef(tableRef)));
             }
         }
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2229,7 +2229,8 @@ public class SnapshotTransaction extends AbstractTransaction
                         getStartTimestamp(),
                         spanningWrites,
                         dominatingWrites,
-                        System.currentTimeMillis() - timeCreated);
+                        System.currentTimeMillis() - timeCreated,
+                        List.of(LoggingArgs.tableRef("tableRef", tableRef)));
             }
         }
     }
@@ -2240,7 +2241,7 @@ public class SnapshotTransaction extends AbstractTransaction
      * value was written after our start time.
      */
     private void throwIfValueChangedConflict(
-            TableReference table,
+            TableReference tableRef,
             Map<Cell, byte[]> writes,
             Set<CellConflict> spanningWrites,
             Set<CellConflict> dominatingWrites,
@@ -2252,21 +2253,24 @@ public class SnapshotTransaction extends AbstractTransaction
             cellToTs.put(c.getCell(), c.getTheirStart() + 1);
         }
 
-        Map<Cell, byte[]> oldValues = getIgnoringLocalWrites(table, cellToTs.keySet());
+        Map<Cell, byte[]> oldValues = getIgnoringLocalWrites(tableRef, cellToTs.keySet());
         Map<Cell, Value> conflictingValues =
-                AtlasFutures.getUnchecked(transactionKeyValueService.getAsync(table, cellToTs));
+                AtlasFutures.getUnchecked(transactionKeyValueService.getAsync(tableRef, cellToTs));
 
         Set<Cell> conflictingCells = new HashSet<>();
         for (Map.Entry<Cell, Long> cellEntry : cellToTs.entrySet()) {
             Cell cell = cellEntry.getKey();
             if (!writes.containsKey(cell)) {
-                Validate.isTrue(false, "Missing write for cell: %s for table %s", cellToConflict.get(cell), table);
+                Validate.isTrue(false, "Missing write for cell: %s for table %s", cellToConflict.get(cell), tableRef);
             }
             if (!conflictingValues.containsKey(cell)) {
                 // This error case could happen if our locks expired.
                 preCommitRequirementValidator.throwIfPreCommitRequirementsNotMet(commitLocksToken, getStartTimestamp());
                 Validate.isTrue(
-                        false, "Missing conflicting value for cell: %s for table %s", cellToConflict.get(cell), table);
+                        false,
+                        "Missing conflicting value for cell: %s for table %s",
+                        cellToConflict.get(cell),
+                        tableRef);
             }
             if (conflictingValues.get(cell).getTimestamp() != (cellEntry.getValue() - 1)) {
                 // This error case could happen if our locks expired.
@@ -2274,7 +2278,7 @@ public class SnapshotTransaction extends AbstractTransaction
                 Validate.isTrue(
                         false,
                         "Wrong timestamp for cell in table %s Expected: %s Actual: %s",
-                        table,
+                        tableRef,
                         cellToConflict.get(cell),
                         conflictingValues.get(cell));
             }
@@ -2288,7 +2292,7 @@ public class SnapshotTransaction extends AbstractTransaction
                         "Another transaction committed to the same cell before us but their value was the same."
                                 + " Cell: {} Table: {}",
                         UnsafeArg.of("cell", cell),
-                        LoggingArgs.tableRef(table));
+                        LoggingArgs.tableRef(tableRef));
             }
         }
         if (conflictingCells.isEmpty()) {
@@ -2296,13 +2300,14 @@ public class SnapshotTransaction extends AbstractTransaction
         }
         Predicate<CellConflict> conflicting =
                 Predicates.compose(Predicates.in(conflictingCells), CellConflict.getCellFunction());
-        transactionOutcomeMetrics.markWriteWriteConflict(table);
+        transactionOutcomeMetrics.markWriteWriteConflict(tableRef);
         throw TransactionConflictException.create(
-                table,
+                tableRef,
                 getStartTimestamp(),
                 Sets.filter(spanningWrites, conflicting),
                 Sets.filter(dominatingWrites, conflicting),
-                System.currentTimeMillis() - timeCreated);
+                System.currentTimeMillis() - timeCreated,
+                List.of(LoggingArgs.tableRef(tableRef)));
     }
 
     /**


### PR DESCRIPTION
When a transaction fails due to a conflict and is retried, the logs do not indicate the table which had the conflict. This makes it difficult to diagnose the cause of excessive conflicts when retries ultimately allow the transaction to succeed.