### PR TITLE
Safe loggable TransactionConflictException exception

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2209,7 +2209,8 @@ public class SnapshotTransaction extends AbstractTransaction
                         getStartTimestamp(),
                         spanningWrites,
                         dominatingWrites,
-                        System.currentTimeMillis() - timeCreated);
+                        System.currentTimeMillis() - timeCreated,
+                        List.of(LoggingArgs.tableRef(tableRef)));
             }
         }
     }
@@ -2282,7 +2283,8 @@ public class SnapshotTransaction extends AbstractTransaction
                 getStartTimestamp(),
                 Sets.filter(spanningWrites, conflicting),
                 Sets.filter(dominatingWrites, conflicting),
-                System.currentTimeMillis() - timeCreated);
+                System.currentTimeMillis() - timeCreated,
+                List.of(LoggingArgs.tableRef(table)));
     }
 
     /**


### PR DESCRIPTION
## General
**Before this PR**:
`TransactionConflictException` was not safe for logging so it was very hard to find the cause of conflict by simply looking at logs

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
TransactionConflictException now implements the SafeLoggable interface and includes table references in it's arguments.
==COMMIT_MSG==


I had this locally for a while and finally got a change to open a PR, there is however one more opened yesterday https://github.com/palantir/atlasdb/pull/7109