### PR TITLE
Allow disabling validating locks on reads on a per transaction basis

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -467,4 +467,18 @@ public interface Transaction {
     default void markTableInvolved(TableReference tableRef) {
         throw new UnsupportedOperationException();
     }
+
+    /**
+     * Disables lock validation on reads.
+     * <p>
+     * This method should be called before any reads are done inside this transaction or after the last read that can
+     * result in a side effect.
+     * <p>
+     * This method is always safe to be called inside a transaction that has no side effects outside of transaction
+     * scope as necessary validation will still be executed at commit time.
+     */
+    @Idempotent
+    default void disableValidatingLocksOnReads() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -477,6 +477,18 @@ public interface Transaction {
      * This method is always safe to be called inside a transaction that has no side effects outside of transaction
      * scope as necessary validation will still be executed at commit time.
      */
+    @RestrictedApi(
+            explanation = "This API is only meant to be used by AtlasDb proxies that want to make use of the "
+                    + "performance improvement that are achievable by avoiding immutable timestamp lock check on reads "
+                    + "and delaying them to commit time. When validation on reads is disabled, it is possible for a "
+                    + "transaction to read values that were thoroughly swept and the transaction would not fail until "
+                    + "validation is done at commit commit time. Disabling validation on reads in situations when a "
+                    + "transaction can potentially have side effects outside the transaction scope (e.g. remote call "
+                    + "to another service) can cause correctness issues. The API is restricted as misuses of it can "
+                    + "cause correctness issues.",
+            link = "https://github.com/palantir/atlasdb/pull/7111",
+            allowedOnPath = ".*/src/test/.*", // Unsafe behavior in tests is ok.
+            allowlistAnnotations = {ReviewedRestrictedApiUsage.class})
     @Idempotent
     default void disableValidatingLocksOnReads() {
         throw new UnsupportedOperationException();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -205,6 +205,11 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
     }
 
     @Override
+    public void disableValidatingLocksOnReads() {
+        delegate().disableValidatingLocksOnReads();
+    }
+
+    @Override
     public void markTableInvolved(TableReference tableRef) {
         delegate().markTableInvolved(tableRef);
     }

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -17,6 +17,7 @@ package com.palantir.atlasdb.transaction.impl;
 
 import com.google.common.collect.ForwardingObject;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -204,6 +205,18 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
         delegate().disableReadWriteConflictChecking(tableRef);
     }
 
+    @RestrictedApi(
+            explanation = "This API is only meant to be used by AtlasDb proxies that want to make use of the "
+                    + "performance improvement that are achievable by avoiding immutable timestamp lock check on reads "
+                    + "and delaying them to commit time. When validation on reads is disabled, it is possible for a "
+                    + "transaction to read values that were thoroughly swept and the transaction would not fail until "
+                    + "validation is done at commit commit time. Disabling validation on reads in situations when a "
+                    + "transaction can potentially have side effects outside the transaction scope (e.g. remote call "
+                    + "to another service) can cause correctness issues. The API is restricted as misuses of it can "
+                    + "cause correctness issues.",
+            link = "https://github.com/palantir/atlasdb/pull/7111",
+            allowedOnPath = ".*/src/test/.*",
+            allowlistAnnotations = {ReviewedRestrictedApiUsage.class})
     @Override
     public void disableValidatingLocksOnReads() {
         delegate().disableValidatingLocksOnReads();

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -17,7 +17,6 @@ package com.palantir.atlasdb.transaction.impl;
 
 import com.google.common.collect.ForwardingObject;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -205,18 +204,7 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
         delegate().disableReadWriteConflictChecking(tableRef);
     }
 
-    @RestrictedApi(
-            explanation = "This API is only meant to be used by AtlasDb proxies that want to make use of the "
-                    + "performance improvement that are achievable by avoiding immutable timestamp lock check on reads "
-                    + "and delaying them to commit time. When validation on reads is disabled, it is possible for a "
-                    + "transaction to read values that were thoroughly swept and the transaction would not fail until "
-                    + "validation is done at commit commit time. Disabling validation on reads in situations when a "
-                    + "transaction can potentially have side effects outside the transaction scope (e.g. remote call "
-                    + "to another service) can cause correctness issues. The API is restricted as misuses of it can "
-                    + "cause correctness issues.",
-            link = "https://github.com/palantir/atlasdb/pull/7111",
-            allowedOnPath = ".*/src/test/.*",
-            allowlistAnnotations = {ReviewedRestrictedApiUsage.class})
+    @ReviewedRestrictedApiUsage
     @Override
     public void disableValidatingLocksOnReads() {
         delegate().disableValidatingLocksOnReads();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -281,7 +281,7 @@ public class SnapshotTransaction extends AbstractTransaction
     protected final DeleteExecutor deleteExecutor;
     private final Timer.Context transactionTimerContext;
     protected final TransactionOutcomeMetrics transactionOutcomeMetrics;
-    protected final boolean validateLocksOnReads;
+    protected volatile boolean validateLocksOnReads;
     protected final Supplier<TransactionConfig> transactionConfig;
     protected final TableLevelMetricsController tableLevelMetricsController;
     protected final SuccessCallbackManager successCallbackManager = new SuccessCallbackManager();
@@ -431,6 +431,12 @@ public class SnapshotTransaction extends AbstractTransaction
     @Override
     public void disableReadWriteConflictChecking(TableReference tableRef) {
         conflictDetectionManager.disableReadWriteConflict(tableRef);
+    }
+
+    @Override
+    public synchronized void disableValidatingLocksOnReads() {
+        this.validateLocksOnReads = false;
+        this.readSnapshotValidator.disableValidatingLocksOnReads();
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/precommit/DefaultReadSnapshotValidator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/precommit/DefaultReadSnapshotValidator.java
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
 
 public final class DefaultReadSnapshotValidator implements ReadSnapshotValidator {
     private final PreCommitRequirementValidator preCommitRequirementValidator;
-    private final boolean validateLocksOnReads;
+    private volatile boolean validateLocksOnReads;
     private final SweepStrategyManager sweepStrategyManager;
     private final Supplier<TransactionConfig> transactionConfigSupplier;
 
@@ -57,6 +57,11 @@ public final class DefaultReadSnapshotValidator implements ReadSnapshotValidator
     @Override
     public boolean doesTableRequirePreCommitValidation(TableReference tableRef, boolean allReadsCompleteOrValidated) {
         return requiresImmutableTimestampLocking(tableRef, allReadsCompleteOrValidated);
+    }
+
+    @Override
+    public void disableValidatingLocksOnReads() {
+        validateLocksOnReads = false;
     }
 
     private boolean isValidationNecessaryOnReads(TableReference tableRef, boolean allPossibleCellsReadAndPresent) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/precommit/ReadSnapshotValidator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/precommit/ReadSnapshotValidator.java
@@ -41,6 +41,8 @@ public interface ReadSnapshotValidator {
 
     boolean doesTableRequirePreCommitValidation(TableReference tableRef, boolean allPossibleCellsReadAndPresent);
 
+    void disableValidatingLocksOnReads();
+
     enum ValidationState {
         COMPLETELY_VALIDATED,
         NOT_COMPLETELY_VALIDATED

--- a/changelog/@unreleased/pr-7111.v2.yml
+++ b/changelog/@unreleased/pr-7111.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Users can disable lock validation for reads on a per transaction basis.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7111


### PR DESCRIPTION
## General
**Before this PR**:
Certain transactions can benefit from not having every one of their gets being validated at read time and delaying the lock validation to the end of the transaction and commit validation.

For transactions that do not have any side effects which are outside of the scope of the transaction (remote calls, internal state changes) enabling this option should always be safe as the validation will still be done but at commit time instead of every get.

The main downside of disabling this check is for long running transaction as loosing a lock will only be detected at commit time which might be much later compared to when it actually happened.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Users can disable lock validation for reads on a per transaction basis.
==COMMIT_MSG==

**Priority**:
P2 (I suppose): in internal tests we had some promising results for several workflows and we'd like to have this option for a more targeted set of tests

**Concerns / possible downsides (what feedback would you like?)**:
How much documentation we need for this and how many warning do we need to put here?

Are there any edge cases that I might have missed?

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

The question is more if it is safe to apply this option on the transaction, at that point B/G is safe.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
It's the other way round, so users of Atlas should be mindful when using this feature.

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
Assuming that disabling lock validation is safe from the protocol perspective.

**What was existing testing like? What have you done to improve it?**:
Added a few more tests for this specific case.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
Doesn't contain it.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
We should be able to see improvements in transaction durations for workflows that enable this option.

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Should have been caught before when we used the option to disable lock validation at the transaction manager level.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Should be simple to revert in cases where we actually use it and it should be relatively easy to rollback. As far as corruption in external systems caused by misuse of this option it is up to the users of the library to come up with a way forward.

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
It reduces the number of calls

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No obviously, maybe if there is a lot of misuse (maybe we want to emit some metric, etc,)

## Development Process

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@fsamuel-bs 
@LucasIME 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
