### PR TITLE
CassandraKeyValueServiceImpl uses CellLoader::flattenReadOnlyLists

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraKeyValueServiceImpl.java
@@ -723,9 +723,7 @@ public class CassandraKeyValueServiceImpl extends AbstractKeyValueService implem
                                         query,
                                         readConsistencyProvider.getConsistency(tableRef));
 
-                        return Maps.transformValues(results, lists -> lists.stream()
-                                .flatMap(Collection::stream)
-                                .collect(Collectors.toList()));
+                        return Maps.transformValues(results, CellLoader::flattenReadOnlyLists);
                     }
 
                     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -316,7 +316,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     /**
      * @param immutableTimestamp If we find a row written before the immutableTimestamp we don't need to grab a read
-     *                           lock for it because we know that no writers exist.
+     * lock for it because we know that no writers exist.
      * @param preCommitCondition This check must pass for this transaction to commit.
      */
     /* package */ SnapshotTransaction(
@@ -1480,7 +1480,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     /**
      * This includes deleted writes as zero length byte arrays, be sure to strip them out.
-     *
+     * <p>
      * For the selectedColumns parameter, empty set means all columns. This is unfortunate, but follows the semantics of
      * {@link RangeRequest}.
      */
@@ -1688,7 +1688,7 @@ public class SnapshotTransaction extends AbstractTransaction
             LongLongMap commitTimestamps) {
         Map<Cell, Long> keysToReload = Maps.newHashMapWithExpectedSize(0);
         Map<Cell, Long> keysToDelete = Maps.newHashMapWithExpectedSize(0);
-        ImmutableSet.Builder<Cell> keysAddedBuilder = ImmutableSet.builder();
+        Set<Cell> keysAdded = new HashSet<>();
 
         for (Map.Entry<Cell, Value> e : rawResults.entrySet()) {
             Cell key = e.getKey();
@@ -1718,14 +1718,14 @@ public class SnapshotTransaction extends AbstractTransaction
                     snapshotEventRecorder.recordFilteredTransactionCommittingAfterOurStart(tableRef);
                 } else {
                     // The value has a commit timestamp less than our start timestamp, and is visible and valid.
-                    if (value.getContents().length != 0) {
+                    if (!value.isEmpty()) {
                         resultsCollector.add(Maps.immutableEntry(key, transformer.apply(value)));
-                        keysAddedBuilder.add(key);
+                        keysAdded.add(key);
                     }
                 }
             }
         }
-        Set<Cell> keysAddedToResults = keysAddedBuilder.build();
+        Set<Cell> keysAddedToResults = Collections.unmodifiableSet(keysAdded);
 
         if (!keysToDelete.isEmpty()) {
             // if we can't roll back the failed transactions, we should just try again
@@ -1749,9 +1749,7 @@ public class SnapshotTransaction extends AbstractTransaction
     }
 
     private Map<Cell, Value> getRemainingResults(Map<Cell, Value> rawResults, Set<Cell> keysAddedToResults) {
-        Map<Cell, Value> remainingResults = new HashMap<>(rawResults);
-        remainingResults.keySet().removeAll(keysAddedToResults);
-        return remainingResults;
+        return Maps.filterKeys(rawResults, cell -> !keysAddedToResults.contains(cell));
     }
 
     /**
@@ -1895,7 +1893,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     /**
      * Returns true iff the transaction is known to have successfully committed.
-     *
+     * <p>
      * Be careful when using this method! A transaction that the client thinks has failed could actually have
      * committed as far as the key-value service is concerned.
      */
@@ -2587,7 +2585,7 @@ public class SnapshotTransaction extends AbstractTransaction
     /**
      * This will attempt to put the commitTimestamp into the DB.
      *
-     * @throws TransactionLockTimeoutException  If our locks timed out while trying to commit.
+     * @throws TransactionLockTimeoutException If our locks timed out while trying to commit.
      * @throws TransactionCommitFailedException failed when committing in a way that isn't retriable
      */
     private void putCommitTimestamp(long commitTimestamp, LockToken locksToken, TransactionService transactionService)

--- a/changelog/@unreleased/pr-7112.v2.yml
+++ b/changelog/@unreleased/pr-7112.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: CassandraKeyValueServiceImpl uses CellLoader::flattenReadOnlyLists
+  links:
+  - https://github.com/palantir/atlasdb/pull/7112


### PR DESCRIPTION
## General
**Before this PR**:

Allocation profiling indicates expensive stream collect to list and `ArrayList#grow()` in `com.palantir.atlasdb.transaction.impl.SnapshotTransaction.collectCellsToPostFilter(TableReference, Map, Collection, Function, TransactionKeyValueService, Set, LongLongMap)`


![image](https://github.com/palantir/atlasdb/assets/54594/004c2b01-e1fc-4891-bdf7-2cb6b73bdf26)

![image](https://github.com/palantir/atlasdb/assets/54594/2f9b752d-8e2c-4e32-9805-c67866a02621)


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
CassandraKeyValueServiceImpl uses CellLoader::flattenReadOnlyLists
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
