### PR TITLE
Add args to config validation errors

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraKeyValueServiceConfig.java
@@ -31,6 +31,7 @@ import com.palantir.conjure.java.api.config.service.HumanReadableDuration;
 import com.palantir.conjure.java.api.config.ssl.SslConfiguration;
 import com.palantir.logsafe.DoNotLog;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
@@ -421,14 +422,16 @@ public interface CassandraKeyValueServiceConfig extends KeyValueServiceConfig {
 
     @Value.Check
     default void check() {
-        double evictionCheckProportion = proportionConnectionsToCheckPerEvictionRun();
         Preconditions.checkArgument(
-                evictionCheckProportion > 0.01 && evictionCheckProportion <= 1,
-                "'proportionConnectionsToCheckPerEvictionRun' must be between 0.01 and 1");
+                proportionConnectionsToCheckPerEvictionRun() > 0.01
+                        && proportionConnectionsToCheckPerEvictionRun() <= 1,
+                "'proportionConnectionsToCheckPerEvictionRun' must be between 0.01 and 1",
+                SafeArg.of("proportionConnectionsToCheckPerEvictionRun", proportionConnectionsToCheckPerEvictionRun()));
 
         Preconditions.checkArgument(
                 localHostWeighting() >= 0.0 && localHostWeighting() <= 1.0,
-                "'localHostWeighting' must be between 0 and 1 inclusive");
+                "'localHostWeighting' must be between 0 and 1 inclusive",
+                SafeArg.of("localHostWeighting", localHostWeighting()));
     }
 
     /**

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKeyValueServiceRuntimeConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraReloadableKeyValueServiceRuntimeConfig.java
@@ -100,11 +100,17 @@ public final class CassandraReloadableKeyValueServiceRuntimeConfig
     }
 
     private void checkPositiveNumberOfThriftHosts() {
-        checkArgument(servers().numberOfThriftHosts() > 0, "'servers' must have at least one defined host");
+        checkArgument(
+                servers().numberOfThriftHosts() > 0,
+                "'servers' must have at least one defined host",
+                SafeArg.of("numberOfThriftHosts", servers().numberOfThriftHosts()));
     }
 
     private void checkNonNegativeReplicationFactor() {
-        checkArgument(replicationFactor() >= 0, "'replicationFactor' must be non-negative");
+        checkArgument(
+                replicationFactor() >= 0,
+                "'replicationFactor' must be non-negative",
+                SafeArg.of("replicationFactor", replicationFactor()));
     }
 
     private void checkSharedGetRangesPoolGreaterThanOrEqualToConcurrentGetRangesThreadPool() {

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraTracingConfig.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/cassandra/CassandraTracingConfig.java
@@ -61,7 +61,9 @@ public abstract class CassandraTracingConfig {
     protected void check() {
         if (enabled()) {
             Preconditions.checkArgument(
-                    traceProbability() > 0, "trace-probability must be greater than 0 if tracing is enabled");
+                    traceProbability() > 0,
+                    "trace-probability must be greater than 0 if tracing is enabled",
+                    SafeArg.of("traceProbability", traceProbability()));
 
             // Just log a warning once. In witchcraft runtime config is reparsed every second which means this would
             // log every second.

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/TimeLockClientConfig.java
@@ -67,6 +67,6 @@ public abstract class TimeLockClientConfig {
     @Value.Check
     protected final void check() {
         Preconditions.checkArgument(
-                !client().isPresent() || !client().get().isEmpty(), "Timelock client string cannot be empty");
+                client().isEmpty() || !client().get().isEmpty(), "Timelock client string cannot be empty");
     }
 }


### PR DESCRIPTION
When these validations fail, it's hard to debug because we the error does not contain the actual value.