### PR TITLE
Reduce startup contention in Timelock ConcurrentHashMaps

### DIFF
--- a/atlasdb-commons/src/main/java/com/palantir/common/concurrent/ConcurrentMaps.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/concurrent/ConcurrentMaps.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.concurrent;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class ConcurrentMaps {
+
+    /**
+     * Returns a new mutable {@link ConcurrentMap} with capacity to
+     * Increase the initial capacity to reduce contention at startup.
+     * See <a href="https://github.com/ben-manes/caffeine/pull/218">Caffeine PR 218</a>,
+     * <a href="https://github.com/ben-manes/caffeine/wiki/Faq">Caffeine FAQ</a>,
+     * <a href="https://github.com/openjdk/jdk/blob/jdk-21-ga/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java#L348-L349">ConcurrentHashMap comments</a>:
+     * <p>
+     * <bq> Lock contention probability for two threads accessing distinct elements is roughly 1 / (8 * # of elements)
+     * under random hashes.</bq>
+     *
+     * @param expectedEntries number of expected entries
+     */
+    public static <K, V> ConcurrentMap<K, V> newWithExpectedEntries(int expectedEntries) {
+        return new ConcurrentHashMap<>(expectedEntries * 8);
+    }
+
+    private ConcurrentMaps() {}
+}

--- a/atlasdb-commons/src/main/java/com/palantir/common/concurrent/ConcurrentMaps.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/concurrent/ConcurrentMaps.java
@@ -19,7 +19,7 @@ package com.palantir.common.concurrent;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-public class ConcurrentMaps {
+public final class ConcurrentMaps {
 
     /**
      * Returns a new mutable {@link ConcurrentMap} with capacity to

--- a/atlasdb-commons/src/main/java/com/palantir/common/concurrent/ConcurrentMaps.java
+++ b/atlasdb-commons/src/main/java/com/palantir/common/concurrent/ConcurrentMaps.java
@@ -34,7 +34,7 @@ public final class ConcurrentMaps {
      * @param expectedEntries number of expected entries
      */
     public static <K, V> ConcurrentMap<K, V> newWithExpectedEntries(int expectedEntries) {
-        return new ConcurrentHashMap<>(expectedEntries * 8);
+        return new ConcurrentHashMap<>(expectedEntries * (/* contention probability */ 8 * /* load factor */ 3 / 4));
     }
 
     private ConcurrentMaps() {}

--- a/atlasdb-commons/src/test/java/com/palantir/common/concurrent/ConcurrentMapsTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/concurrent/ConcurrentMapsTest.java
@@ -1,0 +1,99 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.common.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ConcurrentMapsTest {
+
+    private static final int PROCESSORS = Runtime.getRuntime().availableProcessors();
+    private final ListeningExecutorService executor =
+            MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(PROCESSORS));
+
+    @AfterEach
+    void after() {
+        executor.shutdown();
+    }
+
+    @Test
+    void canCreateMap() {
+        ConcurrentMap<Integer, String> map = ConcurrentMaps.newWithExpectedEntries(256);
+        assertThat(map).isInstanceOf(ConcurrentHashMap.class).isEmpty();
+        assertThat(map.put(1, "1")).isNull();
+        assertThat(map.put(1, "one")).isEqualTo("1");
+        ConcurrentHashMap<Integer, String> chm = (ConcurrentHashMap<Integer, String>) map;
+        assertThat(chm.entrySet()).hasSize(1);
+        chm.put(2, "2");
+        assertThat(chm).hasSize(2).containsExactlyInAnyOrderEntriesOf(Map.of(1, "one", 2, "2"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    void contending(String name, int count, ConcurrentMap<Integer, String> map) throws Exception {
+        List<ListenableFuture<String>> futures = new ArrayList<>(count);
+        CountDownLatch latch = new CountDownLatch(Math.min(count, PROCESSORS));
+
+        for (int i = 0; i < count; i++) {
+            int j = i;
+            futures.add(executor.submit(() -> {
+                latch.countDown();
+                latch.await();
+                return map.put(j, Integer.toString(j));
+            }));
+        }
+
+        assertThat(Futures.allAsList(futures).get()).hasSize(count).allSatisfy(s -> assertThat(s)
+                .isNull());
+        assertThat(map).as("Map %s should have count entries", name).hasSize(count);
+    }
+
+    static Stream<Arguments> maps() {
+        return IntStream.of(0, 1, 128, 256, 1024, 1_048_576)
+                .boxed()
+                .flatMap(i -> Stream.of(
+                        Arguments.of("CHM(i)", i, new ConcurrentHashMap<>(i)),
+                        Arguments.of("CHM(i,.75," + PROCESSORS + ")", i, new ConcurrentHashMap<>(i, 0.75f, PROCESSORS)),
+                        Arguments.of("CM(0)", i, ConcurrentMaps.newWithExpectedEntries(0)),
+                        Arguments.of("CM(i / 8)", i, ConcurrentMaps.newWithExpectedEntries(i / 8)),
+                        Arguments.of("CM(i / 4)", i, ConcurrentMaps.newWithExpectedEntries(i / 4)),
+                        Arguments.of("CM(i / 2)", i, ConcurrentMaps.newWithExpectedEntries(i / 2)),
+                        Arguments.of("CM(i * .75)", i, ConcurrentMaps.newWithExpectedEntries(i * 3 / 4)),
+                        Arguments.of("CM(i * 4 / 3)", i, ConcurrentMaps.newWithExpectedEntries(i * 4 / 3)),
+                        Arguments.of("CM(1 + i * 4/3)", i, ConcurrentMaps.newWithExpectedEntries(1 + i * 4 / 3)),
+                        Arguments.of("CM(i)", i, ConcurrentMaps.newWithExpectedEntries(i)),
+                        Arguments.of("CHM()", i, new ConcurrentHashMap<>())));
+    }
+}

--- a/atlasdb-commons/src/test/java/com/palantir/common/concurrent/ConcurrentMapsTest.java
+++ b/atlasdb-commons/src/test/java/com/palantir/common/concurrent/ConcurrentMapsTest.java
@@ -18,23 +18,29 @@ package com.palantir.common.concurrent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ConcurrentMapsTest {
@@ -61,8 +67,24 @@ class ConcurrentMapsTest {
     }
 
     @ParameterizedTest
+    @CsvSource({
+        "0, 0, 1",
+        "1, 5, 8",
+        "10, 59, 64",
+        "16, 95, 128",
+        "100, 599, 1024",
+        "128, 767, 1024",
+        "256, 1535, 2048",
+        "1024, 6143, 8192",
+    })
+    void capacities(int elements, int expectedInitialCapacity, int expectedArraySize) {
+        assertThat(ConcurrentMaps.initialCapacity(elements)).isEqualTo(expectedInitialCapacity);
+        assertThat(ConcurrentMaps.expectedArraySize(expectedInitialCapacity)).isEqualTo(expectedArraySize);
+    }
+
+    @ParameterizedTest
     @MethodSource("maps")
-    void contending(String name, int count, ConcurrentMap<Integer, String> map) throws Exception {
+    void contending(String name, int count, Map<Integer, String> map) throws Exception {
         List<ListenableFuture<String>> futures = new ArrayList<>(count);
         CountDownLatch latch = new CountDownLatch(Math.min(count, PROCESSORS));
 
@@ -74,10 +96,17 @@ class ConcurrentMapsTest {
                 return map.put(j, Integer.toString(j));
             }));
         }
+        executor.shutdown();
+        assertThat(executor.awaitTermination(Duration.ofSeconds(10))).isTrue();
 
         assertThat(Futures.allAsList(futures).get()).hasSize(count).allSatisfy(s -> assertThat(s)
                 .isNull());
-        assertThat(map).as("Map %s should have count entries", name).hasSize(count);
+        assertThat(map)
+                .as("Map %s should have count entries", name)
+                .hasSize(count)
+                .containsExactlyInAnyOrderEntriesOf(IntStream.range(0, count)
+                        .boxed()
+                        .collect(Collectors.toMap(Function.identity(), Object::toString)));
     }
 
     static Stream<Arguments> maps() {
@@ -85,15 +114,9 @@ class ConcurrentMapsTest {
                 .boxed()
                 .flatMap(i -> Stream.of(
                         Arguments.of("CHM(i)", i, new ConcurrentHashMap<>(i)),
-                        Arguments.of("CHM(i,.75," + PROCESSORS + ")", i, new ConcurrentHashMap<>(i, 0.75f, PROCESSORS)),
                         Arguments.of("CM(0)", i, ConcurrentMaps.newWithExpectedEntries(0)),
-                        Arguments.of("CM(i / 8)", i, ConcurrentMaps.newWithExpectedEntries(i / 8)),
-                        Arguments.of("CM(i / 4)", i, ConcurrentMaps.newWithExpectedEntries(i / 4)),
-                        Arguments.of("CM(i / 2)", i, ConcurrentMaps.newWithExpectedEntries(i / 2)),
-                        Arguments.of("CM(i * .75)", i, ConcurrentMaps.newWithExpectedEntries(i * 3 / 4)),
-                        Arguments.of("CM(i * 4 / 3)", i, ConcurrentMaps.newWithExpectedEntries(i * 4 / 3)),
-                        Arguments.of("CM(1 + i * 4/3)", i, ConcurrentMaps.newWithExpectedEntries(1 + i * 4 / 3)),
                         Arguments.of("CM(i)", i, ConcurrentMaps.newWithExpectedEntries(i)),
-                        Arguments.of("CHM()", i, new ConcurrentHashMap<>())));
+                        Arguments.of("CHM()", i, new ConcurrentHashMap<>()),
+                        Arguments.of("SHM()", i, Collections.synchronizedMap(Maps.newHashMapWithExpectedSize(i)))));
     }
 }

--- a/changelog/@unreleased/pr-7117.v2.yml
+++ b/changelog/@unreleased/pr-7117.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce startup contention in Timelock ConcurrentHashMaps
+  links:
+  - https://github.com/palantir/atlasdb/pull/7117

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
@@ -16,18 +16,19 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
+import com.palantir.common.concurrent.ConcurrentMaps;
 import com.palantir.leader.BatchingLeaderElectionService;
 import com.palantir.leader.LeaderElectionServiceBuilder;
 import com.palantir.paxos.Client;
 import com.palantir.paxos.PaxosAcceptorNetworkClient;
 import com.palantir.paxos.PaxosProposer;
 import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class LeaderElectionServiceFactory {
 
-    private final Map<Client, BatchingLeaderElectionService> leaderElectionServicesByClient = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Client, BatchingLeaderElectionService> leaderElectionServicesByClient =
+            ConcurrentMaps.newWithExpectedEntries(/* expected clients */ 256);
 
     public BatchingLeaderElectionService create(Dependencies.LeaderElectionService dependencies) {
         return leaderElectionServicesByClient.computeIfAbsent(

--- a/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
+++ b/timelock-agent/src/main/java/com/palantir/atlasdb/timelock/paxos/LeaderElectionServiceFactory.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.timelock.paxos;
 
+import com.palantir.atlasdb.timelock.TimelockNamespaces;
 import com.palantir.common.concurrent.ConcurrentMaps;
 import com.palantir.leader.BatchingLeaderElectionService;
 import com.palantir.leader.LeaderElectionServiceBuilder;
@@ -28,7 +29,7 @@ import java.util.concurrent.ConcurrentMap;
 public class LeaderElectionServiceFactory {
 
     private final ConcurrentMap<Client, BatchingLeaderElectionService> leaderElectionServicesByClient =
-            ConcurrentMaps.newWithExpectedEntries(/* expected clients */ 256);
+            ConcurrentMaps.newWithExpectedEntries(TimelockNamespaces.estimatedClients());
 
     public BatchingLeaderElectionService create(Dependencies.LeaderElectionService dependencies) {
         return leaderElectionServicesByClient.computeIfAbsent(

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.timelock.paxos.PaxosTimeLockConstants;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.common.concurrent.ConcurrentMaps;
 import com.palantir.conjure.java.undertow.lib.RequestContext;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
@@ -31,7 +32,6 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.paxos.Client;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -57,8 +57,8 @@ public final class TimelockNamespaces {
 
     private static final SafeLogger log = SafeLoggerFactory.get(TimelockNamespaces.class);
 
-    // increase initial capacity to reduce contention at startup
-    private final ConcurrentMap<String, TimeLockServices> services = new ConcurrentHashMap<>(1024);
+    private final ConcurrentMap<String, TimeLockServices> services =
+            ConcurrentMaps.newWithExpectedEntries(/* expected clients */ 256);
     private final Function<String, TimeLockServices> factory;
     private final Supplier<Integer> maxNumberOfClients;
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
@@ -58,7 +58,7 @@ public final class TimelockNamespaces {
     private static final SafeLogger log = SafeLoggerFactory.get(TimelockNamespaces.class);
 
     private final ConcurrentMap<String, TimeLockServices> services =
-            ConcurrentMaps.newWithExpectedEntries(/* expected clients */ 256);
+            ConcurrentMaps.newWithExpectedEntries(estimatedClients());
     private final Function<String, TimeLockServices> factory;
     private final Supplier<Integer> maxNumberOfClients;
 
@@ -67,6 +67,13 @@ public final class TimelockNamespaces {
         this.factory = factory;
         this.maxNumberOfClients = maxNumberOfClients;
         registerClientCapacityMetrics(metrics);
+    }
+
+    /**
+     * Returns an estimated number of time-lock clients.
+     */
+    public static int estimatedClients() {
+        return 256;
     }
 
     /**

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
@@ -57,7 +57,8 @@ public final class TimelockNamespaces {
 
     private static final SafeLogger log = SafeLoggerFactory.get(TimelockNamespaces.class);
 
-    private final ConcurrentMap<String, TimeLockServices> services = new ConcurrentHashMap<>();
+    // increase initial capacity to reduce contention at startup
+    private final ConcurrentMap<String, TimeLockServices> services = new ConcurrentHashMap<>(1024);
     private final Function<String, TimeLockServices> factory;
     private final Supplier<Integer> maxNumberOfClients;
 
@@ -82,7 +83,7 @@ public final class TimelockNamespaces {
 
     /**
      * Gets the TimeLockServices for a given namespace.
-     *
+     * <p>
      * Should be best-effort to give a UserAgent - it's possible with Undertow interfaces but not
      * server-side Jersey interfaces (which are just used in tests)
      */

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Counter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.palantir.atlasdb.AtlasDbMetricNames;
+import com.palantir.atlasdb.timelock.TimelockNamespaces;
 import com.palantir.atlasdb.timelock.management.DiskNamespaceLoader;
 import com.palantir.atlasdb.timelock.management.PersistentNamespaceLoader;
 import com.palantir.common.concurrent.ConcurrentMaps;
@@ -64,7 +65,7 @@ public class LocalPaxosComponents {
     private final DataSource sqliteDataSource;
     private final UUID leaderUuid;
     private final Map<Client, Components> componentsByClient =
-            ConcurrentMaps.newWithExpectedEntries(/* expected clients */ 256);
+            ConcurrentMaps.newWithExpectedEntries(TimelockNamespaces.estimatedClients());
     private final Supplier<BatchPaxosAcceptor> memoizedBatchAcceptor;
     private final Supplier<BatchPaxosLearner> memoizedBatchLearner;
     private final Supplier<BatchPingableLeader> memoizedBatchPingableLeader;

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -63,7 +63,8 @@ public class LocalPaxosComponents {
     private final Path baseLogDirectory;
     private final DataSource sqliteDataSource;
     private final UUID leaderUuid;
-    private final Map<Client, Components> componentsByClient = new ConcurrentHashMap<>();
+    // increase initial capacity to reduce contention at startup
+    private final Map<Client, Components> componentsByClient = new ConcurrentHashMap<>(1024);
     private final Supplier<BatchPaxosAcceptor> memoizedBatchAcceptor;
     private final Supplier<BatchPaxosLearner> memoizedBatchLearner;
     private final Supplier<BatchPingableLeader> memoizedBatchPingableLeader;

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/paxos/LocalPaxosComponents.java
@@ -21,6 +21,7 @@ import com.google.common.base.Suppliers;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.timelock.management.DiskNamespaceLoader;
 import com.palantir.atlasdb.timelock.management.PersistentNamespaceLoader;
+import com.palantir.common.concurrent.ConcurrentMaps;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.remoting.ServiceNotAvailableException;
 import com.palantir.leader.LocalPingableLeader;
@@ -48,7 +49,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import javax.sql.DataSource;
@@ -63,8 +63,8 @@ public class LocalPaxosComponents {
     private final Path baseLogDirectory;
     private final DataSource sqliteDataSource;
     private final UUID leaderUuid;
-    // increase initial capacity to reduce contention at startup
-    private final Map<Client, Components> componentsByClient = new ConcurrentHashMap<>(1024);
+    private final Map<Client, Components> componentsByClient =
+            ConcurrentMaps.newWithExpectedEntries(/* expected clients */ 256);
     private final Supplier<BatchPaxosAcceptor> memoizedBatchAcceptor;
     private final Supplier<BatchPaxosLearner> memoizedBatchLearner;
     private final Supplier<BatchPingableLeader> memoizedBatchPingableLeader;


### PR DESCRIPTION
## General
**Before this PR**:

Timelock service is seeing contention on startup when initializing timelock clients.

From https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java#L348-L349

> Lock contention probability for two threads accessing distinct elements is roughly 1 / (8 * #elements) under random hashes.

![image](https://github.com/palantir/atlasdb/assets/54594/2d0e8054-1856-49f0-ac26-c1fdc7e0bf0c)


**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Reduce startup contention in Timelock ConcurrentHashMaps
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
