### PR TITLE
[PDS-543497] Permit 2 DC setups where one of the DCs has less than expected replication

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -37,6 +37,7 @@ import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
 import com.palantir.logsafe.DoNotLog;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
@@ -45,9 +46,11 @@ import com.palantir.util.io.AvailabilityRequirement;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.cassandra.thrift.EndpointDetails;
 import org.apache.cassandra.thrift.InvalidRequestException;
 import org.apache.cassandra.thrift.KsDef;
@@ -385,8 +388,10 @@ public final class CassandraVerifier {
             Set<String> dcs,
             Map<String, String> strategyOptions,
             boolean ignoreDatacenterConfigurationChecks) {
-        for (String datacenter : dcs) {
-            if (Integer.parseInt(strategyOptions.get(datacenter)) != replicationFactor) {
+        boolean allDatacentersMatchAdvertisedReplicationFactor = dcs.stream()
+                .allMatch(datacenter -> Integer.parseInt(strategyOptions.get(datacenter)) == replicationFactor);
+        if (!allDatacentersMatchAdvertisedReplicationFactor) {
+            if (!isValidMigrationReplicationFactorState(replicationFactor, dcs, strategyOptions)) {
                 logErrorOrThrow(
                         "Your current Cassandra keyspace (" + ks.getName()
                                 + ") has a replication factor not matching your Atlas Cassandra configuration."
@@ -395,6 +400,26 @@ public final class CassandraVerifier {
                         ignoreDatacenterConfigurationChecks);
             }
         }
+    }
+
+    /**
+     * Our internal implementation of DC migrations typically involve an intermediate state with two DCs, where one
+     * has the provided replication factor, and the other has a replication factor that may be less than the provided
+     * replication factor. We thus permit situations where there are exactly two DCs, and one DC agrees with the
+     * expected replication factor while the other DC has a replication factor smaller than the expected.
+     */
+    private static boolean isValidMigrationReplicationFactorState(
+            int replicationFactor, Set<String> dcs, Map<String, String> strategyOptions) {
+        if (dcs.size() != 2) {
+            return false;
+        }
+        List<Integer> dcSizes = dcs.stream()
+                .map(dc -> Integer.parseInt(strategyOptions.get(dc)))
+                .sorted()
+                .collect(Collectors.toList());
+        Preconditions.checkState(dcSizes.size() == 2, "Expected to get size for each datacenter");
+        // The list is sorted, so the other DC must have a replication factor <= our expected DC.
+        return dcSizes.get(1) == replicationFactor;
     }
 
     @DoNotLog

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifier.java
@@ -391,7 +391,13 @@ public final class CassandraVerifier {
         boolean allDatacentersMatchAdvertisedReplicationFactor = dcs.stream()
                 .allMatch(datacenter -> Integer.parseInt(strategyOptions.get(datacenter)) == replicationFactor);
         if (!allDatacentersMatchAdvertisedReplicationFactor) {
-            if (!isValidMigrationReplicationFactorState(replicationFactor, dcs, strategyOptions)) {
+            if (isValidMigrationReplicationFactorState(replicationFactor, dcs, strategyOptions)) {
+                log.info(
+                        "Your current Cassandra keyspace had two datacenters with different replication factors, where"
+                            + " the higher replication factor matched expected. This is a valid migration state, hence"
+                            + " allowing it.",
+                        SafeArg.of("keyspace", ks.getName()));
+            } else {
                 logErrorOrThrow(
                         "Your current Cassandra keyspace (" + ks.getName()
                                 + ") has a replication factor not matching your Atlas Cassandra configuration."

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -363,7 +363,7 @@ public class CassandraVerifierTest {
         KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
         ksDef.setStrategy_options(ImmutableMap.of(DC_1, "3", DC_2, "3", DC_3, "3"));
         assertThatCode(() -> CassandraVerifier.sanityCheckReplicationFactor(
-                ksDef, ImmutableSortedSet.of(DC_1, DC_2, DC_3), verifierConfig))
+                        ksDef, ImmutableSortedSet.of(DC_1, DC_2, DC_3), verifierConfig))
                 .doesNotThrowAnyException();
     }
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -362,9 +362,9 @@ public class CassandraVerifierTest {
                 .build();
         KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
         ksDef.setStrategy_options(ImmutableMap.of(DC_1, "3", DC_2, "3", DC_3, "3"));
-        assertThatThrownBy(() -> CassandraVerifier.sanityCheckReplicationFactor(
-                        ksDef, ImmutableSortedSet.of(DC_1, DC_2, DC_3), verifierConfig))
-                .isInstanceOf(IllegalStateException.class);
+        assertThatCode(() -> CassandraVerifier.sanityCheckReplicationFactor(
+                ksDef, ImmutableSortedSet.of(DC_1, DC_2, DC_3), verifierConfig))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraVerifierTest.java
@@ -43,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class CassandraVerifierTest {
     private static final String DC_1 = "dc1";
     private static final String DC_2 = "dc2";
+    private static final String DC_3 = "dc3";
     private static final String HOST_1 = "host1";
     private static final String HOST_2 = "host2";
     private static final String HOST_3 = "host3";
@@ -263,15 +264,106 @@ public class CassandraVerifierTest {
     }
 
     @Test
-    public void differentRfThanConfigThrows() {
+    public void oneDcMatchingRfDoesNotThrow() {
         CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults()
-                .replicationFactor(1)
+                .replicationFactor(3)
                 .ignoreDatacenterConfigurationChecks(false)
                 .build();
         KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
-        ksDef.setStrategy_options(ImmutableMap.of(DC_1, "1", DC_2, "2"));
+        ksDef.setStrategy_options(ImmutableMap.of(DC_1, "3"));
+        assertThatCode(() -> CassandraVerifier.sanityCheckReplicationFactor(
+                        ksDef, ImmutableSortedSet.of(DC_1), verifierConfig))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void oneDcNotMatchingRfThrows() {
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults()
+                .replicationFactor(3)
+                .ignoreDatacenterConfigurationChecks(false)
+                .build();
+        KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
+        ksDef.setStrategy_options(ImmutableMap.of(DC_1, "2"));
+        assertThatThrownBy(() -> CassandraVerifier.sanityCheckReplicationFactor(
+                        ksDef, ImmutableSortedSet.of(DC_1), verifierConfig))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void twoDcsWithBothMatchingRfDoesNotThrow() {
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults()
+                .replicationFactor(3)
+                .ignoreDatacenterConfigurationChecks(false)
+                .build();
+        KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
+        ksDef.setStrategy_options(ImmutableMap.of(DC_1, "3", DC_2, "3"));
+        assertThatCode(() -> CassandraVerifier.sanityCheckReplicationFactor(
+                        ksDef, ImmutableSortedSet.of(DC_1, DC_2), verifierConfig))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void twoDcsWithNeitherMatchingRfThrows() {
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults()
+                .replicationFactor(3)
+                .ignoreDatacenterConfigurationChecks(false)
+                .build();
+        KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
+        ksDef.setStrategy_options(ImmutableMap.of(DC_1, "2", DC_2, "1"));
         assertThatThrownBy(() -> CassandraVerifier.sanityCheckReplicationFactor(
                         ksDef, ImmutableSortedSet.of(DC_1, DC_2), verifierConfig))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void twoDcsWithOneMatchingRfAndOneHavingSmallerRfThanConfigDoesNotThrow() {
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults()
+                .replicationFactor(3)
+                .ignoreDatacenterConfigurationChecks(false)
+                .build();
+        KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
+        ksDef.setStrategy_options(ImmutableMap.of(DC_1, "3", DC_2, "1"));
+        assertThatCode(() -> CassandraVerifier.sanityCheckReplicationFactor(
+                        ksDef, ImmutableSortedSet.of(DC_1, DC_2), verifierConfig))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void twoDcsWithOneMatchingRfAndOneHavingLargerRfThanConfigThrows() {
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults()
+                .replicationFactor(3)
+                .ignoreDatacenterConfigurationChecks(false)
+                .build();
+        KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
+        ksDef.setStrategy_options(ImmutableMap.of(DC_1, "3", DC_2, "5"));
+        assertThatThrownBy(() -> CassandraVerifier.sanityCheckReplicationFactor(
+                        ksDef, ImmutableSortedSet.of(DC_1, DC_2), verifierConfig))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void multipleDcsWithRfMismatchThrows() {
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults()
+                .replicationFactor(3)
+                .ignoreDatacenterConfigurationChecks(false)
+                .build();
+        KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
+        ksDef.setStrategy_options(ImmutableMap.of(DC_1, "3", DC_2, "3", DC_3, "2"));
+        assertThatThrownBy(() -> CassandraVerifier.sanityCheckReplicationFactor(
+                        ksDef, ImmutableSortedSet.of(DC_1, DC_2, DC_3), verifierConfig))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void multipleDcsWithAllMatchingProvidedRfDoesNotThrow() {
+        CassandraVerifierConfig verifierConfig = getVerifierConfigBuilderWithDefaults()
+                .replicationFactor(3)
+                .ignoreDatacenterConfigurationChecks(false)
+                .build();
+        KsDef ksDef = new KsDef("test", CassandraConstants.SIMPLE_STRATEGY, ImmutableList.of());
+        ksDef.setStrategy_options(ImmutableMap.of(DC_1, "3", DC_2, "3", DC_3, "3"));
+        assertThatThrownBy(() -> CassandraVerifier.sanityCheckReplicationFactor(
+                        ksDef, ImmutableSortedSet.of(DC_1, DC_2, DC_3), verifierConfig))
                 .isInstanceOf(IllegalStateException.class);
     }
 

--- a/changelog/@unreleased/pr-7133.v2.yml
+++ b/changelog/@unreleased/pr-7133.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Atlas now permits situations where in a two-DC set-up we have two clusters,
+    where one matches the expected RF and one has an RF smaller than the expected
+    RF.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7133

--- a/changelog/@unreleased/pr-7133.v2.yml
+++ b/changelog/@unreleased/pr-7133.v2.yml
@@ -1,7 +1,7 @@
 type: fix
 fix:
-  description: Atlas now permits situations where in a two-DC set-up we have two clusters,
-    where one matches the expected RF and one has an RF smaller than the expected
-    RF.
+  description: AtlasDB now permits situations where in a two-DC set-up we have two
+    clusters, where one matches the expected RF and one has an RF smaller than the
+    expected RF. This is a normal intermediate state of the cluster during DC migrations.
   links:
   - https://github.com/palantir/atlasdb/pull/7133


### PR DESCRIPTION
## General
**Before this PR**: Atlas fails its Cassandra topology checks if replication in _any_ of the advertised datacenters does not match. This includes a legitimate situation that we encounter in our internal implementation of DC migrations, where we increase/decrease the RFs of the new/old cluster incrementally, rather than all at once.

**After this PR**:
==COMMIT_MSG==
Atlas now permits situations where in a two-DC set-up we have two clusters, where one matches the expected RF and one has an RF smaller than the expected RF.
==COMMIT_MSG==

**Priority**: High P2, blocks migrations

**Concerns / possible downsides (what feedback would you like?)**:
- Is this too permissive? Should I only have permitted "3 and 1"? I viewed not requiring clients to configure anything as a must for this PR. (To my knowledge we have no setups that don't use RF = 3 that would go through the DC migration.)
- On the other hand, is this too strict? Should I have handled cases where you have N datacenters, N - 1 are in agreement and the N-1th has an RF lower than the expected? (To my knowledge we don't have any setups that run with more than one DC in the steady state.)
- There's an argument for rewriting the current `IllegalStateException` to use `SafeIllegalStateException`, though given urgency I did not want to spend time checking all possible inputs to this were compile time constants and/or fixing where required.

**Is documentation needed?**: I don't think so.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes, old versions just will still flag this intermediate state as hazardous

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: Cassandra DC migrations stick to the current procedure.

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That we generally only run our Cassandra clusters with one DC.

**What was existing testing like? What have you done to improve it?**: Added new tests for the new (unfortunately more complex logic)

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: It doesn't

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: It doesn't

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: We might see a new log line in this state.

**Has the safety of all log arguments been decided correctly?**: Yeah, keyspace comes from config so is safe.

**Will this change significantly affect our spending on metrics or logs?**: I don't think so.

**How would I tell that this PR does not work in production? (monitors, etc.)**: We still have failures in this 3-and-1 state.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Yes, if we change the migration process. I imagine tests of the new migration process would flush this out.

## Development Process
**Where should we start reviewing?**: CassandraVerifier. Most of this is tests, honestly.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
