### PR TITLE
TKVSM initialization handles when runtimeConfig is provided as a Supplier

### DIFF
--- a/changelog/@unreleased/pr-7134.v2.yml
+++ b/changelog/@unreleased/pr-7134.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: TKVSM initialization handles when runtimeConfig is provided as a Supplier
+  links:
+  - https://github.com/palantir/atlasdb/pull/7134


### PR DESCRIPTION
## General
**Before this PR**:
TransactionKeyValueServiceManager initialization assumes that the Atlas runtime config is provided as a `Refreshable`.
We also support users providing the config as a `Supplier` under the `runtimeConfigSupplier` field.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
This PR properly handles TKVSM initialization when the runtime config is passed using `runtimeConfigSupplier`. It is already asserted elsewhere that runtimeConfig XOR runtimeConfigSupplier is present.
==COMMIT_MSG==
TKVSM initialization handles when runtimeConfig is provided as a Supplier
==COMMIT_MSG==

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@jkozlowski 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
