### PR TITLE
DefaultOrphanedSentinelDeleter takes a SweepStrategyManager

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultOrphanedSentinelDeleter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/DefaultOrphanedSentinelDeleter.java
@@ -19,21 +19,18 @@ package com.palantir.atlasdb.transaction.impl;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
-import com.palantir.atlasdb.table.description.SweepStrategy;
 import com.palantir.atlasdb.table.description.SweeperStrategy;
 import com.palantir.atlasdb.transaction.api.OrphanedSentinelDeleter;
 import com.palantir.common.streams.KeyedStream;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
 public final class DefaultOrphanedSentinelDeleter implements OrphanedSentinelDeleter {
-    private final Function<TableReference, SweepStrategy> sweepStrategyProvider;
+    private final SweepStrategyManager sweepStrategyManager;
     private final DeleteExecutor deleteExecutor;
 
-    public DefaultOrphanedSentinelDeleter(
-            Function<TableReference, SweepStrategy> sweepStrategyProvider, DeleteExecutor deleteExecutor) {
-        this.sweepStrategyProvider = sweepStrategyProvider;
+    public DefaultOrphanedSentinelDeleter(SweepStrategyManager sweepStrategyManager, DeleteExecutor deleteExecutor) {
+        this.sweepStrategyManager = sweepStrategyManager;
         this.deleteExecutor = deleteExecutor;
     }
 
@@ -42,8 +39,8 @@ public final class DefaultOrphanedSentinelDeleter implements OrphanedSentinelDel
         if (orphanedSentinels.isEmpty()) {
             return;
         }
-        boolean tableIsKnownToBeThoroughlySwept = sweepStrategyProvider
-                .apply(tableReference)
+        boolean tableIsKnownToBeThoroughlySwept = sweepStrategyManager
+                .get(tableReference)
                 .getSweeperStrategy()
                 .map(sweeperStrategy -> sweeperStrategy == SweeperStrategy.THOROUGH)
                 .orElse(false);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -402,7 +402,7 @@ public class SnapshotTransaction extends AbstractTransaction
                 transactionKeyValueService,
                 transactionService,
                 readSentinelBehavior,
-                new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor));
+                new DefaultOrphanedSentinelDeleter(sweepStrategyManager, deleteExecutor));
         this.keyValueSnapshotReader = new DefaultKeyValueSnapshotReader(
                 transactionKeyValueService,
                 transactionService,


### PR DESCRIPTION
1. #7135 
2. #7136 
3. #7137 
4. #7138

## General
**Before this PR**:
DefaultOrphanedSentinelDeleter takes a Function argument, when it could just be taking the FunctionalInterface SweepStrategyManager.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
DefaultOrphanedSentinelDeleter takes a SweepStrategyManager
==COMMIT_MSG==

@jeremyk-91
@jkozlowski 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
