### PR TITLE
wire up KeyValueSnapshotReaderManager

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -551,7 +551,7 @@ public abstract class TransactionManagers {
                 createClearsTable(internalKeyValueService)));
 
         DeleteExecutor deleteExecutor = DefaultDeleteExecutor.createDefault(internalKeyValueService);
-        createKeyValueSnapshotReaderManager(
+        KeyValueSnapshotReaderManager keyValueSnapshotReaderManager = createKeyValueSnapshotReaderManager(
                 transactionKeyValueServiceManager,
                 transactionService,
                 sweepStrategyManager,
@@ -586,7 +586,8 @@ public abstract class TransactionManagers {
                         metricsFilterEvaluationContext(),
                         installConfig.sharedResourcesConfig().map(SharedResourcesConfig::sharedGetRangesPoolSize),
                         knowledge,
-                        deleteExecutor),
+                        deleteExecutor,
+                        keyValueSnapshotReaderManager),
                 closeables);
 
         transactionManager.registerClosingCallback(runtimeConfigRefreshable::close);

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.services;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.cache.DefaultTimestampCache;
+import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.cleaner.Follower;
@@ -37,9 +38,11 @@ import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.DefaultDeleteExecutor;
+import com.palantir.atlasdb.transaction.impl.DefaultOrphanedSentinelDeleter;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.metrics.DefaultMetricsFilterEvaluationContext;
+import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -119,10 +122,16 @@ public class TransactionManagerModule {
             Cleaner cleaner,
             @Internal DerivedSnapshotConfig derivedSnapshotConfig,
             TransactionKnowledgeComponents knowledge) {
+        TransactionKeyValueServiceManager transactionKeyValueServiceManager =
+                new DelegatingTransactionKeyValueServiceManager(kvs);
+        DefaultDeleteExecutor deleteExecutor = new DefaultDeleteExecutor(
+                kvs,
+                Executors.newSingleThreadExecutor(
+                        new NamedThreadFactory(TransactionManagerModule.class + "-delete-executor", true)));
         // todo(gmaretic): should this be using a real sweep queue?
         return new SerializableTransactionManager(
                 metricsManager,
-                new DelegatingTransactionKeyValueServiceManager(kvs),
+                transactionKeyValueServiceManager,
                 lts.timelock(),
                 lts.lockWatcher(),
                 lts.managedTimestampService(),
@@ -138,15 +147,18 @@ public class TransactionManagerModule {
                 derivedSnapshotConfig.concurrentGetRangesThreadPoolSize(),
                 derivedSnapshotConfig.defaultGetRangesConcurrency(),
                 MultiTableSweepQueueWriter.NO_OP,
-                new DefaultDeleteExecutor(
-                        kvs,
-                        Executors.newSingleThreadExecutor(
-                                new NamedThreadFactory(TransactionManagerModule.class + "-delete-executor", true))),
+                deleteExecutor,
                 true,
                 () -> config.atlasDbRuntimeConfig().transaction(),
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                new DefaultKeyValueSnapshotReaderManager(
+                        transactionKeyValueServiceManager,
+                        transactionService,
+                        config.allowAccessToHiddenTables(),
+                        new DefaultOrphanedSentinelDeleter(sweepStrategyManager, deleteExecutor),
+                        deleteExecutor));
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException;
 import com.palantir.atlasdb.transaction.api.annotations.ReviewedRestrictedApiUsage;
 import com.palantir.atlasdb.transaction.api.exceptions.MoreCellsPresentThanExpectedException;
+import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -170,6 +171,7 @@ public class SerializableTransaction extends SnapshotTransaction {
             ConflictTracer conflictTracer,
             TableLevelMetricsController tableLevelMetricsController,
             TransactionKnowledgeComponents knowledge,
+            KeyValueSnapshotReaderManager keyValueSnapshotReaderManager,
             CommitTimestampLoader commitTimestampLoader) {
         super(
                 metricsManager,
@@ -198,6 +200,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                 conflictTracer,
                 tableLevelMetricsController,
                 knowledge,
+                keyValueSnapshotReaderManager,
                 commitTimestampLoader);
     }
 
@@ -937,6 +940,7 @@ public class SerializableTransaction extends SnapshotTransaction {
                 conflictTracer,
                 tableLevelMetricsController,
                 knowledge,
+                keyValueSnapshotReaderManager,
                 new ReadValidationCommitTimestampLoader(
                         commitTimestampLoader, getTimestamp(), commitTs, transactionOutcomeMetrics)) {
             @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -109,7 +109,9 @@ import com.palantir.atlasdb.transaction.api.metrics.KeyValueSnapshotMetricRecord
 import com.palantir.atlasdb.transaction.api.precommit.PreCommitRequirementValidator;
 import com.palantir.atlasdb.transaction.api.precommit.ReadSnapshotValidator;
 import com.palantir.atlasdb.transaction.api.precommit.ReadSnapshotValidator.ValidationState;
+import com.palantir.atlasdb.transaction.api.snapshot.ImmutableTransactionContext;
 import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReader;
+import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.expectations.ExpectationsMetrics;
 import com.palantir.atlasdb.transaction.impl.ImmutableTimestampLockManager.SummarizedLockCheckResult;
 import com.palantir.atlasdb.transaction.impl.expectations.CellCountValidator;
@@ -123,7 +125,6 @@ import com.palantir.atlasdb.transaction.impl.metrics.TransactionOutcomeMetrics;
 import com.palantir.atlasdb.transaction.impl.precommit.DefaultLockValidityChecker;
 import com.palantir.atlasdb.transaction.impl.precommit.DefaultPreCommitRequirementValidator;
 import com.palantir.atlasdb.transaction.impl.precommit.DefaultReadSnapshotValidator;
-import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReader;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.AsyncTransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -317,6 +318,7 @@ public class SnapshotTransaction extends AbstractTransaction
     private final KeyValueSnapshotMetricRecorder snapshotEventRecorder;
     private final ReadSentinelHandler readSentinelHandler;
     private final KeyValueSnapshotReader keyValueSnapshotReader;
+    protected final KeyValueSnapshotReaderManager keyValueSnapshotReaderManager;
 
     /**
      * @param immutableTimestamp If we find a row written before the immutableTimestamp we don't need to grab a read
@@ -350,6 +352,7 @@ public class SnapshotTransaction extends AbstractTransaction
             ConflictTracer conflictTracer,
             TableLevelMetricsController tableLevelMetricsController,
             TransactionKnowledgeComponents knowledge,
+            KeyValueSnapshotReaderManager keyValueSnapshotReaderManager,
             CommitTimestampLoader commitTimestampLoader) {
         this.metricsManager = metricsManager;
         this.lockWatchManager = lockWatchManager;
@@ -404,16 +407,19 @@ public class SnapshotTransaction extends AbstractTransaction
                 transactionService,
                 readSentinelBehavior,
                 new DefaultOrphanedSentinelDeleter(sweepStrategyManager, deleteExecutor));
-        this.keyValueSnapshotReader = new DefaultKeyValueSnapshotReader(
-                transactionKeyValueService,
-                transactionService,
-                commitTimestampLoader,
-                allowHiddenTableAccess,
-                readSentinelHandler,
-                startTimestamp,
-                readSnapshotValidator,
-                deleteExecutor,
-                snapshotEventRecorder);
+        this.keyValueSnapshotReaderManager = keyValueSnapshotReaderManager;
+        this.keyValueSnapshotReader = getDefaultKeyValueSnapshotReader();
+    }
+
+    private KeyValueSnapshotReader getDefaultKeyValueSnapshotReader() {
+        return keyValueSnapshotReaderManager.createKeyValueSnapshotReader(ImmutableTransactionContext.builder()
+                .startTimestampSupplier(startTimestamp)
+                .transactionReadSentinelBehavior(TransactionReadSentinelBehavior.THROW_EXCEPTION)
+                .commitTimestampLoader(commitTimestampLoader)
+                .preCommitRequirementValidator(preCommitRequirementValidator)
+                .readSnapshotValidator(readSnapshotValidator)
+                .keyValueSnapshotMetricRecorder(snapshotEventRecorder)
+                .build());
     }
 
     protected TransactionScopedCache getCache() {

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -177,6 +177,7 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 ConflictTracer.NO_OP,
                 new SimpleTableLevelMetricsController(metricsManager),
                 knowledge,
+                keyValueSnapshotReaderManager,
                 commitTimestampLoaderFactory.createCommitTimestampLoader(
                         startTimestampSupplier, 0L, options.immutableLockToken)) {
             @Override

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -35,6 +35,7 @@ import com.palantir.atlasdb.transaction.api.DeleteExecutor;
 import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.impl.metrics.DefaultMetricsFilterEvaluationContext;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -66,7 +67,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             TimestampCache timestampCache,
             MultiTableSweepQueueWriter sweepQueue,
             TransactionKnowledgeComponents knowledge,
-            DeleteExecutor deleteExecutor) {
+            DeleteExecutor deleteExecutor,
+            KeyValueSnapshotReaderManager keyValueSnapshotReaderManager) {
         this(
                 metricsManager,
                 keyValueService,
@@ -79,7 +81,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 sweepQueue,
                 deleteExecutor,
                 WrapperWithTracker.TRANSACTION_NO_OP,
-                knowledge);
+                knowledge,
+                keyValueSnapshotReaderManager);
     }
 
     public TestTransactionManagerImpl(
@@ -94,7 +97,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             MultiTableSweepQueueWriter sweepQueue,
             DeleteExecutor deleteExecutor,
             WrapperWithTracker<CallbackAwareTransaction> transactionWrapper,
-            TransactionKnowledgeComponents knowledge) {
+            TransactionKnowledgeComponents knowledge,
+            KeyValueSnapshotReaderManager keyValueSnapshotReaderManager) {
         this(
                 metricsManager,
                 createAssertKeyValue(keyValueService, lockService),
@@ -107,7 +111,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 sweepQueue,
                 deleteExecutor,
                 transactionWrapper,
-                knowledge);
+                knowledge,
+                keyValueSnapshotReaderManager);
     }
 
     private TestTransactionManagerImpl(
@@ -122,7 +127,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             MultiTableSweepQueueWriter sweepQueue,
             DeleteExecutor deleteExecutor,
             WrapperWithTracker<CallbackAwareTransaction> transactionWrapper,
-            TransactionKnowledgeComponents knowledge) {
+            TransactionKnowledgeComponents knowledge,
+            KeyValueSnapshotReaderManager keyValueSnapshotReaderManager) {
         super(
                 metricsManager,
                 keyValueService,
@@ -146,7 +152,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                keyValueSnapshotReaderManager);
         this.transactionWrapper = transactionWrapper;
     }
 
@@ -205,6 +212,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         ConflictTracer.NO_OP,
                         tableLevelMetricsController,
                         knowledge,
+                        keyValueSnapshotReaderManager,
                         commitTimestampLoaderFactory.createCommitTimestampLoader(
                                 startTimestampSupplier, immutableTimestamp, Optional.of(immutableTsLock))),
                 pathTypeTracker);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -31,15 +31,18 @@ import com.palantir.atlasdb.sweep.queue.SpecialTimestampsSupplier;
 import com.palantir.atlasdb.sweep.queue.TargetedSweeper;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.DeleteExecutor;
+import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.impl.CachingTestTransactionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
 import com.palantir.atlasdb.transaction.impl.DefaultDeleteExecutor;
+import com.palantir.atlasdb.transaction.impl.DefaultOrphanedSentinelDeleter;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
 import com.palantir.atlasdb.transaction.impl.TestTransactionManager;
 import com.palantir.atlasdb.transaction.impl.TestTransactionManagerImpl;
 import com.palantir.atlasdb.transaction.impl.TransactionTables;
+import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
@@ -79,6 +82,7 @@ public class AtlasDbTestCase {
 
     protected TransactionKnowledgeComponents knowledge;
     protected DeleteExecutor deleteExecutor;
+    protected KeyValueSnapshotReaderManager keyValueSnapshotReaderManager;
 
     @RegisterExtension
     public InMemoryTimelockExtension inMemoryTimelockExtension = new InMemoryTimelockExtension(CLIENT);
@@ -98,6 +102,12 @@ public class AtlasDbTestCase {
         sweepQueue = spy(TargetedSweeper.createUninitializedForTest(keyValueService, () -> sweepQueueShards));
         knowledge = TransactionKnowledgeComponents.createForTests(keyValueService, metricsManager.getTaggedRegistry());
         deleteExecutor = new DefaultDeleteExecutor(keyValueService, MoreExecutors.newDirectExecutorService());
+        keyValueSnapshotReaderManager = new DefaultKeyValueSnapshotReaderManager(
+                txnKeyValueServiceManager,
+                transactionService,
+                false,
+                new DefaultOrphanedSentinelDeleter(sweepStrategyManager, deleteExecutor),
+                deleteExecutor);
         setUpTransactionManagers();
         sweepQueue.initialize(serializableTxManager);
         sweepTimestampSupplier = new SpecialTimestampsSupplier(
@@ -126,7 +136,8 @@ public class AtlasDbTestCase {
                 DefaultTimestampCache.createForTests(),
                 sweepQueue,
                 knowledge,
-                deleteExecutor);
+                deleteExecutor,
+                keyValueSnapshotReaderManager);
     }
 
     protected KeyValueService getBaseKeyValueService() {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
@@ -178,7 +178,8 @@ public class CommitLockTest extends TransactionTestSetup {
                 timestampCache,
                 MultiTableSweepQueueWriter.NO_OP,
                 knowledge,
-                deleteExecutor);
+                deleteExecutor,
+                keyValueSnapshotReaderManager);
         transactionManager.overrideConflictHandlerForTable(TEST_TABLE, conflictHandler);
         return transactionManager;
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -269,7 +269,8 @@ public class TransactionManagerTest extends TransactionTestSetup {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                keyValueSnapshotReaderManager);
 
         when(timelock.getFreshTimestamp()).thenReturn(1L);
         when(timelock.lockImmutableTimestamp())


### PR DESCRIPTION
1. #7135 
2. #7136 
3. #7137 
4. #7138

## General
**Before this PR**:
KeyValueSnapshotReaderManager created but not actually used by Snapshot/Serializable transaction. 

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
wire up KeyValueSnapshotReaderManager
==COMMIT_MSG==

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@jkozlowski 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
