### PR TITLE
[KeyValueSnapshotReaderManager] Part 2: Wire up KeyValueSnapshotReaderManager

### DIFF
--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -540,6 +540,9 @@ public abstract class TransactionManagers {
                 asyncInitializationCallback(),
                 createClearsTable(internalKeyValueService)));
 
+        KeyValueSnapshotReaderManager keyValueSnapshotReaderManager = createKeyValueSnapshotReaderManager(
+                transactionKeyValueServiceManager, transactionService, sweepStrategyManager, metricsManager);
+
         TransactionManager transactionManager = initializeCloseable(
                 () -> SerializableTransactionManager.createInstrumented(
                         metricsManager,
@@ -567,7 +570,8 @@ public abstract class TransactionManagers {
                         conflictTracer,
                         metricsFilterEvaluationContext(),
                         installConfig.sharedResourcesConfig().map(SharedResourcesConfig::sharedGetRangesPoolSize),
-                        knowledge),
+                        knowledge,
+                        keyValueSnapshotReaderManager),
                 closeables);
 
         transactionManager.registerClosingCallback(runtimeConfigRefreshable::close);
@@ -605,7 +609,6 @@ public abstract class TransactionManagers {
         return transactionManager;
     }
 
-    @SuppressWarnings("unused") // todo(rhuffman): wire up in a follow up PR
     private KeyValueSnapshotReaderManager createKeyValueSnapshotReaderManager(
             TransactionKeyValueServiceManager transactionKeyValueServiceManager,
             TransactionService transactionService,

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.services.test;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.cache.DefaultTimestampCache;
+import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.cleaner.Follower;
@@ -38,9 +39,11 @@ import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.DefaultDeleteExecutor;
+import com.palantir.atlasdb.transaction.impl.DefaultOrphanedSentinelDeleter;
 import com.palantir.atlasdb.transaction.impl.SerializableTransactionManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.metrics.DefaultMetricsFilterEvaluationContext;
+import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -120,6 +123,10 @@ public class TestTransactionManagerModule {
             Cleaner cleaner,
             @Internal DerivedSnapshotConfig derivedSnapshotConfig,
             TransactionKnowledgeComponents knowledge) {
+        TransactionKeyValueServiceManager transactionKeyValueServiceManager =
+                new DelegatingTransactionKeyValueServiceManager(kvs);
+        DefaultDeleteExecutor deleteExecutor =
+                new DefaultDeleteExecutor(kvs, PTExecutors.newSingleThreadExecutor(true));
         return new SerializableTransactionManager(
                 metricsManager,
                 new DelegatingTransactionKeyValueServiceManager(kvs),
@@ -138,12 +145,18 @@ public class TestTransactionManagerModule {
                 derivedSnapshotConfig.concurrentGetRangesThreadPoolSize(),
                 derivedSnapshotConfig.defaultGetRangesConcurrency(),
                 MultiTableSweepQueueWriter.NO_OP,
-                new DefaultDeleteExecutor(kvs, PTExecutors.newSingleThreadExecutor(true)),
+                deleteExecutor,
                 true,
                 () -> config.atlasDbRuntimeConfig().transaction(),
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                new DefaultKeyValueSnapshotReaderManager(
+                        transactionKeyValueServiceManager,
+                        transactionService,
+                        config.allowAccessToHiddenTables(),
+                        new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor),
+                        deleteExecutor));
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -66,6 +66,7 @@ import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
 import com.palantir.atlasdb.transaction.api.TransactionSerializableConflictException;
 import com.palantir.atlasdb.transaction.api.annotations.ReviewedRestrictedApiUsage;
 import com.palantir.atlasdb.transaction.api.exceptions.MoreCellsPresentThanExpectedException;
+import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.impl.metrics.TableLevelMetricsController;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -170,7 +171,8 @@ public class SerializableTransaction extends SnapshotTransaction {
             ConflictTracer conflictTracer,
             TableLevelMetricsController tableLevelMetricsController,
             TransactionKnowledgeComponents knowledge,
-            CommitTimestampLoader commitTimestampLoader) {
+            CommitTimestampLoader commitTimestampLoader,
+            KeyValueSnapshotReaderManager keyValueSnapshotReaderManager) {
         super(
                 metricsManager,
                 keyValueService,
@@ -198,7 +200,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 conflictTracer,
                 tableLevelMetricsController,
                 knowledge,
-                commitTimestampLoader);
+                commitTimestampLoader,
+                keyValueSnapshotReaderManager);
     }
 
     @Override
@@ -938,7 +941,8 @@ public class SerializableTransaction extends SnapshotTransaction {
                 tableLevelMetricsController,
                 knowledge,
                 new ReadValidationCommitTimestampLoader(
-                        commitTimestampLoader, getTimestamp(), commitTs, transactionOutcomeMetrics)) {
+                        commitTimestampLoader, getTimestamp(), commitTs, transactionOutcomeMetrics),
+                keyValueSnapshotReaderManager) {
             @Override
             protected TransactionScopedCache getCache() {
                 return lockWatchManager.getReadOnlyTransactionScopedCache(SerializableTransaction.this.getTimestamp());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -414,7 +414,7 @@ public class SnapshotTransaction extends AbstractTransaction
     private KeyValueSnapshotReader getDefaultKeyValueSnapshotReader() {
         return keyValueSnapshotReaderManager.createKeyValueSnapshotReader(ImmutableTransactionContext.builder()
                 .startTimestampSupplier(startTimestamp)
-                .transactionReadSentinelBehavior(TransactionReadSentinelBehavior.THROW_EXCEPTION)
+                .transactionReadSentinelBehavior(readSentinelBehavior)
                 .commitTimestampLoader(commitTimestampLoader)
                 .preCommitRequirementValidator(preCommitRequirementValidator)
                 .readSnapshotValidator(readSnapshotValidator)

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -181,7 +181,8 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 new SimpleTableLevelMetricsController(metricsManager),
                 knowledge,
                 commitTimestampLoaderFactory.createCommitTimestampLoader(
-                        startTimestampSupplier, 0L, options.immutableLockToken)) {
+                        startTimestampSupplier, 0L, options.immutableLockToken),
+                keyValueSnapshotReaderManager) {
             @Override
             protected Map<Cell, byte[]> transformGetsForTesting(Map<Cell, byte[]> map) {
                 return Maps.transformValues(map, byte[]::clone);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -34,6 +34,7 @@ import com.palantir.atlasdb.transaction.api.ConflictHandler;
 import com.palantir.atlasdb.transaction.api.PreCommitCondition;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionReadSentinelBehavior;
+import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.impl.metrics.DefaultMetricsFilterEvaluationContext;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -66,7 +67,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             TimestampCache timestampCache,
             MultiTableSweepQueueWriter sweepQueue,
             TransactionKnowledgeComponents knowledge,
-            ExecutorService deleteExecutor) {
+            ExecutorService deleteExecutor,
+            KeyValueSnapshotReaderManager keyValueSnapshotReaderManager) {
         this(
                 metricsManager,
                 keyValueService,
@@ -79,7 +81,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 sweepQueue,
                 deleteExecutor,
                 WrapperWithTracker.TRANSACTION_NO_OP,
-                knowledge);
+                knowledge,
+                keyValueSnapshotReaderManager);
     }
 
     public TestTransactionManagerImpl(
@@ -94,7 +97,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             MultiTableSweepQueueWriter sweepQueue,
             ExecutorService deleteExecutor,
             WrapperWithTracker<CallbackAwareTransaction> transactionWrapper,
-            TransactionKnowledgeComponents knowledge) {
+            TransactionKnowledgeComponents knowledge,
+            KeyValueSnapshotReaderManager keyValueSnapshotReaderManager) {
         this(
                 metricsManager,
                 createAssertKeyValue(keyValueService, lockService),
@@ -107,7 +111,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 sweepQueue,
                 deleteExecutor,
                 transactionWrapper,
-                knowledge);
+                knowledge,
+                keyValueSnapshotReaderManager);
     }
 
     private TestTransactionManagerImpl(
@@ -122,7 +127,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
             MultiTableSweepQueueWriter sweepQueue,
             ExecutorService deleteExecutor,
             WrapperWithTracker<CallbackAwareTransaction> transactionWrapper,
-            TransactionKnowledgeComponents knowledge) {
+            TransactionKnowledgeComponents knowledge,
+            KeyValueSnapshotReaderManager keyValueSnapshotReaderManager) {
         super(
                 metricsManager,
                 keyValueService,
@@ -146,7 +152,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                keyValueSnapshotReaderManager);
         this.transactionWrapper = transactionWrapper;
     }
 
@@ -206,7 +213,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
                         tableLevelMetricsController,
                         knowledge,
                         commitTimestampLoaderFactory.createCommitTimestampLoader(
-                                startTimestampSupplier, immutableTimestamp, Optional.of(immutableTsLock))),
+                                startTimestampSupplier, immutableTimestamp, Optional.of(immutableTsLock)),
+                        keyValueSnapshotReaderManager),
                 pathTypeTracker);
     }
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -47,8 +47,11 @@ import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.transaction.ImmutableTransactionConfig;
 import com.palantir.atlasdb.transaction.TransactionConfig;
 import com.palantir.atlasdb.transaction.api.ConflictHandler;
+import com.palantir.atlasdb.transaction.api.DeleteExecutor;
 import com.palantir.atlasdb.transaction.api.Transaction;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
+import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager;
+import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -125,12 +128,14 @@ public abstract class TransactionTestSetup {
     protected ConflictDetectionManager conflictDetectionManager;
     protected SweepStrategyManager sweepStrategyManager;
     protected TransactionManager txMgr;
+    protected DeleteExecutor deleteExecutor;
 
     protected TimestampCache timestampCache;
 
     protected TransactionKnowledgeComponents knowledge;
     protected Supplier<TransactionConfig> transactionConfigSupplier;
     protected CommitTimestampLoaderFactory commitTimestampLoaderFactory;
+    protected KeyValueSnapshotReaderManager keyValueSnapshotReaderManager;
 
     @RegisterExtension
     public InMemoryTimelockExtension inMemoryTimelockExtension = new InMemoryTimelockExtension();
@@ -150,6 +155,8 @@ public abstract class TransactionTestSetup {
 
         keyValueService = getKeyValueService();
         transactionKeyValueServiceManager = new DelegatingTransactionKeyValueServiceManager(keyValueService);
+        deleteExecutor = DefaultDeleteExecutor.createDefault(
+                transactionKeyValueServiceManager.getKeyValueService().orElseThrow());
         keyValueService.createTables(ImmutableMap.of(
                 TEST_TABLE_THOROUGH,
                 TableMetadata.builder()
@@ -205,6 +212,12 @@ public abstract class TransactionTestSetup {
                 transactionConfigSupplier);
         conflictDetectionManager = ConflictDetectionManagers.createWithoutWarmingCache(keyValueService);
         sweepStrategyManager = SweepStrategyManagers.createDefault(keyValueService);
+        keyValueSnapshotReaderManager = new DefaultKeyValueSnapshotReaderManager(
+                transactionKeyValueServiceManager,
+                transactionService,
+                false,
+                new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor),
+                deleteExecutor);
         txMgr = createAndRegisterManager();
     }
 
@@ -234,7 +247,8 @@ public abstract class TransactionTestSetup {
                 timestampCache,
                 MultiTableSweepQueueWriter.NO_OP,
                 knowledge,
-                MoreExecutors.newDirectExecutorService());
+                MoreExecutors.newDirectExecutorService(),
+                keyValueSnapshotReaderManager);
     }
 
     protected void put(Transaction txn, String rowName, String columnName, String value) {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -103,7 +103,8 @@ public class AtlasDbTestCase {
         sweepQueue = spy(TargetedSweeper.createUninitializedForTest(keyValueService, () -> sweepQueueShards));
         knowledge = TransactionKnowledgeComponents.createForTests(keyValueService, metricsManager.getTaggedRegistry());
         DeleteExecutor typedDeleteExecutor = new DefaultDeleteExecutor(keyValueService, deleteExecutor);
-        keyValueSnapshotReaderManager = TestKeyValueSnapshotReaderManagers.createForTests(txnKeyValueServiceManager, transactionService, sweepStrategyManager, typedDeleteExecutor);
+        keyValueSnapshotReaderManager = TestKeyValueSnapshotReaderManagers.createForTests(
+                txnKeyValueServiceManager, transactionService, sweepStrategyManager, typedDeleteExecutor);
         setUpTransactionManagers();
         sweepQueue.initialize(serializableTxManager);
         sweepTimestampSupplier = new SpecialTimestampsSupplier(

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -36,13 +36,12 @@ import com.palantir.atlasdb.transaction.impl.CachingTestTransactionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManager;
 import com.palantir.atlasdb.transaction.impl.ConflictDetectionManagers;
 import com.palantir.atlasdb.transaction.impl.DefaultDeleteExecutor;
-import com.palantir.atlasdb.transaction.impl.DefaultOrphanedSentinelDeleter;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManager;
 import com.palantir.atlasdb.transaction.impl.SweepStrategyManagers;
+import com.palantir.atlasdb.transaction.impl.TestKeyValueSnapshotReaderManagers;
 import com.palantir.atlasdb.transaction.impl.TestTransactionManager;
 import com.palantir.atlasdb.transaction.impl.TestTransactionManagerImpl;
 import com.palantir.atlasdb.transaction.impl.TransactionTables;
-import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
@@ -104,12 +103,7 @@ public class AtlasDbTestCase {
         sweepQueue = spy(TargetedSweeper.createUninitializedForTest(keyValueService, () -> sweepQueueShards));
         knowledge = TransactionKnowledgeComponents.createForTests(keyValueService, metricsManager.getTaggedRegistry());
         DeleteExecutor typedDeleteExecutor = new DefaultDeleteExecutor(keyValueService, deleteExecutor);
-        keyValueSnapshotReaderManager = new DefaultKeyValueSnapshotReaderManager(
-                txnKeyValueServiceManager,
-                transactionService,
-                false,
-                new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, typedDeleteExecutor),
-                typedDeleteExecutor);
+        keyValueSnapshotReaderManager = TestKeyValueSnapshotReaderManagers.createForTests(txnKeyValueServiceManager, transactionService, sweepStrategyManager, typedDeleteExecutor);
         setUpTransactionManagers();
         sweepQueue.initialize(serializableTxManager);
         sweepTimestampSupplier = new SpecialTimestampsSupplier(

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/CommitLockTest.java
@@ -179,7 +179,8 @@ public class CommitLockTest extends TransactionTestSetup {
                 timestampCache,
                 MultiTableSweepQueueWriter.NO_OP,
                 knowledge,
-                MoreExecutors.newDirectExecutorService());
+                MoreExecutors.newDirectExecutorService(),
+                keyValueSnapshotReaderManager);
         transactionManager.overrideConflictHandlerForTable(TEST_TABLE, conflictHandler);
         return transactionManager;
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/FakeTransactionKeyValueServiceManager.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/FakeTransactionKeyValueServiceManager.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import com.palantir.atlasdb.cell.api.DdlManager;
+import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.Optional;
+import java.util.function.LongSupplier;
+
+public class FakeTransactionKeyValueServiceManager implements TransactionKeyValueServiceManager {
+    private final TransactionKeyValueService tkvsMock;
+
+    public FakeTransactionKeyValueServiceManager(TransactionKeyValueService tkvsMock) {
+        this.tkvsMock = tkvsMock;
+    }
+
+    @Override
+    public TransactionKeyValueService getTransactionKeyValueService(LongSupplier timestampSupplier) {
+        return tkvsMock;
+    }
+
+    @Override
+    public Optional<KeyValueService> getKeyValueService() {
+        return Optional.empty();
+    }
+
+    @Override
+    public DdlManager getDdlManager() {
+        throw new SafeIllegalStateException("Not expecting to call in to DDL manager here");
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return true;
+    }
+
+    @Override
+    public void close() {}
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/FakeTransactionKeyValueServiceManager.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/FakeTransactionKeyValueServiceManager.java
@@ -24,16 +24,16 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.Optional;
 import java.util.function.LongSupplier;
 
-public class FakeTransactionKeyValueServiceManager implements TransactionKeyValueServiceManager {
-    private final TransactionKeyValueService tkvsMock;
+public final class FakeTransactionKeyValueServiceManager implements TransactionKeyValueServiceManager {
+    private final TransactionKeyValueService delegate;
 
-    public FakeTransactionKeyValueServiceManager(TransactionKeyValueService tkvsMock) {
-        this.tkvsMock = tkvsMock;
+    public FakeTransactionKeyValueServiceManager(TransactionKeyValueService delegate) {
+        this.delegate = delegate;
     }
 
     @Override
     public TransactionKeyValueService getTransactionKeyValueService(LongSupplier timestampSupplier) {
-        return tkvsMock;
+        return delegate;
     }
 
     @Override

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -40,6 +40,7 @@ import com.palantir.atlasdb.transaction.ImmutableTransactionConfig;
 import com.palantir.atlasdb.transaction.api.KeyValueServiceStatus;
 import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.impl.metrics.DefaultMetricsFilterEvaluationContext;
+import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -300,7 +301,13 @@ public class SerializableTransactionManagerTest {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                new DefaultKeyValueSnapshotReaderManager(
+                        new DelegatingTransactionKeyValueServiceManager(mockKvs),
+                        mock(TransactionService.class),
+                        false,
+                        mock(DefaultOrphanedSentinelDeleter.class),
+                        DefaultDeleteExecutor.createDefault(mockKvs)));
     }
 
     private void nothingInitialized() {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -42,8 +42,8 @@ import com.palantir.atlasdb.transaction.ImmutableTransactionConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.DeleteExecutor;
 import com.palantir.atlasdb.transaction.api.OpenTransaction;
+import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.impl.metrics.DefaultMetricsFilterEvaluationContext;
-import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -332,13 +332,11 @@ public class SnapshotTransactionManagerTest {
                 getKeyValueSnapshotReaderManager(SweepStrategyManagers.createDefault(keyValueService)));
     }
 
-    private DefaultKeyValueSnapshotReaderManager getKeyValueSnapshotReaderManager(
-            SweepStrategyManager sweepStrategyManager) {
-        return new DefaultKeyValueSnapshotReaderManager(
+    private KeyValueSnapshotReaderManager getKeyValueSnapshotReaderManager(SweepStrategyManager sweepStrategyManager) {
+        return TestKeyValueSnapshotReaderManagers.createForTests(
                 transactionKeyValueServiceManager,
                 mock(TransactionService.class),
-                false,
-                new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor),
+                sweepStrategyManager,
                 deleteExecutor);
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -43,6 +43,7 @@ import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
 import com.palantir.atlasdb.transaction.api.DeleteExecutor;
 import com.palantir.atlasdb.transaction.api.OpenTransaction;
 import com.palantir.atlasdb.transaction.impl.metrics.DefaultMetricsFilterEvaluationContext;
+import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.knowledge.TransactionKnowledgeComponents;
 import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.util.MetricsManager;
@@ -122,7 +123,8 @@ public class SnapshotTransactionManagerTest {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                getKeyValueSnapshotReaderManager(ThrowingSweepStrategyManager.INSTANCE));
     }
 
     @Test
@@ -179,7 +181,8 @@ public class SnapshotTransactionManagerTest {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                getKeyValueSnapshotReaderManager(SweepStrategyManagers.createDefault(keyValueService)));
         newTransactionManager.close(); // should not throw
     }
 
@@ -325,6 +328,17 @@ public class SnapshotTransactionManagerTest {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                getKeyValueSnapshotReaderManager(SweepStrategyManagers.createDefault(keyValueService)));
+    }
+
+    private DefaultKeyValueSnapshotReaderManager getKeyValueSnapshotReaderManager(
+            SweepStrategyManager sweepStrategyManager) {
+        return new DefaultKeyValueSnapshotReaderManager(
+                transactionKeyValueServiceManager,
+                mock(TransactionService.class),
+                false,
+                new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor),
+                deleteExecutor);
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TestKeyValueSnapshotReaderManagers.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TestKeyValueSnapshotReaderManagers.java
@@ -1,0 +1,54 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.transaction.api.DeleteExecutor;
+import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager;
+import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReaderManager;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+
+public interface TestKeyValueSnapshotReaderManagers {
+
+    static KeyValueSnapshotReaderManager createForTests(
+            KeyValueService keyValueService,
+            TransactionService transactionService,
+            SweepStrategyManager sweepStrategyManager,
+            DeleteExecutor deleteExecutor) {
+        return new DefaultKeyValueSnapshotReaderManager(
+                new DelegatingTransactionKeyValueServiceManager(keyValueService),
+                transactionService,
+                false,
+                new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor),
+                deleteExecutor);
+    }
+
+    static KeyValueSnapshotReaderManager createForTests(
+            TransactionKeyValueServiceManager transactionKeyValueServiceManager,
+            TransactionService transactionService,
+            SweepStrategyManager sweepStrategyManager,
+            DeleteExecutor deleteExecutor) {
+        return new DefaultKeyValueSnapshotReaderManager(
+                transactionKeyValueServiceManager,
+                transactionService,
+                false,
+                new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor),
+                deleteExecutor);
+    }
+}

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -269,7 +269,8 @@ public class TransactionManagerTest extends TransactionTestSetup {
                 ConflictTracer.NO_OP,
                 DefaultMetricsFilterEvaluationContext.createDefault(),
                 Optional.empty(),
-                knowledge);
+                knowledge,
+                keyValueSnapshotReaderManager);
 
         when(timelock.getFreshTimestamp()).thenReturn(1L);
         when(timelock.lockImmutableTimestamp())

--- a/changelog/@unreleased/pr-7142.v2.yml
+++ b/changelog/@unreleased/pr-7142.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Support user-provided implementations of KeyValueSnapshotReaderManager
+  links:
+  - https://github.com/palantir/atlasdb/pull/7142


### PR DESCRIPTION
1. #7141
2. #7142

## General
**Before this PR**:
Default implementation of `KeyValueSnapshotReader` is always used.

**After this PR**:
Wires up the `KeyValueSnapshotReaderManager`, potentially constructed with a service loaded factory, and actually use that manger to construct instances of `KeyValueSnapshotReaders`. This allows users to provide custom snapshot reader implementations.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Wire up KeyValueSnapshotReaderManager
==COMMIT_MSG==

**For Reviewers**
Production implementation: f551d8c
Test wiring: b8fd048

@jeremyk-91
@jkozlowski 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
