### PR TITLE
Make DdlManager accessible from a TransactionManager

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -126,6 +126,16 @@ acceptedBreaks:
         \ com.palantir.atlasdb.keyvalue.api.TableReference, java.util.List<com.palantir.logsafe.Arg<?>>)"
       justification: "Transaction conflict exceptions are only intended to be instantiated\
         \ internally"
+  "0.1095.0":
+    com.palantir.atlasdb:atlasdb-api:
+    - code: "java.method.addedToInterface"
+      new: "method com.palantir.atlasdb.cell.api.DdlManager com.palantir.atlasdb.transaction.api.TransactionManager::getDdlManager()"
+      justification: "Adding getDdlManager() to TransactionManager will not break\
+        \ existing usage"
+    - code: "java.method.addedToInterface"
+      new: "method void com.palantir.atlasdb.cell.api.DdlManager::dropTables(java.util.Set<com.palantir.atlasdb.keyvalue.api.TableReference>)"
+      justification: "Adding getDdlManager() to TransactionManager will not break\
+        \ existing usage"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/DdlManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/DdlManager.java
@@ -18,10 +18,13 @@ package com.palantir.atlasdb.cell.api;
 
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import java.util.Map;
+import java.util.Set;
 
 public interface DdlManager {
 
     // TODO(jakubk): Convert all these to be async.
     // TODO(jakubk): Switch to using TableMetadata.
     void createTables(Map<TableReference, byte[]> tableRefToTableMetadata);
+
+    void dropTables(Set<TableReference> tableRefs);
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.transaction.api;
 
+import com.palantir.atlasdb.cell.api.DdlManager;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.watch.LockWatchManager;
@@ -365,6 +366,14 @@ public interface TransactionManager extends AutoCloseable {
      * @return the key value service for this transaction manager.
      */
     KeyValueService getKeyValueService();
+
+    /**
+     * Returns the DdlManager used by this transaction manager. This should be used in place of the KeyValueService
+     * when creating tables or making other schema changes.
+     *
+     * @return the DdlManager for this transaction manager.
+     */
+    DdlManager getDdlManager();
 
     /**
      * Provides a {@link KeyValueServiceStatus}, indicating the current availability of the key value store.

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DelegatingDdlManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DelegatingDdlManager.java
@@ -20,6 +20,7 @@ import com.palantir.atlasdb.cell.api.DdlManager;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import java.util.Map;
+import java.util.Set;
 
 public final class DelegatingDdlManager implements DdlManager {
 
@@ -32,5 +33,10 @@ public final class DelegatingDdlManager implements DdlManager {
     @Override
     public void createTables(Map<TableReference, byte[]> tableRefToTableMetadata) {
         delegate.createTables(tableRefToTableMetadata);
+    }
+
+    @Override
+    public void dropTables(Set<TableReference> tableRefs) {
+        delegate.dropTables(tableRefs);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 import com.palantir.atlasdb.cache.TimestampCache;
+import com.palantir.atlasdb.cell.api.DdlManager;
 import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
@@ -523,6 +524,11 @@ import java.util.stream.Collectors;
         return transactionKeyValueServiceManager
                 .getKeyValueService()
                 .orElseThrow(() -> new SafeIllegalStateException("KeyValueService is not supported"));
+    }
+
+    @Override
+    public DdlManager getDdlManager() {
+        return transactionKeyValueServiceManager.getDdlManager();
     }
 
     @Override

--- a/changelog/@unreleased/pr-7143.v2.yml
+++ b/changelog/@unreleased/pr-7143.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Make DdlManager accessible from a TransactionManager
+  links:
+  - https://github.com/palantir/atlasdb/pull/7143


### PR DESCRIPTION
## General
**Before this PR**:
An internal Atlas proxy uses the `KeyValueService` directly to create and drop tables.

**After this PR**:
Make the DdlManager accessible in the same way via the TransactionManager, with the ultimate goal of removing all direct usage of the KeyValueService.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make DdlManager accessible from a TransactionManager
==COMMIT_MSG==

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@jkozlowski 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
