### PR TITLE
Improve logging for dynamic tables

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
@@ -234,7 +234,7 @@ public class KvTableMappingService implements TableMappingService {
             return Optional.ofNullable(entryForTable.get(getKeyCellForTable(tableRef)))
                     .map(row -> TableReference.createWithEmptyNamespace(PtBytes.toString(row.getContents())))
                     .orElseThrow(() -> new TableMappingNotFoundException(
-                            "Unable to resolve mapping for table reference " + tableRef));
+                            "Unable to resolve mapping for table reference (Uncached) " + tableRef));
         }
     }
 
@@ -245,7 +245,8 @@ public class KvTableMappingService implements TableMappingService {
             updateTableMap();
             candidate = tableMap.get().get(tableRef);
             if (candidate == null) {
-                throw new TableMappingNotFoundException("Unable to resolve mapping for table reference " + tableRef);
+                throw new TableMappingNotFoundException(
+                        "Unable to resolve mapping for table reference (Cached) " + tableRef);
             }
         }
         return candidate;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueService.java
@@ -43,8 +43,11 @@ import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
 import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.common.base.ClosableIterator;
 import com.palantir.common.exception.TableMappingNotFoundException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.util.Collection;
 import java.util.HashSet;
@@ -54,6 +57,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public final class TableRemappingKeyValueService extends ForwardingObject implements KeyValueService {
+    private static final SafeLogger log = SafeLoggerFactory.get(TableRemappingKeyValueService.class);
+
     public static TableRemappingKeyValueService create(KeyValueService delegate, TableMappingService tableMapper) {
         return new TableRemappingKeyValueService(delegate, tableMapper);
     }
@@ -156,6 +161,10 @@ public final class TableRemappingKeyValueService extends ForwardingObject implem
                 tableNames.add(tableMapper.getMappedTableName(tableRef));
             } catch (TableMappingNotFoundException e) {
                 // Table does not exist - do nothing
+                log.debug(
+                        "Could not find short table reference for an existing table",
+                        LoggingArgs.tableRef(tableRef),
+                        e);
             }
         }
         return tableNames;

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingServiceTest.java
@@ -298,7 +298,7 @@ public class KvTableMappingServiceTest {
         anotherService.removeTable(UNCACHEABLE_TABLE_1);
         assertThatThrownBy(() -> tableMapping.getMappedTableName(UNCACHEABLE_TABLE_1))
                 .isInstanceOf(TableMappingNotFoundException.class)
-                .hasMessage("Unable to resolve mapping for table reference " + UNCACHEABLE_TABLE_1);
+                .hasMessage("Unable to resolve mapping for table reference (Uncached) " + UNCACHEABLE_TABLE_1);
     }
 
     @Test
@@ -333,7 +333,7 @@ public class KvTableMappingServiceTest {
     public void mapToShortTableNamesThrowsIfKeyNotFoundInTableMap() {
         assertThatThrownBy(() -> tableMapping.mapToShortTableNames(ImmutableMap.of(FQ_TABLE, 1, FQ_TABLE2, 2)))
                 .isInstanceOf(TableMappingNotFoundException.class)
-                .hasMessage("Unable to resolve mapping for table reference " + FQ_TABLE2);
+                .hasMessage("Unable to resolve mapping for table reference (Cached) " + FQ_TABLE2);
     }
 
     @Test

--- a/changelog/@unreleased/pr-7154.v2.yml
+++ b/changelog/@unreleased/pr-7154.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    * Log when tables not found during getShortTableReferencesForExistingTables
+    * Improve logging for "table not found" exceptions during KVS mapping failures
+  links:
+  - https://github.com/palantir/atlasdb/pull/7154


### PR DESCRIPTION
## General
**Before this PR**:
Unclear from single loglines when cache misses vs. uncached reads were failing during dynamic table deletion operations

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
* Log when tables not found during getShortTableReferencesForExistingTables
* Improve logging for "table not found" exceptions during KVS mapping failures
==COMMIT_MSG==

**Priority**:
P1 (See internal support tickets)

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
