### PR TITLE
cacheableTablePredicate-dependent table lookups during table creation in KvTableMappingService

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingService.java
@@ -139,6 +139,19 @@ public class KvTableMappingService implements TableMappingService {
         // about the removal. Attempting to create a table that was previously deleted on another node will also
         // fail, with the actual TableReference being read in the exception handler.
         // Please see TableRemappingKeyValueServiceTest for some tests that mirror real-world failure cases.
+        if (cacheableTablePredicate.test(tableRef)) {
+            TableReference cachedShortName = tableMap.get().get(tableRef);
+            if (cachedShortName != null) {
+                logDebugOrTrace(
+                        "Table mapping already exists",
+                        LoggingArgs.tableRef("longTableRef", tableRef),
+                        SafeArg.of("shortTableRef", cachedShortName));
+                return cachedShortName;
+            } else {
+                logDebugOrTrace("Table mapping not found in cache", LoggingArgs.tableRef("longTableRef", tableRef));
+            }
+        }
+
         Cell key = getKeyCellForTable(tableRef);
         String shortName = AtlasDbConstants.NAMESPACE_PREFIX + uniqueLongSupplier.getAsLong();
         TableReference shortNameRef = TableReference.createWithEmptyNamespace(shortName);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingServiceTest.java
@@ -110,7 +110,7 @@ public class KvTableMappingServiceTest {
         assertThat(tableMapping.getMappedTableName(FQ_TABLE2)).isEqualTo(shortTableRefForNumber(2));
 
         // implementation detail: the first time we reattempt, we will try to CAS, fail, and reload the mapping
-        verify(kvs, times(4)).putUnlessExists(eq(AtlasDbConstants.NAMESPACE_TABLE), anyMap());
+        verify(kvs, times(3)).putUnlessExists(eq(AtlasDbConstants.NAMESPACE_TABLE), anyMap());
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/KvTableMappingServiceTest.java
@@ -110,7 +110,7 @@ public class KvTableMappingServiceTest {
         assertThat(tableMapping.getMappedTableName(FQ_TABLE2)).isEqualTo(shortTableRefForNumber(2));
 
         // implementation detail: the first time we reattempt, we will try to CAS, fail, and reload the mapping
-        verify(kvs, times(3)).putUnlessExists(eq(AtlasDbConstants.NAMESPACE_TABLE), anyMap());
+        verify(kvs, times(4)).putUnlessExists(eq(AtlasDbConstants.NAMESPACE_TABLE), anyMap());
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueServiceTest.java
@@ -59,7 +59,6 @@ public class TableRemappingKeyValueServiceTest {
     private final AtomicLong timestamp = new AtomicLong();
     private final KeyValueService rawKvs = new InMemoryKeyValueService(true);
     private final KvTableMappingService tableMapper = KvTableMappingService.create(rawKvs, timestamp::incrementAndGet);
-    ;
     private final KeyValueService kvs = TableRemappingKeyValueService.create(rawKvs, tableMapper);
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueServiceTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableRemappingKeyValueServiceTest.java
@@ -26,6 +26,7 @@ import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.Namespace;
+import com.palantir.atlasdb.keyvalue.api.TableMappingCacheConfiguration;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.table.description.TableDefinition;
@@ -35,12 +36,17 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TableRemappingKeyValueServiceTest {
     private static final Namespace NAMESPACE = Namespace.create("namespace");
@@ -53,6 +59,7 @@ public class TableRemappingKeyValueServiceTest {
     private final AtomicLong timestamp = new AtomicLong();
     private final KeyValueService rawKvs = new InMemoryKeyValueService(true);
     private final KvTableMappingService tableMapper = KvTableMappingService.create(rawKvs, timestamp::incrementAndGet);
+    ;
     private final KeyValueService kvs = TableRemappingKeyValueService.create(rawKvs, tableMapper);
 
     @Test
@@ -85,6 +92,144 @@ public class TableRemappingKeyValueServiceTest {
                 assertThat(read).containsExactly(Maps.immutableEntry(testCell, Value.create(value, testTimestamp)));
                 return null;
             }));
+            futures.forEach(Futures::getUnchecked);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false}) // KvTableMappingService issues prevent cached lookups from working as intended
+    public void testAddTableInOneNodeAfterDropInAnother(boolean cacheTableLookups) {
+        // Simulate a pair of KVS clients hitting the same raw KVS
+        KvTableMappingService tableMapper1 = KvTableMappingService.createWithCustomNamespaceValidation(
+                rawKvs,
+                timestamp::incrementAndGet,
+                Namespace.STRICTLY_CHECKED_NAME,
+                new TableMappingCacheConfiguration() {
+                    @Override
+                    public Predicate<TableReference> cacheableTablePredicate() {
+                        return tableReference -> cacheTableLookups;
+                    }
+                });
+        KvTableMappingService tableMapper2 = KvTableMappingService.createWithCustomNamespaceValidation(
+                rawKvs,
+                timestamp::incrementAndGet,
+                Namespace.STRICTLY_CHECKED_NAME,
+                new TableMappingCacheConfiguration() {
+                    @Override
+                    public Predicate<TableReference> cacheableTablePredicate() {
+                        return tableReference -> cacheTableLookups;
+                    }
+                });
+        TableRemappingKeyValueService kvs1 = TableRemappingKeyValueService.create(rawKvs, tableMapper1);
+        TableRemappingKeyValueService kvs2 = TableRemappingKeyValueService.create(rawKvs, tableMapper2);
+        // Create the table in the first node
+        kvs1.createTable(DATA_TABLE_REF, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        Cell cell = Cell.create(PtBytes.toBytes("row"), PtBytes.toBytes("col"));
+        // Try to get a value, creating the mapping in memory
+        kvs1.get(DATA_TABLE_REF, ImmutableMap.of(cell, 1L));
+        // Drop the table in node 2. This removes the mapping from the db, but the in memory mapping in node 1 isn't
+        // removed
+        kvs2.dropTable(DATA_TABLE_REF);
+        // Create the table again in node 1. This will re-write the table entry in the db.
+        kvs1.createTable(DATA_TABLE_REF, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        // Write some data to kvs2 and try to read it back from kvs1. This verifies that the table caches across 1 & 2
+        // are consistent.
+        kvs1.put(DATA_TABLE_REF, ImmutableMap.of(cell, new byte[] {0x42}), 1L);
+        // Try and get a value on both nodes and make sure they are the same.
+        Map<Cell, Value> result = kvs1.get(DATA_TABLE_REF, ImmutableMap.of(cell, 2L));
+        Map<Cell, Value> result2 = kvs2.get(DATA_TABLE_REF, ImmutableMap.of(cell, 2L));
+        assertThat(result).isNotEmpty();
+        assertThat(result2).isNotEmpty();
+        assertThat(result).isEqualTo(result2);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false}) // KvTableMappingService issues prevent cached lookups from working as intended
+    public void testAddTableInOneNodeAfterDropInAnother2(boolean cacheTableLookups) {
+        // Simulate a pair of KVS clients hitting the same raw KVS
+        KvTableMappingService tableMapper1 = KvTableMappingService.createWithCustomNamespaceValidation(
+                rawKvs,
+                timestamp::incrementAndGet,
+                Namespace.STRICTLY_CHECKED_NAME,
+                new TableMappingCacheConfiguration() {
+                    @Override
+                    public Predicate<TableReference> cacheableTablePredicate() {
+                        return tableReference -> cacheTableLookups;
+                    }
+                });
+        KvTableMappingService tableMapper2 = KvTableMappingService.createWithCustomNamespaceValidation(
+                rawKvs,
+                timestamp::incrementAndGet,
+                Namespace.STRICTLY_CHECKED_NAME,
+                new TableMappingCacheConfiguration() {
+                    @Override
+                    public Predicate<TableReference> cacheableTablePredicate() {
+                        return tableReference -> cacheTableLookups;
+                    }
+                });
+        TableRemappingKeyValueService kvs1 = TableRemappingKeyValueService.create(rawKvs, tableMapper1);
+        TableRemappingKeyValueService kvs2 = TableRemappingKeyValueService.create(rawKvs, tableMapper2);
+        // Create the table in the first node
+        kvs1.createTable(DATA_TABLE_REF, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        Cell cell = Cell.create(PtBytes.toBytes("row"), PtBytes.toBytes("col"));
+        // Try to get a value, creating the mapping in memory
+        kvs1.get(DATA_TABLE_REF, ImmutableMap.of(cell, 1L));
+        // Drop the table in node 2. This removes the mapping from the db, but the in memory mapping in node 1 isn't
+        // removed
+        kvs2.dropTable(DATA_TABLE_REF);
+        // Create the table again in node 2. This will write a new mapping to the db, which doesn't match the mapping
+        // that is still in memory on node 1.
+        kvs2.createTable(DATA_TABLE_REF, AtlasDbConstants.GENERIC_TABLE_METADATA);
+        // Write some data to kvs2 and try to read it back from kvs1. This verifies that the table caches across 1 & 2
+        // are consistent.
+        kvs2.put(DATA_TABLE_REF, ImmutableMap.of(cell, new byte[] {0x42}), 1L);
+        // Try and get a value on both nodes and make sure they are the same.
+        Map<Cell, Value> result = kvs1.get(DATA_TABLE_REF, ImmutableMap.of(cell, 2L));
+        Map<Cell, Value> result2 = kvs2.get(DATA_TABLE_REF, ImmutableMap.of(cell, 2L));
+        assertThat(result).isNotEmpty();
+        assertThat(result2).isNotEmpty();
+        assertThat(result).isEqualTo(result2);
+    }
+
+    @Test
+    @Disabled("Issues with both table creation and metadata storage after table creation exist to cause this test to"
+            + " fail.")
+    public void fuzzTestConcurrentlyCreateAndDeleteTablesAcrossManyWriters() {
+        int createAndDeleteWriters = 32;
+        int totalAttempts = 10;
+        int tableCount = 1000;
+
+        ExecutorService executor = Executors.newFixedThreadPool(createAndDeleteWriters);
+        for (int i = 0; i < totalAttempts; i++) {
+            // Try and ensure the creates and deletes happen as close to simultaneously as possible
+            CyclicBarrier waitUntilAllFuturesAreReady = new CyclicBarrier(createAndDeleteWriters);
+            final Set<Future<Void>> futures = new HashSet<>();
+            for (int j = 0; j < createAndDeleteWriters; j++) {
+                futures.add(executor.submit(() -> {
+                    AtomicLong timestamp = new AtomicLong();
+                    KvTableMappingService tableMapper = KvTableMappingService.createWithCustomNamespaceValidation(
+                            rawKvs,
+                            timestamp::incrementAndGet,
+                            Namespace.STRICTLY_CHECKED_NAME,
+                            new TableMappingCacheConfiguration() {
+                                @Override
+                                public Predicate<TableReference> cacheableTablePredicate() {
+                                    return tableReference -> false;
+                                }
+                            });
+                    KeyValueService kvs = TableRemappingKeyValueService.create(rawKvs, tableMapper);
+                    waitUntilAllFuturesAreReady.await();
+                    for (int k = 0; k < tableCount; k++) {
+                        kvs.dropTable(TableReference.create(NAMESPACE, TABLENAME + "_" + k));
+                        kvs.createTable(
+                                TableReference.create(NAMESPACE, TABLENAME + "_" + k),
+                                AtlasDbConstants.GENERIC_TABLE_METADATA);
+                    }
+
+                    return null;
+                }));
+            }
+
             futures.forEach(Futures::getUnchecked);
         }
     }

--- a/changelog/@unreleased/pr-7155.v2.yml
+++ b/changelog/@unreleased/pr-7155.v2.yml
@@ -1,0 +1,14 @@
+type: fix
+fix:
+  description: |-
+    There are some situations that can result in cached table lookups returning the wrong table for a table which has been dropped and re-created.
+
+    There are different scenarios where the caching breaks down, see the tests in TableRemappingKeyValueServiceTest for details.
+
+    This change is the first in what may become a series to resolve the concurrency issues within KvTableMappingService.
+
+    Unfortunately this change isn't actually sufficient to solve the table caching issues, however the feature to disable the table cache added in https://github.com/palantir/atlasdb/pull/6946 should allow for correctness where we expect namespaced tables to be created and deleted at a reasonably high scale.
+
+    The long-term fix for this problem is likely to either remove the cache from KvTableMappingService completely, or to re-write KvTableMappingService to be multi-node safe. As it stands, KvTableMappingService is NOT concurrency safe.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7155


### PR DESCRIPTION
## General
**Before this PR**:
Even with cached table lookups disabled, deleting and creating tables across KVS clients would break.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
There are some situations that can result in cached table lookups returning the wrong table for a table which has been dropped and re-created.

There are different scenarios where the caching breaks down, see the tests in TableRemappingKeyValueServiceTest for details.

This change is the first in what may become a series to resolve the concurrency issues within KvTableMappingService.

Unfortunately this change isn't actually sufficient to solve the table caching issues, however the feature to disable the table cache added in https://github.com/palantir/atlasdb/pull/6946 should allow for correctness where we expect namespaced tables to be created and deleted at a reasonably high scale.

The long-term fix for this problem is likely to either remove the cache from KvTableMappingService completely, or to re-write KvTableMappingService to be multi-node safe. As it stands, KvTableMappingService is NOT concurrency safe.
==COMMIT_MSG==

**Priority**:
P1

**Concerns / possible downsides (what feedback would you like?)**:
This does not resolve everything related to caching in KvTableMappingService

**Is documentation needed?**:
No

## Testing and Correctness
**What was existing testing like? What have you done to improve it?**:
3 new tests, 2 of which are based on ErikH's initial investigations.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Set the table caching predicate with this patch, re-run customer workflows which currently error.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Completely remove caching from KvTableMappingService and always read short -> long name lookups from the DB

## Development Process
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju