### PR TITLE
Use Async cache to avoid cache contention

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
@@ -39,7 +39,7 @@ public class ConflictDetectionManager {
      *  (This has always been the behavior of this class; I'm simply calling it out)
      */
     public ConflictDetectionManager(CacheLoader<TableReference, ConflictHandler> loader) {
-        this.cache = Caffeine.newBuilder().initialCapacity(4096).maximumSize(100_000).buildAsync(loader).synchronous();
+        this.cache = Caffeine.newBuilder().initialCapacity(256).maximumSize(100_000).buildAsync(loader).synchronous();
     }
 
     public void warmCacheWith(Map<TableReference, ConflictHandler> preload) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
@@ -39,7 +39,7 @@ public class ConflictDetectionManager {
      *  (This has always been the behavior of this class; I'm simply calling it out)
      */
     public ConflictDetectionManager(CacheLoader<TableReference, ConflictHandler> loader) {
-        this.cache = Caffeine.newBuilder().maximumSize(100_000).build(loader);
+        this.cache = Caffeine.newBuilder().initialCapacity(4096).maximumSize(100_000).buildAsync(loader).synchronous();
     }
 
     public void warmCacheWith(Map<TableReference, ConflictHandler> preload) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ConflictDetectionManager.java
@@ -39,7 +39,11 @@ public class ConflictDetectionManager {
      *  (This has always been the behavior of this class; I'm simply calling it out)
      */
     public ConflictDetectionManager(CacheLoader<TableReference, ConflictHandler> loader) {
-        this.cache = Caffeine.newBuilder().initialCapacity(256).maximumSize(100_000).buildAsync(loader).synchronous();
+        this.cache = Caffeine.newBuilder()
+                .initialCapacity(256)
+                .maximumSize(100_000)
+                .buildAsync(loader)
+                .synchronous();
     }
 
     public void warmCacheWith(Map<TableReference, ConflictHandler> preload) {


### PR DESCRIPTION
Several stack trace from our service shows blocked threads on this cache when trying to getRows. Generally these are during service restart as the cache is cold.

As per caffeine documentation:

```
Some attempted update operations on this cache by other threads may be blocked while the computation is in 
progress, so the computation should be short and simple, and must not attempt to update any other mappings
of this cache.
```
 
The [async loading cache](https://github.com/ben-manes/caffeine/wiki/Population#asynchronous-manual) will have internally store a CompletableFuture in the ConcurrentHashMap to avoid locking inside the ConcurrentHashMap and blocking concurrent accesses to nodes in the same bucket.

Initial capacity impacts the number of buckets in the internal ConcurrentHashMap used by the cache. We want to increase the minimum to reduce contention under heavy concurrent access. This will avoid situations where threads that ask for cache values are blocked due to resizing of the underlying hashMap

## General
**Before this PR**:

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use Async cache to avoid cache contention
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
