### PR TITLE
Don't retry lock request in lock condition

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AdvisoryLocksConditionTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AdvisoryLocksConditionTest.java
@@ -186,17 +186,6 @@ public class AdvisoryLocksConditionTest {
     }
 
     @Test
-    public void conditionSupplier_transactionLockFailureBeforeSuccess() throws InterruptedException {
-        Supplier<AdvisoryLocksCondition> conditionSupplier =
-                AdvisoryLockConditionSuppliers.get(lockService, ImmutableSet.of(), LOCK_REQUEST_SUPPLIER);
-        when(lockService.lockAndGetHeldLocks(LockClient.ANONYMOUS.getClientId(), LOCK_REQUEST))
-                .thenReturn(null)
-                .thenReturn(null)
-                .thenReturn(TRANSACTION_LOCK_TOKEN);
-        assertThat(conditionSupplier.get().getLocks()).containsOnly(TRANSACTION_LOCK_TOKEN);
-    }
-
-    @Test
     public void conditionSupplier_bothLocks() throws InterruptedException {
         Supplier<AdvisoryLocksCondition> conditionSupplier = AdvisoryLockConditionSuppliers.get(
                 lockService, ImmutableSet.of(EXTERNAL_LOCK_TOKEN), LOCK_REQUEST_SUPPLIER);

--- a/changelog/@unreleased/pr-7158.v2.yml
+++ b/changelog/@unreleased/pr-7158.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Advisory lock acquisition is no longer retried. Lock acquisition will
+    behave exactly as specified in the provided `LockRequest`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7158


### PR DESCRIPTION
## Before this PR

Consider the following code:

```java
transactionManager.runWithLocksWithRetry(
        () -> LockRequest.builder(lockDescriptors)
                .blockForAtMost(SimpleTimeDuration.of(10, TimeUnit.SECONDS))
                .build(),
        (txn, heldLocks) -> { ... });
```

As a caller, I would expect that I could use the `blockForAtMost` value to control how long I'm willing to wait for the lock before giving up. So I would expect that this code would wait for 10 seconds to acquire the lock and then fail by throwing a `LockAcquisitionException` if it cannot acquire the lock.

However, the `AdvisoryLocksCondition` that is used here will end up retrying the lock request 10 times. So this code will actually wait for up to 100 seconds to acquire the lock. This is surprising behavior and can result in much higher latency than callers intended.

With these retries, it is difficult for callers to reliably control how long they wait to acquire locks, since the actual time depends on implementation details of AtlasDB - namely, how many retries are performed here.

It seems much better to avoid retries here so callers are in complete control over how long to wait for locks.

Some of the blocking modes don't really makes sense to retry anyways. The only blocking mode that would be reasonable to retry is `BLOCK_UNTIL_TIMEOUT` and that has the problems mentioned above.

## After this PR

When running transactions with locks, AtlasDB does not retry the lock request if it was unable to acquire the locks on the first attempt.