### PR TITLE
getActiveNamespaces tracks active namespaces with expiry

### DIFF
--- a/timelock-api/src/main/conjure/timelock-management-api.yml
+++ b/timelock-api/src/main/conjure/timelock-management-api.yml
@@ -23,7 +23,7 @@ services:
         http: POST /getActiveNamespaces
         returns: set<string>
         docs: |
-          The endpoint loads all namespaces that have requested new timestamps within the past 6 hours
+          The endpoint loads all namespaces that have had any interaction with the namespace within the past 6 hours
           (or since the last restart, if that happened within the last 6 hours).
           ``leaderPaxos`` is filtered out from the set as it is not a namespace.
 

--- a/timelock-api/src/main/conjure/timelock-management-api.yml
+++ b/timelock-api/src/main/conjure/timelock-management-api.yml
@@ -23,7 +23,7 @@ services:
         http: POST /getActiveNamespaces
         returns: set<string>
         docs: |
-          The endpoint loads all namespaces with new timestamps since the last restart. 
+          The endpoint loads all namespaces with new timestamps in the past 6 hours or since the last restart. 
           ``leaderPaxos`` is filtered out from the set as it is not a namespace.
 
       achieveConsensus:

--- a/timelock-api/src/main/conjure/timelock-management-api.yml
+++ b/timelock-api/src/main/conjure/timelock-management-api.yml
@@ -23,7 +23,8 @@ services:
         http: POST /getActiveNamespaces
         returns: set<string>
         docs: |
-          The endpoint loads all namespaces with new timestamps in the past 6 hours or since the last restart. 
+          The endpoint loads all namespaces that have requested new timestamps within the past 6 hours
+          (or since the last restart, if that happened within the last 6 hours).
           ``leaderPaxos`` is filtered out from the set as it is not a namespace.
 
       achieveConsensus:

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
@@ -104,10 +104,10 @@ public final class TimelockNamespaces {
      */
     public TimeLockServices get(String namespace, Optional<String> userAgent) {
         // Attempt a slight perf optimization, to avoid synchronization on every single call
+        Instant now = Instant.now();
         Instant oldActiveTime = activeServicesToTime.get(namespace);
-        if (oldActiveTime == null
-                || Instant.now().truncatedTo(ChronoUnit.MINUTES).isAfter(oldActiveTime)) {
-            activeServicesToTime.put(namespace, Instant.now());
+        if (oldActiveTime == null || now.truncatedTo(ChronoUnit.MINUTES).isAfter(oldActiveTime)) {
+            activeServicesToTime.put(namespace, now);
         }
 
         return services.computeIfAbsent(namespace, _namespace -> {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
@@ -67,7 +67,8 @@ public final class TimelockNamespaces {
     private final Supplier<Integer> maxNumberOfClients;
 
     // Do not use a cache, which performs maintenance on each write. We want writes to be fast
-    private final ConcurrentMap<String, Instant> activeServicesToTime = ConcurrentMaps.newWithExpectedEntries(200);
+    private final ConcurrentMap<String, Instant> activeServicesToTime =
+            ConcurrentMaps.newWithExpectedEntries(estimatedClients());
 
     public TimelockNamespaces(
             MetricsManager metrics, Function<String, TimeLockServices> factory, Supplier<Integer> maxNumberOfClients) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
@@ -103,10 +103,7 @@ public final class TimelockNamespaces {
      * server-side Jersey interfaces (which are just used in tests)
      */
     public TimeLockServices get(String namespace, Optional<String> userAgent) {
-        // Potentially preemptive optimization, but using merge rather than put to avoid synchronization when it's
-        // already been updated recently enough
-        activeServicesToTime.merge(
-                namespace, Instant.now().truncatedTo(ChronoUnit.MINUTES), (a, b) -> a.isAfter(b) ? a : b);
+        activeServicesToTime.put(namespace, Instant.now());
 
         return services.computeIfAbsent(namespace, _namespace -> {
             log.info(

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java
@@ -103,8 +103,11 @@ public final class TimelockNamespaces {
      * server-side Jersey interfaces (which are just used in tests)
      */
     public TimeLockServices get(String namespace, Optional<String> userAgent) {
+        // Potentially preemptive optimization, but using merge rather than put to avoid synchronization when it's
+        // already been updated recently enough
         activeServicesToTime.merge(
                 namespace, Instant.now().truncatedTo(ChronoUnit.MINUTES), (a, b) -> a.isAfter(b) ? a : b);
+
         return services.computeIfAbsent(namespace, _namespace -> {
             log.info(
                     "Creating new timelock client",

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/management/TimeLockManagementResource.java
@@ -92,7 +92,7 @@ public final class TimeLockManagementResource implements UndertowTimeLockManagem
     @Override
     public ListenableFuture<Set<String>> getActiveNamespaces(AuthHeader authHeader) {
         // This endpoint only returns state already in memory, so it's okay to NOT make it async.
-        return Futures.immediateFuture(timelockNamespaces.getActiveClients().stream()
+        return Futures.immediateFuture(timelockNamespaces.getActiveClientsWithExpiry().stream()
                 .map(Client::value)
                 .filter(value -> !value.equals(PaxosTimeLockConstants.LEADER_PAXOS_NAMESPACE))
                 .collect(Collectors.toSet()));


### PR DESCRIPTION
Before this PR:
TimeLockManagementService#getActiveNamespaces returns client namespaces active since the last time this Timelock node was restarted.

After this PR:
TimeLockManagementService#getActiveNamespaces returns client namespaces active in the past 6 hours or since the last time this Timelock node was restarted. This way, when client services are uninstalled or have their config modified to change their namespace name, it no longer shows as active (potentially for days) until each Timelock node is bounced.
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
