### PR TITLE
Add namespace parameter to getLockState

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -144,6 +144,13 @@ acceptedBreaks:
       new: "parameter void com.palantir.atlasdb.keyvalue.cassandra.TracingQueryRunner::<init>(===com.palantir.logsafe.logger.SafeLogger===,\
         \ java.util.function.Supplier<com.palantir.atlasdb.cassandra.CassandraTracingConfig>)"
       justification: "internal API change on tracingqueryrunner"
+  "0.1104.0":
+    com.palantir.atlasdb:atlasdb-config:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method com.palantir.lock.LockState com.palantir.atlasdb.factory.timelock.TimeoutSensitiveLockRpcClient::getLockState(com.palantir.lock.LockDescriptor)"
+      new: "method com.palantir.lock.LockState com.palantir.atlasdb.factory.timelock.TimeoutSensitiveLockRpcClient::getLockState(java.lang.String,\
+        \ com.palantir.lock.LockDescriptor)"
+      justification: "LockRpcClient#getLockState is broken"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimeoutSensitiveLockRpcClient.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/timelock/TimeoutSensitiveLockRpcClient.java
@@ -159,7 +159,7 @@ public class TimeoutSensitiveLockRpcClient implements LockRpcClient {
     }
 
     @Override
-    public LockState getLockState(LockDescriptor lock) {
-        return shortTimeoutProxy.getLockState(lock);
+    public LockState getLockState(String namespace, LockDescriptor lock) {
+        return shortTimeoutProxy.getLockState(namespace, lock);
     }
 }

--- a/changelog/@unreleased/pr-7161.v2.yml
+++ b/changelog/@unreleased/pr-7161.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '`LockService.getLockState` now works with external Timelock.'
+  links:
+  - https://github.com/palantir/atlasdb/pull/7161

--- a/lock-api/src/main/java/com/palantir/lock/LockRpcClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/LockRpcClient.java
@@ -141,5 +141,5 @@ public interface LockRpcClient {
 
     @POST
     @Path("get-debugging-lock-state")
-    LockState getLockState(LockDescriptor lock);
+    LockState getLockState(@Safe @PathParam("namespace") String namespace, LockDescriptor lock);
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/DialogueComposingLockRpcClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/DialogueComposingLockRpcClient.java
@@ -163,7 +163,7 @@ public class DialogueComposingLockRpcClient implements LockRpcClient {
     }
 
     @Override
-    public LockState getLockState(LockDescriptor lock) {
-        return dialogueShimDelegate.getLockState(lock);
+    public LockState getLockState(String namespace, LockDescriptor lock) {
+        return dialogueShimDelegate.getLockState(namespace, lock);
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/NamespaceAgnosticLockClientAdaptor.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/NamespaceAgnosticLockClientAdaptor.java
@@ -150,6 +150,6 @@ public class NamespaceAgnosticLockClientAdaptor implements NamespaceAgnosticLock
 
     @Override
     public LockState getLockState(LockDescriptor lock) {
-        return lockRpcClient.getLockState(lock);
+        return lockRpcClient.getLockState(namespace, lock);
     }
 }


### PR DESCRIPTION
## Before this PR

`LockService.getLockState` always fails when using external Timelock.

The `LockRpcClient` JAX-RS client interface has a class level `@Path("/{namespace}/lock")` annotation, but the `getLockState` method does not include a `@PathParam("namespace")` parameter. So the `{namespace}` template does not get replaced in the URL and Timelock sees a literal `{namespace}` for the namespace value, which fails the validation here:

https://github.com/palantir/atlasdb/blob/1830ac97688d5c45e3d99b321a88891de6dd4bf2/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/TimelockNamespaces.java#L120-L121

```
com.palantir.logsafe.exceptions.SafeIllegalArgumentException: Invalid namespace
	at com.palantir.logsafe.Preconditions.checkArgument(Preconditions.java:79)
	at com.palantir.atlasdb.timelock.TimelockNamespaces.createNewClient(TimelockNamespaces.java:120)
	at com.palantir.atlasdb.timelock.TimelockNamespaces.lambda$get$0(TimelockNamespaces.java:103)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at com.palantir.atlasdb.timelock.TimelockNamespaces.get(TimelockNamespaces.java:98)
	at com.palantir.atlasdb.timelock.LockV1Resource.getLockService(LockV1Resource.java:556)
	at com.palantir.atlasdb.timelock.LockV1Resource.getLockState(LockV1Resource.java:552)
```

## After this PR

This PR adds the required `@PathParam("namespace")` parameter to `getLockState`. This is an ABI break, but this feels acceptable because:

- This method is simply broken without it.

    At least, in places using external Timelock, which is nearly all production environments.

- There are no implementations or callers in internal repos.

    This PR does not change the `LockService` API, only the internal client interface.

I've confirmed with local testing that this now works when using external Timelock.