### PR TITLE
[PDS-549354] Add additional Timelock telemetry to better understand SNCLEs

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
@@ -231,7 +231,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 .collect(Collectors.toList()));
 
         assertThat(ColumnFamilyDefinitions.isMatchingCf(
-                kvs.getCfForTable(NEVER_SEEN, getMetadata(), FOUR_DAYS_IN_SECONDS), clusterSideCf))
+                        kvs.getCfForTable(NEVER_SEEN, getMetadata(), FOUR_DAYS_IN_SECONDS), clusterSideCf))
                 .as("After serialization and deserialization to database, Cf metadata did not match.")
                 .isTrue();
     }
@@ -256,8 +256,10 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
     @SuppressWarnings("CompileTimeConstant")
     public void shouldNotErrorForTimestampTableWhenCreatingCassandraKvs() {
         verify(logger, atLeast(0))
-                .error(startsWith("Found a table {} that did not have persisted"),
-                        assertArg((Arg<String> arg) -> assertThat(arg.getValue()).doesNotContain("timestamp")));
+                .error(
+                        startsWith("Found a table {} that did not have persisted"),
+                        assertArg(
+                                (Arg<String> arg) -> assertThat(arg.getValue()).doesNotContain("timestamp")));
     }
 
     @Test
@@ -492,20 +494,20 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
 
         keyValueService.putUnlessExists(userTable, ImmutableMap.of(CELL, sad));
         assertThat(keyValueService
-                .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
-                .get(CELL)
-                .getContents())
+                        .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
+                        .get(CELL)
+                        .getContents())
                 .containsExactly(sad);
 
         keyValueService.setOnce(userTable, ImmutableMap.of(CELL, happy));
         assertThat(keyValueService
-                .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
-                .get(CELL)
-                .getContents())
+                        .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
+                        .get(CELL)
+                        .getContents())
                 .containsExactly(happy);
         assertThat(keyValueService
-                .getAllTimestamps(userTable, ImmutableSet.of(CELL), Long.MAX_VALUE)
-                .size())
+                        .getAllTimestamps(userTable, ImmutableSet.of(CELL), Long.MAX_VALUE)
+                        .size())
                 .isEqualTo(1);
         keyValueService.truncateTable(userTable);
     }
@@ -665,9 +667,9 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
         Cell nextTestCell = Cell.create(row(1), column(1));
 
         assertThatThrownBy(() -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                TEST_TABLE,
-                firstTestCell.getRowName(),
-                ImmutableMap.of(firstTestCell, val(0, 0), nextTestCell, val(0, 1)))))
+                        TEST_TABLE,
+                        firstTestCell.getRowName(),
+                        ImmutableMap.of(firstTestCell, val(0, 0), nextTestCell, val(0, 1)))))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Can only update cells in one row.");
     }
@@ -683,7 +685,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 1))));
 
         assertThatThrownBy(() -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))))
+                        TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))))
                 .isInstanceOf(MultiCheckAndSetException.class);
 
         MultiCheckAndSetException ex = catchThrowableOfType(
@@ -808,7 +810,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 .setComment("")
                 .setColumn_metadata(new ArrayList<>())
                 .setTriggers(new ArrayList<>())
-                .setKey_alias(new byte[]{0x6B, 0x65, 0x79})
+                .setKey_alias(new byte[] {0x6B, 0x65, 0x79})
                 .setComparator_type("org.apache.cassandra.db.marshal.CompositeType"
                         + "(org.apache.cassandra.db.marshal.BytesType,org.apache.cassandra.db.marshal.LongType)")
                 .setCompaction_strategy_options(new HashMap<>())

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
@@ -231,7 +231,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 .collect(Collectors.toList()));
 
         assertThat(ColumnFamilyDefinitions.isMatchingCf(
-                        kvs.getCfForTable(NEVER_SEEN, getMetadata(), FOUR_DAYS_IN_SECONDS), clusterSideCf))
+                kvs.getCfForTable(NEVER_SEEN, getMetadata(), FOUR_DAYS_IN_SECONDS), clusterSideCf))
                 .as("After serialization and deserialization to database, Cf metadata did not match.")
                 .isTrue();
     }
@@ -494,20 +494,20 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
 
         keyValueService.putUnlessExists(userTable, ImmutableMap.of(CELL, sad));
         assertThat(keyValueService
-                        .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
-                        .get(CELL)
-                        .getContents())
+                .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
+                .get(CELL)
+                .getContents())
                 .containsExactly(sad);
 
         keyValueService.setOnce(userTable, ImmutableMap.of(CELL, happy));
         assertThat(keyValueService
-                        .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
-                        .get(CELL)
-                        .getContents())
+                .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
+                .get(CELL)
+                .getContents())
                 .containsExactly(happy);
         assertThat(keyValueService
-                        .getAllTimestamps(userTable, ImmutableSet.of(CELL), Long.MAX_VALUE)
-                        .size())
+                .getAllTimestamps(userTable, ImmutableSet.of(CELL), Long.MAX_VALUE)
+                .size())
                 .isEqualTo(1);
         keyValueService.truncateTable(userTable);
     }
@@ -667,9 +667,9 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
         Cell nextTestCell = Cell.create(row(1), column(1));
 
         assertThatThrownBy(() -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                        TEST_TABLE,
-                        firstTestCell.getRowName(),
-                        ImmutableMap.of(firstTestCell, val(0, 0), nextTestCell, val(0, 1)))))
+                TEST_TABLE,
+                firstTestCell.getRowName(),
+                ImmutableMap.of(firstTestCell, val(0, 0), nextTestCell, val(0, 1)))))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Can only update cells in one row.");
     }
@@ -685,7 +685,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 1))));
 
         assertThatThrownBy(() -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                        TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))))
+                TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))))
                 .isInstanceOf(MultiCheckAndSetException.class);
 
         MultiCheckAndSetException ex = catchThrowableOfType(
@@ -810,7 +810,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 .setComment("")
                 .setColumn_metadata(new ArrayList<>())
                 .setTriggers(new ArrayList<>())
-                .setKey_alias(new byte[] {0x6B, 0x65, 0x79})
+                .setKey_alias(new byte[]{0x6B, 0x65, 0x79})
                 .setComparator_type("org.apache.cassandra.db.marshal.CompositeType"
                         + "(org.apache.cassandra.db.marshal.BytesType,org.apache.cassandra.db.marshal.LongType)")
                 .setCompaction_strategy_options(new HashMap<>())

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
@@ -256,10 +256,8 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
     @SuppressWarnings("CompileTimeConstant")
     public void shouldNotErrorForTimestampTableWhenCreatingCassandraKvs() {
         verify(logger, atLeast(0))
-                .error(
-                        startsWith("Found a table {} that did not have persisted"),
-                        assertArg(
-                                (Arg<String> arg) -> assertThat(arg.getValue()).doesNotContain("timestamp")));
+                .error(startsWith("Found a table {} that did not have persisted"),
+                        assertArg((Arg<String> arg) -> assertThat(arg.getValue()).doesNotContain("timestamp")));
     }
 
     @Test

--- a/changelog/@unreleased/pr-7163.v2.yml
+++ b/changelog/@unreleased/pr-7163.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Added telemetry for some cases where we decide we are not the leader
+    in a call to `determineLeadershipStatus`.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7163

--- a/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
+++ b/leader-election-impl/src/main/java/com/palantir/leader/PaxosLeaderElectionService.java
@@ -230,7 +230,8 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
 
     private ListenableFuture<StillLeadingStatus> determineLeadershipStatus(PaxosValue value) {
         if (!isThisNodeTheLeaderFor(value)) {
-            log.info("This node is not the leader for this Paxos value.",
+            log.info(
+                    "This node is not the leader for this Paxos value.",
                     SafeArg.of("value", value),
                     SafeArg.of("proposerId", proposer.getUuid()));
             return Futures.immediateFuture(StillLeadingStatus.NOT_LEADING);
@@ -238,7 +239,8 @@ public class PaxosLeaderElectionService implements LeaderElectionService {
 
         Optional<PaxosValue> greatestLearnedValue = knowledge.getGreatestLearnedValue();
         if (greatestLearnedValue.isEmpty() || !greatestLearnedValue.get().equals(value)) {
-            log.info("According to our local Paxos knowledge, this round is not the most recent round.",
+            log.info(
+                    "According to our local Paxos knowledge, this round is not the most recent round.",
                     SafeArg.of("value", value),
                     SafeArg.of("proposerId", proposer.getUuid()),
                     SafeArg.of("greatestLearnedValue", greatestLearnedValue));


### PR DESCRIPTION
## General
**Before this PR**:
In PDS-549354, we saw some issues with `SuspectedNotCurrentLeaderException`s (SNCLEs) that were a bit unclear to debug: we can see from the timeline that a node caught the SNCLE, but it believed it was no longer the leader even though it still actually was.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Added telemetry for some cases where we decide we are not the leader in a call to `determineLeadershipStatus`.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: Not much in particular

**Is documentation needed?**: No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes, older nodes will just not log these lines

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing in particular

**What was existing testing like? What have you done to improve it?**: No new tests, only a logging change

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: Relevant log lines are visible

**Has the safety of all log arguments been decided correctly?**: I believe so, please check: values in the context of a `LeaderElectionService` are already assumed to be safe, and `leaderUuid` is a UUID.

**Will this change significantly affect our spending on metrics or logs?**:  Probably not

**How would I tell that this PR does not work in production? (monitors, etc.)**: No log lines are visible, or there are too many log lines leading to load

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Maybe if this actually causes perf problems though I doubt it

## Development Process
**Where should we start reviewing?**: It's small

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: +9-5

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
