### PR TITLE
updated gradle-docker to support gradle8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         classpath 'com.palantir.baseline:gradle-baseline-java:5.55.0'
         classpath 'com.palantir.gradle.conjure:gradle-conjure:5.47.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:2.22.0'
-        classpath 'com.palantir.gradle.docker:gradle-docker:0.32.0'
+        classpath 'com.palantir.gradle.docker:gradle-docker:0.35.0'
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.15.0'
         classpath 'com.palantir.gradle.failure-reports:gradle-failure-reports:1.9.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:3.1.0'


### PR DESCRIPTION
## General

Updates `gradle-docker` to version `0.35.0` in order to unblock upgrading to gradle8.

ref: https://github.com/palantir/gradle-docker/issues/618#issuecomment-1495261319

**Please tag any other people who should be aware of this PR**:
@ergo14 
