### PR TITLE
Remove Jackson byte[] workaround

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/persister/JacksonPersister.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/persister/JacksonPersister.java
@@ -19,10 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
 import com.palantir.atlasdb.persist.api.ReusablePersister;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 
 /**
  * A {@link ReusablePersister} that uses an {@link ObjectMapper} to serialize and deserialize objects
@@ -41,14 +38,7 @@ public abstract class JacksonPersister<T> implements ReusablePersister<T> {
     @Override
     public final T hydrateFromBytes(byte[] input) {
         try {
-            if (input.length <= 8192 && mapper.getFactory().canUseCharArrays()) {
-                // Optimize to avoid allocation of heap ByteBuffer via InputStreamReader.
-                // Remove after upgrade to Jackson 2.16.
-                // see: https://github.com/FasterXML/jackson-core/pull/1081
-                // and https://github.com/FasterXML/jackson-benchmarks/pull/9
-                return mapper.readValue(new StringReader(new String(input, StandardCharsets.UTF_8)), typeRef);
-            }
-            return mapper.readValue(new ByteArrayInputStream(input), typeRef);
+            return mapper.readValue(input, typeRef);
         } catch (IOException e) {
             throw Throwables.propagate(e);
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/InternalSchemaMetadataPayloadCodec.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/InternalSchemaMetadataPayloadCodec.java
@@ -25,10 +25,7 @@ import com.palantir.atlasdb.internalschema.InternalSchemaMetadata;
 import com.palantir.conjure.java.serialization.ObjectMappers;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -101,15 +98,7 @@ public final class InternalSchemaMetadataPayloadCodec {
 
     private static InternalSchemaMetadata decodeViaJson(byte[] byteArray) {
         try {
-            if (byteArray.length <= 8192) {
-                // Optimize to avoid allocation of heap ByteBuffer via InputStreamReader.
-                // Remove after upgrade to Jackson 2.16.
-                // see: https://github.com/FasterXML/jackson-core/pull/1081
-                // and https://github.com/FasterXML/jackson-benchmarks/pull/9
-                return SCHEMA_METADATA_READER.readValue(
-                        new StringReader(new String(byteArray, StandardCharsets.UTF_8)));
-            }
-            return SCHEMA_METADATA_READER.readValue(new ByteArrayInputStream(byteArray));
+            return SCHEMA_METADATA_READER.readValue(byteArray);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/changelog/@unreleased/pr-7168.v2.yml
+++ b/changelog/@unreleased/pr-7168.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Now that AtlasDB has upgraded to Jackson 2.16.1, remove performance workaround that landed upstream in Jackson 2.16.0. See https://github.com/FasterXML/jackson-core/pull/1081
+
+    Removes changes from https://github.com/palantir/atlasdb/pull/6750
+  links:
+  - https://github.com/palantir/atlasdb/pull/7168


### PR DESCRIPTION
## General
**Before this PR**:

https://github.com/palantir/atlasdb/pull/6750 added performance workaround until https://github.com/FasterXML/jackson-core/pull/1081 merged upstream in 2.16.0 as AtlasDB was not yet on 2.16.0+.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Now that AtlasDB has upgraded to Jackson 2.16.1, remove performance workaround that landed upstream in Jackson 2.16.0. See https://github.com/FasterXML/jackson-core/pull/1081

Removes changes from https://github.com/palantir/atlasdb/pull/6750

==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
