### PR TITLE
switch to `using` instead of `with` since it is deprecated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,12 +87,12 @@ allprojects {
 
     configurations.all {
         resolutionStrategy.dependencySubstitution {
-            it.substitute it.module('org.glassfish.hk2.external:javax.inject') with it.module('javax.inject:javax.inject:1')
-            it.substitute it.module('org.glassfish.hk2.external:jakarta.inject') with it.module('javax.inject:javax.inject:1')
+            it.substitute it.module('org.glassfish.hk2.external:javax.inject') using it.module('javax.inject:javax.inject:1')
+            it.substitute it.module('org.glassfish.hk2.external:jakarta.inject') using it.module('javax.inject:javax.inject:1')
 
             // See internal migration plugin PR 26: this direction is intentional.
-            it.substitute it.module('javax.el:javax.el-api') with it.module('org.glassfish:jakarta.el:3.0.4')
-            it.substitute it.module('jakarta.el:jakarta.el-api') with it.module('org.glassfish:jakarta.el:3.0.4')
+            it.substitute it.module('javax.el:javax.el-api') using it.module('org.glassfish:jakarta.el:3.0.4')
+            it.substitute it.module('jakarta.el:jakarta.el-api') using it.module('org.glassfish:jakarta.el:3.0.4')
         }
     }
 


### PR DESCRIPTION
## General
**Before this PR**: `build.gradle` used the `with` method but it is now deprecated.

**After this PR**: `build.gradle` uses `using` which is supported by Gradle 8.

==COMMIT_MSG==
switch to `using` instead of `with` since it is deprecated
==COMMIT_MSG==