### PR TITLE
Add coverage for #7118 code path

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
@@ -192,6 +192,17 @@ public final class VersionedEventStoreTest {
     }
 
     @Test
+    public void retentionEventsClearsEventsAboveMaxSize() {
+        eventStore = new VersionedEventStore(CACHE_METRICS, 1, 2);
+        eventStore.putAll(makeEvents(EVENT_1, EVENT_2, EVENT_3, EVENT_4));
+        assertThat(eventStore.retentionEvents(Optional.of(SEQ_MIN)).events().stream()
+                        .map(LockWatchEvent::sequence)
+                        .map(Sequence::of))
+                .containsExactly(SEQ_1, SEQ_2);
+        assertThat(eventStore.containsEntryLessThanOrEqualTo(SEQ_3.value())).isTrue();
+    }
+
+    @Test
     public void retentionEventsClearsEventsAboveMaxSizeRegardlessOfVersion() {
         eventStore = new VersionedEventStore(CACHE_METRICS, 1, 3);
         eventStore.putAll(makeEvents(EVENT_1, EVENT_2, EVENT_3, EVENT_4));

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
@@ -193,13 +193,12 @@ public final class VersionedEventStoreTest {
 
     @Test
     public void retentionEventsClearsEventsAboveMaxSize() {
-        eventStore = new VersionedEventStore(CACHE_METRICS, 1, 2);
+        eventStore = new VersionedEventStore(CACHE_METRICS, 1, 3);
         eventStore.putAll(makeEvents(EVENT_1, EVENT_2, EVENT_3, EVENT_4));
-        assertThat(eventStore.retentionEvents(Optional.of(SEQ_MIN)).events().stream()
+        assertThat(eventStore.retentionEvents(Optional.empty()).events().stream()
                         .map(LockWatchEvent::sequence)
                         .map(Sequence::of))
-                .containsExactly(SEQ_1, SEQ_2);
-        assertThat(eventStore.containsEntryLessThanOrEqualTo(SEQ_3.value())).isTrue();
+                .containsExactly(SEQ_1, SEQ_2, SEQ_3);
     }
 
     @Test


### PR DESCRIPTION
## General
**Before this PR**:
No test coverage would have caught the bug referenced in #7174.

**After this PR**:
Follow-up to https://github.com/palantir/atlasdb/pull/7174 adding test coverage that would have caught the bug.

==COMMIT_MSG==
Add test to `VersionedEventStore` (#7174).
==COMMIT_MSG==

**Priority**:
P1
**Concerns / possible downsides (what feedback would you like?)**:
The test is a bit contrived, and the failure path is not throwing but given there is an output it does not hurt to assert that. This class in general needs a bit more cover. 

Though, there was some coverage for the max case. It just unfortunately did not hit the code path because the first call to the internal retention had an empty view of the map.

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A

**What was existing testing like? What have you done to improve it?**:
This is testing

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
I ran the test with the bad version of `VersionedEventStore` and it did not pass.

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
N/A

**How would I tell that this PR does not work in production? (monitors, etc.)**:
See above

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:
Small

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@mdaudali 

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
