### PR TITLE
[ASTS] feat(bucket-retrieval): Parallel task executor for ShardedSweepableBucketRetriever

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutor.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 
 public final class DefaultParallelTaskExecutor implements ParallelTaskExecutor {
     private final ExecutorService cachedExecutorService;
+    // Should be the upper bound of the task duration + a little bit of buffer
     private final Refreshable<Duration> semaphoreAcquireTimeout;
 
     private DefaultParallelTaskExecutor(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutor.java
@@ -1,0 +1,91 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts;
+
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.refreshable.Refreshable;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class DefaultParallelTaskExecutor implements ParallelTaskExecutor {
+    private final ExecutorService cachedExecutorService;
+    private final Refreshable<Duration> semaphoreAcquireTimeout;
+
+    private DefaultParallelTaskExecutor(
+            ExecutorService cachedExecutorService, Refreshable<Duration> semaphoreAcquireTimeout) {
+        this.cachedExecutorService = cachedExecutorService;
+        this.semaphoreAcquireTimeout = semaphoreAcquireTimeout;
+    }
+
+    public static DefaultParallelTaskExecutor create(
+            ExecutorService cachedExecutorService, Refreshable<Duration> semaphoreAcquireTimeout) {
+        return new DefaultParallelTaskExecutor(cachedExecutorService, semaphoreAcquireTimeout);
+    }
+
+    @Override
+    public <V, K> List<V> execute(Stream<K> arg, Function<K, V> task, int maxParallelism) {
+        Semaphore semaphore = new Semaphore(maxParallelism);
+        List<Future<V>> executedTasks = arg.map(k -> {
+                    // This is outside of the executor otherwise we end up spinning up a tonne of threads
+                    acquireSemaphore(semaphore);
+                    try {
+                        return cachedExecutorService.submit(() -> {
+                            try {
+                                return task.apply(k);
+                            } finally {
+                                semaphore.release();
+                            }
+                        });
+                    } catch (Exception e) {
+                        semaphore.release(); // Doesn't really matter, since this will cause the whole execute method
+                        // to fail and we'll re-create a semaphore on the next execute call
+                        // but good hygiene
+                        throw e;
+                    }
+                })
+                // Needed to force computation at this layer, rather than blocking on get
+                .collect(Collectors.toList());
+        return executedTasks.stream()
+                .map(future -> {
+                    try {
+                        return future.get();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    private void acquireSemaphore(Semaphore semaphore) {
+        try {
+            boolean result = semaphore.tryAcquire(semaphoreAcquireTimeout.get().toMillis(), TimeUnit.MILLISECONDS);
+            if (!result) {
+                throw new SafeRuntimeException("Failed to acquire semaphore within timeout");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutor.java
@@ -76,6 +76,9 @@ public final class DefaultParallelTaskExecutor implements ParallelTaskExecutor {
                 .map(future -> {
                     try {
                         return future.get();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/ParallelTaskExecutor.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/ParallelTaskExecutor.java
@@ -16,14 +16,12 @@
 
 package com.palantir.atlasdb.sweep.asts;
 
-import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
-public interface SweepableBucketRetriever {
-    /**
-     * Returns the sweepable buckets for a given shard. The list of sweepable buckets will be ordered
-     * by bucket identifier, then by shard.
-     * TODO: Should the ordering of the buckets be done here, or in another class?
-     */
-    List<SweepableBucket> getSweepableBuckets();
+// Came out of making ShardedSweepableBucketRetriever way easier to test. It was a pain to test
+// concurrency logic with no way of controlling the task from the test
+public interface ParallelTaskExecutor {
+    <V, K> List<V> execute(Stream<K> arg, Function<K, V> task, int maxParallelism);
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutorTest.java
@@ -94,6 +94,8 @@ public final class DefaultParallelTaskExecutorTest {
         CountDownLatch continueTest = new CountDownLatch(1);
         Function<Integer, Integer> task = i -> {
             waitForTasksToStart.countDown();
+
+            // We don't actually want the task to ever progress, so we don't count down continueTest
             awaitLatch(continueTest, Duration.ofSeconds(1));
             return i;
         };

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutorTest.java
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-public final class DefaultParallelTestExecutorTest {
+public final class DefaultParallelTaskExecutorTest {
     private final ThreadGroup threadGroup = new ThreadGroup("workers");
 
     private final ExecutorService cachedExecutorService =
@@ -87,7 +87,7 @@ public final class DefaultParallelTestExecutorTest {
     }
 
     @Test
-    public void spinsUpNoMoreThanMaxParallelismTasks() {
+    public void spinsUpNoMoreThanMaxParallelismThreads() {
         int maxParallelism = 2;
         Stream<Integer> args = IntStream.range(0, 10).boxed();
         CountDownLatch waitForTasksToStart = new CountDownLatch(maxParallelism);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutorTest.java
@@ -17,9 +17,11 @@
 package com.palantir.atlasdb.sweep.asts;
 
 import static com.palantir.logsafe.testing.Assertions.assertThat;
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.logsafe.SafeArg;
 import com.palantir.refreshable.Refreshable;
 import com.palantir.refreshable.SettableRefreshable;
 import java.time.Duration;
@@ -134,8 +136,8 @@ public final class DefaultParallelTaskExecutorTest {
             awaitLatch(continueTest, Duration.ofSeconds(1));
             return i;
         };
-        assertThatThrownBy(() -> taskExecutor.execute(args, task, 1))
-                .hasMessage("Failed to acquire semaphore within timeout");
+        assertThatLoggableExceptionThrownBy(() -> taskExecutor.execute(args, task, 1))
+                .hasLogMessage("Failed to acquire semaphore within timeout").hasExactlyArgs(SafeArg.of("timeout", semaphoreAcquireTimeout.get()));
     }
 
     private void awaitLatch(CountDownLatch latch, Duration timeout) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTaskExecutorTest.java
@@ -42,7 +42,7 @@ public final class DefaultParallelTaskExecutorTest {
     private final ThreadGroup threadGroup = new ThreadGroup("workers");
 
     private final ExecutorService cachedExecutorService =
-            Executors.newCachedThreadPool(r -> new Thread(threadGroup, r));
+            Executors.newCachedThreadPool(runnable -> new Thread(threadGroup, runnable));
 
     private final SettableRefreshable<Duration> semaphoreAcquireTimeout = Refreshable.create(Duration.ofSeconds(5));
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTestExecutorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultParallelTestExecutorTest.java
@@ -1,0 +1,150 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts;
+
+import static com.palantir.logsafe.testing.Assertions.assertThat;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.refreshable.Refreshable;
+import com.palantir.refreshable.SettableRefreshable;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public final class DefaultParallelTestExecutorTest {
+    private final ThreadGroup threadGroup = new ThreadGroup("workers");
+
+    private final ExecutorService cachedExecutorService =
+            Executors.newCachedThreadPool(r -> new Thread(threadGroup, r));
+
+    private final SettableRefreshable<Duration> semaphoreAcquireTimeout = Refreshable.create(Duration.ofSeconds(5));
+
+    private final ParallelTaskExecutor taskExecutor =
+            DefaultParallelTaskExecutor.create(cachedExecutorService, semaphoreAcquireTimeout);
+
+    @AfterEach
+    public void tearDown() {
+        cachedExecutorService.shutdownNow();
+    }
+
+    @Test
+    public void taskCalledInSequenceWithArgs() {
+        Stream<Integer> args = IntStream.range(0, 10).boxed();
+        Function<Integer, Integer> task = i -> i;
+        List<Integer> result = taskExecutor.execute(args, task, 1);
+        assertThat(result)
+                .containsExactlyElementsOf(IntStream.range(0, 10).boxed().collect(toList()));
+    }
+
+    @Test
+    public void executesAtMostMaxParallelismInParallel() throws ExecutionException, InterruptedException {
+        int maxParallelism = 2;
+        Stream<Integer> args = IntStream.range(0, 10).boxed();
+        CountDownLatch continueTest = new CountDownLatch(1);
+        CountDownLatch waitForTasksToStart = new CountDownLatch(maxParallelism);
+        Set<Integer> executed = ConcurrentHashMap.newKeySet();
+        Function<Integer, Integer> task = i -> {
+            executed.add(i);
+            waitForTasksToStart.countDown();
+            awaitLatch(continueTest, Duration.ofSeconds(1));
+            return i;
+        };
+        Future<List<Integer>> future =
+                cachedExecutorService.submit(() -> taskExecutor.execute(args, task, maxParallelism));
+        awaitLatch(waitForTasksToStart, Duration.ofMillis(100));
+        assertThat(executed).hasSize(maxParallelism);
+        continueTest.countDown();
+        List<Integer> result = future.get();
+        assertThat(result)
+                .containsExactlyElementsOf(IntStream.range(0, 10).boxed().collect(toList()));
+    }
+
+    @Test
+    public void spinsUpNoMoreThanMaxParallelismTasks() {
+        int maxParallelism = 2;
+        Stream<Integer> args = IntStream.range(0, 10).boxed();
+        CountDownLatch waitForTasksToStart = new CountDownLatch(maxParallelism);
+        CountDownLatch continueTest = new CountDownLatch(1);
+        Function<Integer, Integer> task = i -> {
+            waitForTasksToStart.countDown();
+            awaitLatch(continueTest, Duration.ofSeconds(1));
+            return i;
+        };
+        Future<List<Integer>> _future =
+                cachedExecutorService.submit(() -> taskExecutor.execute(args, task, maxParallelism));
+        awaitLatch(waitForTasksToStart, Duration.ofMillis(100));
+
+        // + 1 to include the taskExecutor call
+        assertThat(threadGroup.activeCount()).isEqualTo(maxParallelism + 1);
+    }
+
+    @Test
+    // i.e, we release the semaphore and don't block forever!
+    public void continuesToExecuteEvenWhenTasksFail() {
+        Stream<Integer> args = IntStream.range(0, 10).boxed();
+        Set<Integer> executed = ConcurrentHashMap.newKeySet();
+        Function<Integer, Integer> task = i -> {
+            if (i == 5) {
+                throw new RuntimeException("Task failed");
+            }
+            executed.add(i);
+            return i;
+        };
+        assertThatThrownBy(() -> taskExecutor.execute(args, task, 1));
+        assertThat(executed)
+                .containsExactlyElementsOf(
+                        IntStream.range(0, 10).filter(i -> i != 5).boxed().collect(toList()));
+    }
+
+    @Test
+    public void eventuallyFailsToAcquireSemaphore() {
+        Stream<Integer> args = IntStream.range(0, 10).boxed();
+        CountDownLatch continueTest = new CountDownLatch(1);
+        semaphoreAcquireTimeout.update(Duration.ofMillis(100));
+        Function<Integer, Integer> task = i -> {
+            awaitLatch(continueTest, Duration.ofSeconds(1));
+            return i;
+        };
+        assertThatThrownBy(() -> taskExecutor.execute(args, task, 1))
+                .hasMessage("Failed to acquire semaphore within timeout");
+    }
+
+    private void awaitLatch(CountDownLatch latch, Duration timeout) {
+        try {
+            boolean result = latch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            if (!result) {
+                throw new RuntimeException("Latch did not count down in time");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
I need a way to execute y tasks with x parallelism, so that we can grab all sweepable buckets from shards

**After this PR**:
Now we can
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
Check my semaphores, but it's pretty simple.
**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
no
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
no
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
no
**Does this PR need a schema migration?**
no
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
None
**What was existing testing like? What have you done to improve it?**:
Added tests for the parallel task executor
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
I believe so!
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
n/a
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Tasks are executed
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
You don't, but I'll add telemetry later
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
This isn't wired up
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
Not by itself
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
I don't think so
## Development Process
**Where should we start reviewing?**:
DPTE
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
