### PR TITLE
[ASTS] feat(bucket-retrieval): Sharded sweepable bucket retriever

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/ShardedSweepableBucketRetriever.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/ShardedSweepableBucketRetriever.java
@@ -1,0 +1,133 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.atlasdb.sweep.asts.ShardedSweepTimestampManager.SweepTimestamps;
+import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.table.description.SweeperStrategy;
+import com.palantir.refreshable.Refreshable;
+import com.palantir.tracing.CloseableTracer;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class ShardedSweepableBucketRetriever implements SweepableBucketRetriever {
+    private final Refreshable<Integer> numShards;
+    private final SweeperStrategy strategy;
+
+    private final ShardedRetrievalStrategy shardedRetrievalStrategy;
+    private final ShardedSweepTimestampManager sweepTimestampManager;
+    private final ParallelTaskExecutor parallelTaskExecutor;
+
+    private final Refreshable<Integer> maxParallelism;
+
+    private final Refreshable<Duration> maxBackoff;
+
+    // Exists to facilitate testing in unit tests, rather than needing to mock out ThreadLocalRandom.
+    private final Supplier<Long> backoffMillisGenerator;
+
+    @VisibleForTesting
+    ShardedSweepableBucketRetriever(
+            Refreshable<Integer> numShards,
+            SweeperStrategy strategy,
+            ShardedRetrievalStrategy shardedRetrievalStrategy,
+            ShardedSweepTimestampManager sweepTimestampManager,
+            ParallelTaskExecutor parallelTaskExecutor,
+            Refreshable<Integer> maxParallelism,
+            Refreshable<Duration> maxBackoff,
+            Supplier<Long> backoffMillisGenerator) {
+        this.numShards = numShards;
+        this.shardedRetrievalStrategy = shardedRetrievalStrategy;
+        this.strategy = strategy;
+        this.sweepTimestampManager = sweepTimestampManager;
+        this.parallelTaskExecutor = parallelTaskExecutor;
+        this.maxParallelism = maxParallelism;
+        this.maxBackoff = maxBackoff;
+        this.backoffMillisGenerator = backoffMillisGenerator;
+    }
+
+    public static SweepableBucketRetriever create(
+            Refreshable<Integer> numShards,
+            SweeperStrategy strategy,
+            ShardedRetrievalStrategy shardedRetrievalStrategy,
+            ShardedSweepTimestampManager sweepTimestampManager,
+            ParallelTaskExecutor parallelTaskExecutor,
+            Refreshable<Integer> maxParallelism,
+            Refreshable<Duration> maxBackoff) {
+        return new ShardedSweepableBucketRetriever(
+                numShards,
+                strategy,
+                shardedRetrievalStrategy,
+                sweepTimestampManager,
+                parallelTaskExecutor,
+                maxParallelism,
+                maxBackoff,
+                // We want _some_ backoff, hence the minimum is 1, rather than the standard 0.
+                () -> ThreadLocalRandom.current().nextLong(1, maxBackoff.get().toMillis()));
+    }
+
+    @Override
+    public Set<SweepableBucket> getSweepableBuckets() {
+        List<List<SweepableBucket>> sweepableBuckets;
+        try (CloseableTracer tracer = CloseableTracer.startSpan("getSweepableBucketsAcrossAllShards")) {
+            // TODO: Time it!
+            sweepableBuckets = parallelTaskExecutor.execute(
+                    IntStream.range(0, numShards.get()).boxed(),
+                    this::getSweepableBucketsForShardWithJitter,
+                    maxParallelism.get());
+        }
+        return sweepableBuckets.stream().flatMap(List::stream).collect(Collectors.toSet());
+    }
+
+    /**
+     *
+     * What we want (Essentially, don't kill the database):
+     * Don't run more than maxParallelism tasks
+     * Have a delay between tasks executing (and random) to avoid thundering herd
+     *
+     * maxBackoff must be small (e.g. like 5ms) - otherwise you'll end up massively serialising the requests and not
+     * really achieving any parallelism.
+     *
+     * The "obvious" but partially wrong? solution to this is to add a delay before / after the semaphore acquisition
+     * in parallel task executor.
+     * If you do that, you won't actually delay from occurring - if you do it before the semaphore acquisition, you'll
+     * run through your delay _in parallel_ to the current task executing, rather than after.
+     * If you do it after the semaphore is released, the next task will execute whilst the jittering thread
+     * is running through the delay, also resulting in limited actual delay occurring.
+     */
+    private List<SweepableBucket> getSweepableBucketsForShardWithJitter(int shard) {
+        try {
+            Thread.sleep(backoffMillisGenerator.get());
+            return getSweepableBucketsForShard(shard);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<SweepableBucket> getSweepableBucketsForShard(int shard) {
+        ShardAndStrategy shardAndStrategy = ShardAndStrategy.of(shard, strategy);
+        SweepTimestamps sweepTimestamps = sweepTimestampManager.getSweepTimestamps(shardAndStrategy);
+        return shardedRetrievalStrategy.getSweepableBucketsForShard(shardAndStrategy, sweepTimestamps);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/SweepableBucketRetriever.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/SweepableBucketRetriever.java
@@ -17,13 +17,9 @@
 package com.palantir.atlasdb.sweep.asts;
 
 import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
-import java.util.List;
+import java.util.Set;
 
 public interface SweepableBucketRetriever {
-    /**
-     * Returns the sweepable buckets for a given shard. The list of sweepable buckets will be ordered
-     * by bucket identifier, then by shard.
-     * TODO: Should the ordering of the buckets be done here, or in another class?
-     */
-    List<SweepableBucket> getSweepableBuckets();
+    // TODO: Consider making this a list and doing a K way merge sort internally.
+    Set<SweepableBucket> getSweepableBuckets();
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/ShardedSweepableBucketRetrieverTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/ShardedSweepableBucketRetrieverTest.java
@@ -1,0 +1,180 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.atlasdb.sweep.asts.ShardedSweepTimestampManager.SweepTimestamps;
+import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.table.description.SweeperStrategy;
+import com.palantir.common.concurrent.PTExecutors;
+import com.palantir.refreshable.Refreshable;
+import com.palantir.refreshable.SettableRefreshable;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ShardedSweepableBucketRetrieverTest {
+    private static final SweepTimestamps SWEEP_TIMESTAMPS =
+            SweepTimestamps.builder().sweepTimestamp(1).lastSweptTimestamp(12).build();
+    private final SettableRefreshable<Integer> numShards = Refreshable.create(1);
+    private final SettableRefreshable<Integer> maxParallelism = Refreshable.create(1);
+    private final SettableRefreshable<Duration> maxBackoff = Refreshable.create(Duration.ofMillis(0));
+    private final TestShardedRetrievalStrategy strategy = new TestShardedRetrievalStrategy();
+    private final TestParallelTaskExecutor parallelTaskExecutor = new TestParallelTaskExecutor();
+    private final ExecutorService executorService = PTExecutors.newSingleThreadScheduledExecutor();
+    private SweepableBucketRetriever retriever;
+
+    @BeforeEach
+    public void before() {
+        retriever = new ShardedSweepableBucketRetriever(
+                numShards,
+                SweeperStrategy.CONSERVATIVE,
+                strategy,
+                shardAndStrategy -> SWEEP_TIMESTAMPS,
+                parallelTaskExecutor,
+                maxParallelism,
+                maxBackoff,
+
+                // The tests that rely on this are based off the sleep duration being equal to the maxBackoff.
+                // so for simplicity, it's set to that for all tests.
+                () -> maxBackoff.get().toMillis());
+    }
+
+    @AfterEach
+    public void after() {
+        executorService.shutdown();
+    }
+
+    @Test
+    public void everyShardIsRequested() {
+        int shards = 10;
+        numShards.update(shards);
+        retriever.getSweepableBuckets();
+        assertThat(strategy.getRequestedShards())
+                .isEqualTo(IntStream.range(0, shards).boxed().collect(Collectors.toSet()));
+    }
+
+    @Test
+    public void noMoreThanMaxParallelismRequestsAreMadeInParallel() {
+        maxParallelism.update(23);
+        retriever.getSweepableBuckets();
+        assertThat(parallelTaskExecutor.getLastMaxParallelism()).contains(23);
+    }
+
+    @Test
+    public void updatesToMaxParallelismAreReflectedInSubsequentRequests() {
+        int newMaxParallelism = 9084;
+        maxParallelism.update(12);
+        retriever.getSweepableBuckets();
+        maxParallelism.update(newMaxParallelism);
+        retriever.getSweepableBuckets();
+        assertThat(parallelTaskExecutor.getLastMaxParallelism()).contains(newMaxParallelism);
+    }
+
+    @Test
+    public void boundedBackoffBetweenRequests() throws InterruptedException {
+        Duration backoff = Duration.ofMillis(100);
+        maxBackoff.update(backoff);
+        CountDownLatch latch = new CountDownLatch(1);
+        Future<?> future = executorService.submit(() -> {
+            latch.countDown();
+            retriever.getSweepableBuckets();
+        });
+        latch.await(); // reduce flakes from delay caused by executor not starting
+
+        Awaitility.await()
+                .atLeast(backoff)
+                // add an extra leeway to account for any context switching.
+                .atMost(backoff.plus(Duration.ofMillis(20)))
+                .pollInterval(Duration.ofMillis(10))
+                .until(future::isDone);
+    }
+
+    @Test
+    public void backoffCanBeInterrupted() throws InterruptedException {
+        maxBackoff.update(Duration.ofSeconds(10));
+        CountDownLatch latch = new CountDownLatch(1);
+        Future<?> future = executorService.submit(() -> {
+            latch.countDown();
+            retriever.getSweepableBuckets();
+        });
+        latch.await(); // reduce flakes where task doesn't actually run
+        future.cancel(true);
+        executorService.shutdown();
+
+        // Even though the backoff in 10s, interrupting the task should make it finish much faster.
+        Awaitility.await().atMost(Duration.ofMillis(200)).untilAsserted(() -> assertThat(
+                        executorService.awaitTermination(0, TimeUnit.MILLISECONDS))
+                .isTrue());
+    }
+
+    private static final class TestShardedRetrievalStrategy implements ShardedRetrievalStrategy {
+        private final Set<Integer> shards = new HashSet<>();
+
+        @Override
+        public List<SweepableBucket> getSweepableBucketsForShard(
+                ShardAndStrategy shard, SweepTimestamps _sweepTimestamps) {
+            int shardId = shard.shard();
+            shards.add(shardId);
+            return generateList(shardId);
+        }
+
+        public Set<Integer> getRequestedShards() {
+            return shards;
+        }
+
+        private static List<SweepableBucket> generateList(int shard) {
+            return IntStream.range(0, new Random().nextInt(10))
+                    .mapToObj(i -> SweepableBucket.of(ShardAndStrategy.of(shard, SweeperStrategy.CONSERVATIVE), i))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private static final class TestParallelTaskExecutor implements ParallelTaskExecutor {
+        private Optional<Integer> lastMaxParallelism = Optional.empty();
+
+        @Override
+        public <V, K> List<V> execute(Stream<K> arg, Function<K, V> task, int maxParallelism) {
+            lastMaxParallelism = Optional.of(maxParallelism);
+            return arg.map(task).collect(Collectors.toList());
+        }
+
+        public Optional<Integer> getLastMaxParallelism() {
+            return lastMaxParallelism;
+        }
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
No way of getting buckets across all shards

**After this PR**:
now can! Includes backoff and jitter
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
List -> Set. I'm tempted to just do a k-way merge sort, but I also figured I can do that later.
See comment on method parameter vs class arg for sweep strategy
**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That are underlying KVS can handle parallel requests
**What was existing testing like? What have you done to improve it?**:
Added tests. Does rely on the behaviour of ParallelTaskExecutor though
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
I don't think it's complicated
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/a
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Can get info for all shards
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
Max parallelism is tunable
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
Yes, if you don't tune it 
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
We might be able to do a single request to cassandra with multi get multi slice.

## Development Process
**Where should we start reviewing?**:
SSBR
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
