### PR TITLE
[ASTS] feat(bucket-retrieval): Lockables

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/locks/Lockable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/locks/Lockable.java
@@ -1,0 +1,152 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.locks;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.CheckReturnValue;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.refreshable.Refreshable;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+// See the LockableFactory comment for why keeping the value in the class ends up making things simpler from a local
+// lock management perspective.
+// Separately:
+// I, personally, am much more used to working with locks being attached to the data object. It's, imo, harder to screw
+// up and forget to lock / unlock things when a) you can't access the data without the lock and b) the error checker
+// will shout at you for not unlocking
+// TODO: Make the error checker shout at you
+// It also made the local isLocked check easier to manage rather than having a separate mapping (or, you don't have it
+// at all, but with so many threads and relatively high chance of some collisions, it seems like wasted RPCs otherwise)
+
+public final class Lockable<T> {
+    private static final SafeLogger log = SafeLoggerFactory.get(Lockable.class);
+    private final LockDescriptor lockDescriptor;
+    private final T inner;
+    private final TimelockService timelockService;
+    private final Refreshable<Duration> lockTimeout;
+
+    // Consider whether this should be a lock. It's simply an optimisation to avoid a check for timelock
+    // each time you want to test if it's locked by something locally, but we must make sure there are no false
+    // negatives. It's allowed that something local is working on this item and Timelock has released the lock due to
+    // expiry and this is still True (since that still lets us minimise conflicts by not working on it locally),
+    // but it should not be true if something local has stopped working on this item and closed the inner class
+    // successfully.
+    private final AtomicBoolean isLocked = new AtomicBoolean(false);
+
+    private Lockable(
+            T inner,
+            LockDescriptor lockDescriptor,
+            TimelockService timelockService,
+            Refreshable<Duration> lockTimeout) {
+        this.timelockService = timelockService;
+        this.inner = inner;
+        this.lockTimeout = lockTimeout;
+        this.lockDescriptor = lockDescriptor;
+    }
+
+    public static <T> Lockable<T> create(
+            T inner, LockDescriptor lockDescriptor, TimelockService timeLock, Refreshable<Duration> lockTimeout) {
+        return new Lockable<>(inner, lockDescriptor, timeLock, lockTimeout);
+    }
+
+    // For code owners:
+    // Do not use this for multiple locks!! If you're not careful, you can make it really easy to deadlock
+    // If you end up using this class and have a need for batch locks, implement a separate method that uses
+    // Timelocks batch locking methods and ensure there's a consistent ordering when taking out local locks
+    // to avoid circular waiting.
+    //    @MustBeClosed TODO: How do I get this working?? I'll track looking into this for another time.
+    // Would be good to have an IfPresentMustBeClosed annotation if it exists
+    @CheckReturnValue
+    public Optional<LockedItem<T>> tryLock(Consumer<Lockable<T>> disposeCallback) {
+        if (isLocked.compareAndSet(false, true)) {
+            // We do not want the timeout to be too low to avoid a race condition where we give up too soon
+            LockRequest request = LockRequest.of(
+                    ImmutableSet.of(lockDescriptor), lockTimeout.get().toMillis());
+
+            try {
+                return timelockService
+                        .lock(request)
+                        .getTokenOrEmpty()
+                        .map(lockToken -> new LockedItem<>(inner, this, () -> unlock(lockToken, disposeCallback)));
+            } catch (Exception e) {
+                log.warn("Failed to acquire lock", UnsafeArg.of("lockDescriptor", lockDescriptor), e);
+                isLocked.set(false);
+                return Optional.empty();
+            }
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private void unlock(LockToken lockToken, Consumer<Lockable<T>> disposeCallback) {
+        try {
+            timelockService.unlock(ImmutableSet.of(lockToken));
+        } finally {
+            isLocked.set(false); // We end up holding the local lock ever so slightly longer than necessary.
+            disposeCallback.accept(this);
+        }
+    }
+
+    // Expected to be used in a try closeable.
+    public static final class LockedItem<T> implements AutoCloseable {
+        private final T item;
+
+        // We need to capture the outer Lockable<T> as a strong reference so that LockableFactory doesn't GC it away
+        // while we're using the inner value. While the dispose callback does hold a reference, we're making it
+        // more explicit by actually holding outer.
+        private final Lockable<T> outer;
+        private final Runnable disposeCallback;
+
+        private LockedItem(T item, Lockable<T> outer, Runnable disposeCallback) {
+            this.item = item;
+            this.disposeCallback = disposeCallback;
+            this.outer = outer;
+        }
+
+        public T getItem() {
+            return item;
+        }
+
+        @Override
+        public void close() {
+            disposeCallback.run();
+        }
+    }
+
+    public static class LockableComparator<T> implements Comparator<Lockable<T>> {
+        private final Comparator<T> comparator;
+
+        public LockableComparator(Comparator<T> comparator) {
+            this.comparator = comparator;
+        }
+
+        @Override
+        public int compare(Lockable<T> o1, Lockable<T> o2) {
+            return comparator.compare(o1.inner, o2.inner);
+        }
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/locks/LockableTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/locks/LockableTest.java
@@ -1,0 +1,199 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.locks;
+
+import static com.palantir.logsafe.testing.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.atlasdb.sweep.asts.locks.Lockable.LockableComparator;
+import com.palantir.atlasdb.sweep.asts.locks.Lockable.LockedItem;
+import com.palantir.lock.v2.LockRequest;
+import com.palantir.lock.v2.LockResponse;
+import com.palantir.lock.v2.LockToken;
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.refreshable.Refreshable;
+import com.palantir.refreshable.SettableRefreshable;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.OngoingStubbing;
+
+@ExtendWith(MockitoExtension.class)
+public final class LockableTest {
+    private static final TestLockable TEST_LOCKABLE = TestLockable.of(1);
+    private static final Consumer<Lockable<TestLockable>> NO_OP = _ignored -> {};
+    private final SettableRefreshable<Duration> lockTimeout = Refreshable.create(Duration.ofSeconds(1));
+    private Lockable<TestLockable> lockable;
+
+    @Mock
+    private TimelockService timelockService;
+
+    @BeforeEach
+    public void setup() {
+        lockable = createLockable(TEST_LOCKABLE);
+    }
+
+    @Test
+    public void comparatorUsesProvidedComparatorForComparison() {
+        TestLockable otherLockable = TestLockable.of(2);
+        Lockable<TestLockable> lockOne = createLockable(TEST_LOCKABLE);
+        Lockable<TestLockable> lockTwo = createLockable(otherLockable);
+        Comparator<TestLockable> comparator = mock(Comparator.class);
+        LockableComparator<TestLockable> lockableComparator = new LockableComparator<>(comparator);
+
+        lockableComparator.compare(lockOne, lockTwo);
+        verify(comparator).compare(TEST_LOCKABLE, otherLockable);
+    }
+
+    @Test
+    public void tryLockLocksObjectLocally() {
+        withLockMock().thenReturn(lockResponse(lockToken()));
+        Optional<LockedItem<TestLockable>> lockedValue = lockable.tryLock(NO_OP);
+        assertThatValueIsLocked(lockedValue);
+
+        Optional<LockedItem<TestLockable>> attemptTwo = lockable.tryLock(NO_OP);
+        assertThat(attemptTwo).isEmpty();
+    }
+
+    @Test
+    public void tryLockLocksObjectInTimelock() {
+        withLockMock().thenReturn(lockResponse(lockToken()));
+
+        // We have to assign to an unused variable as we explicitly mark the output of tryLock as @CheckReturnValue
+        Optional<LockedItem<TestLockable>> _lockedValue = lockable.tryLock(NO_OP);
+        verify(timelockService)
+                .lock(LockRequest.of(
+                        ImmutableSet.of(TEST_LOCKABLE.lockDescriptor()),
+                        lockTimeout.get().toMillis()));
+    }
+
+    @Test
+    public void tryLockReturnsEmptyAndUnlocksLocallyIfTimelockCallFails() {
+        withLockMock().thenThrow(new RuntimeException("Timelock is down")).thenReturn(lockResponse(lockToken()));
+        Optional<LockedItem<TestLockable>> lockedValue = lockable.tryLock(NO_OP);
+        assertThat(lockedValue).isEmpty();
+
+        Optional<LockedItem<TestLockable>> attemptTwo = lockable.tryLock(NO_OP);
+        assertThatValueIsLocked(attemptTwo);
+    }
+
+    @Test
+    public void closingLockedItemCallsTimelockUnlock() {
+        LockToken lockToken = lockToken();
+        withLockMock().thenReturn(lockResponse(lockToken));
+        Optional<LockedItem<TestLockable>> lockedValue = lockable.tryLock(NO_OP);
+        assertThatValueIsLocked(lockedValue);
+
+        withUnlockMock(lockToken).thenReturn(ImmutableSet.of(lockToken));
+        lockedValue.orElseThrow().close();
+        verify(timelockService).unlock(ImmutableSet.of(lockToken));
+    }
+
+    @Test
+    public void closingLockedItemRemovesIsLockedFlagEvenIfTimelockUnlockFails() {
+        LockToken lockToken = lockToken();
+
+        withLockMock().thenReturn(lockResponse(lockToken));
+        Optional<LockedItem<TestLockable>> lockedValue = lockable.tryLock(NO_OP);
+        assertThatValueIsLocked(lockedValue);
+
+        RuntimeException exception = new RuntimeException("Timelock is down");
+        withUnlockMock(lockToken).thenThrow(exception);
+        assertThatThrownBy(lockedValue.orElseThrow()::close).isEqualTo(exception);
+        assertThat(lockable.tryLock(NO_OP)).isPresent();
+    }
+
+    @Test
+    public void closingLockedItemCallsDisposeCallbackWithSameLockableItem() {
+        AtomicReference<Lockable<TestLockable>> disposedLockable = new AtomicReference<>();
+        Optional<LockedItem<TestLockable>> lockedValue =
+                lockable.tryLock(item -> assertThat(disposedLockable.compareAndSet(null, item))
+                        .as("We should only be running the dispose callback once")
+                        .isTrue());
+        assertThatValueIsLocked(lockedValue);
+
+        lockedValue.orElseThrow().close();
+        // It must be the exact same object (not object equality, but _reference_ equality)
+        assertThat(disposedLockable.get()).isSameAs(lockable);
+    }
+
+    @Test
+    public void requestsUseCurrentLockTimeout() {
+        lockTimeout.update(Duration.ofSeconds(2));
+        LockToken lockToken = lockToken();
+        withLockMock().thenReturn(lockResponse(lockToken));
+        Optional<LockedItem<TestLockable>> lockedValueTwoSeconds = lockable.tryLock(NO_OP);
+
+        verify(timelockService)
+                .lock(LockRequest.of(
+                        ImmutableSet.of(TEST_LOCKABLE.lockDescriptor()),
+                        Duration.ofSeconds(2).toMillis()));
+
+        lockedValueTwoSeconds.orElseThrow().close();
+
+        lockTimeout.update(Duration.ofSeconds(3));
+        withLockMock().thenReturn(lockResponse(lockToken()));
+
+        Optional<LockedItem<TestLockable>> _lockedValueThreeSeconds = lockable.tryLock(NO_OP);
+
+        verify(timelockService)
+                .lock(LockRequest.of(
+                        ImmutableSet.of(TEST_LOCKABLE.lockDescriptor()),
+                        Duration.ofSeconds(3).toMillis()));
+    }
+
+    private Lockable<TestLockable> createLockable(TestLockable value) {
+        return Lockable.create(value, value.lockDescriptor(), timelockService, lockTimeout);
+    }
+
+    private OngoingStubbing<LockResponse> withLockMock() {
+        return when(timelockService.lock(LockRequest.of(
+                ImmutableSet.of(LockableTest.TEST_LOCKABLE.lockDescriptor()),
+                lockTimeout.get().toMillis())));
+    }
+
+    private OngoingStubbing<Set<LockToken>> withUnlockMock(LockToken lockToken) {
+        return when(timelockService.unlock(ImmutableSet.of(lockToken)));
+    }
+
+    private LockToken lockToken() {
+        return LockToken.of(UUID.randomUUID());
+    }
+
+    private LockResponse lockResponse(LockToken lockToken) {
+        return LockResponse.successful(lockToken);
+    }
+
+    private void assertThatValueIsLocked(Optional<LockedItem<TestLockable>> maybeLocked) {
+        assertThat(maybeLocked).hasValueSatisfying(lockedItem -> Assertions.assertThat(lockedItem.getItem())
+                .isEqualTo(TEST_LOCKABLE));
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/locks/TestLockable.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/locks/TestLockable.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.locks;
+
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.StringLockDescriptor;
+import org.immutables.value.Value;
+
+@Value.Immutable
+interface TestLockable {
+    @Value.Parameter
+    int value();
+
+    static TestLockable of(int value) {
+        return ImmutableTestLockable.of(value);
+    }
+
+    default LockDescriptor lockDescriptor() {
+        return StringLockDescriptor.of(String.valueOf(value()));
+    }
+}


### PR DESCRIPTION
This one is fun!
## General
**Before this PR**:
We don't have a mechanism for locking SweepableBuckets
**After this PR**:
Now we do!
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
No more than what we discussed. It's worth looking at LockableFactory (the PR after this one) as well - I split them into two PRs because it was getting quite big.
**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
Failed calls to Timelock will eventually result in a state where the thing is unlocked, regardless of the call.

**What was existing testing like? What have you done to improve it?**:
Added tests!

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
I believe so - it's not that complicated, given it pushes most things to Timelock
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
tryCloseable.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Sweep works
**Has the safety of all log arguments been decided correctly?**:
I believe so
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Fix it - it's not wired up
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Batch calls, but this can be extended
## Development Process
**Where should we start reviewing?**:
Lockable
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
