### PR TITLE
[ASTS] feat(bucket-retrieval): Lockable Factory

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/locks/LockableFactory.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/locks/LockableFactory.java
@@ -1,0 +1,65 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.locks;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.palantir.lock.LockDescriptor;
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.refreshable.Refreshable;
+import java.time.Duration;
+import java.util.function.Function;
+
+// This isn't necessary for correctness, but it's a nice way to keep the optimisation around having a local
+// lock check by sharing the underlying locked object, especially since this ended up being pretty simple (as long
+// as it's correct!)
+
+// rough notes:
+// This implementation ended up simplifying a bunch of things around local lock management.
+// It is possible for us to instead _not_ use the value inside the locked object, but that makes it _much_ harder
+// to keep track of the objects that are around, as you'll only construct the locked object as you need it (and so
+// you have no reference to it!) and so can't rely on a weakref cache.
+// By keeping the object in the locked value, then you have to keep the locked value around, so you keep the reference
+// alive.
+// Or, you cache the underlying immutable objects and not recreate them whenever you reload, but that pushes the
+// problem elsewhere.
+public final class LockableFactory<T> {
+    // This _has_ to be weak references, unless we do some manual pruning (but, why bother implementing that
+    // ourselves when the GC already exists?)
+    // Cannot be weak keys, since weak keys means identity equality not equals.
+    private final LoadingCache<T, Lockable<T>> memoizedLocks;
+
+    private LockableFactory(
+            TimelockService timelockService,
+            Refreshable<Duration> lockTimeout,
+            Function<T, LockDescriptor> lockDescriptorFunction) {
+        this.memoizedLocks = Caffeine.newBuilder()
+                .weakValues()
+                .build(key -> Lockable.create(key, lockDescriptorFunction.apply(key), timelockService, lockTimeout));
+    }
+
+    public static <T> LockableFactory<T> create(
+            TimelockService timelockService,
+            Refreshable<Duration> lockTimeout,
+            Function<T, LockDescriptor> lockDescriptorFunction) {
+        return new LockableFactory<>(timelockService, lockTimeout, lockDescriptorFunction);
+    }
+
+    public Lockable<T> createLockable(T lockable) {
+        return memoizedLocks.get(lockable);
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/locks/LockableFactoryTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/locks/LockableFactoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.locks;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.palantir.lock.v2.TimelockService;
+import com.palantir.refreshable.Refreshable;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class LockableFactoryTest {
+    @Mock
+    private TimelockService timelockService;
+
+    private LockableFactory<TestLockable> factory;
+
+    @BeforeEach
+    public void setup() {
+        factory = LockableFactory.create(
+                timelockService, Refreshable.create(Duration.ofSeconds(1)), TestLockable::lockDescriptor);
+    }
+
+    @Test
+    public void createReturnsSameInstanceIfUnderlyingObjectEqualEvenIfNotSameObject() {
+        TestLockable item1 = TestLockable.of(1);
+        TestLockable item2 = TestLockable.of(1);
+        Lockable<TestLockable> lockable1 = factory.createLockable(item1);
+        Lockable<TestLockable> lockable2 = factory.createLockable(item2);
+        assertThat(lockable1).isSameAs(lockable2);
+        assertThat(item1).isNotSameAs(item2);
+    }
+
+    @Test
+    public void createReturnsDifferentInstanceIfUnderlyingObjectDifferent() {
+        TestLockable lockable1 = TestLockable.of(1);
+        TestLockable lockable2 = TestLockable.of(2);
+        Lockable<TestLockable> lock1 = factory.createLockable(lockable1);
+        Lockable<TestLockable> lock2 = factory.createLockable(lockable2);
+        assertThat(lock1).isNotSameAs(lock2);
+    }
+
+    @Test
+    public void createReturnsDifferentObjectIfValueIsGarbageCollected() {
+        TestLockable lockable = TestLockable.of(1);
+        Lockable<TestLockable> lock1 = factory.createLockable(lockable);
+        int lock1HashCode = lock1.hashCode();
+        lock1 = null; // Lose the references
+
+        System.gc();
+        Lockable<TestLockable> lock2 = factory.createLockable(lockable);
+        int lock2HashCode = lock2.hashCode();
+        assertThat(lock1HashCode).isNotEqualTo(lock2HashCode);
+    }
+}


### PR DESCRIPTION
See alongside: #7185
## General
**Before this PR**:
We'd need some way to keep a mapping from underlying object -> lockables if we want to use the isLocked info.

**After this PR**:
Now we do! This one is fun too.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
Check the weak value map. Also look at tests and comments/

**Is documentation needed?**:
will fixup comments
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
nO
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That my tests are sufficient
**What was existing testing like? What have you done to improve it?**:
Added some!
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
This one doesn't
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Not too many calls to timelock - TODO later - keep track of this!
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
More than necessary calls to timelock
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
N/A
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
N/A
## Development Process
**Where should we start reviewing?**:
LockableFactory
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
