### PR TITLE
Expose a lock watch manager dump state method

### DIFF
--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManager.java
@@ -53,5 +53,5 @@ public abstract class LockWatchManager {
     abstract TransactionsLockWatchUpdate getUpdateForTransactions(
             Set<Long> startTimestamps, Optional<LockWatchVersion> version);
 
-    abstract void dumpState();
+    abstract void logState();
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManager.java
@@ -52,4 +52,6 @@ public abstract class LockWatchManager {
      */
     abstract TransactionsLockWatchUpdate getUpdateForTransactions(
             Set<Long> startTimestamps, Optional<LockWatchVersion> version);
+
+    abstract void dumpState();
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
@@ -24,10 +24,14 @@ import com.palantir.lock.watch.LockWatchCacheImpl;
 import com.palantir.lock.watch.LockWatchReferences;
 import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.lock.watch.TransactionsLockWatchUpdate;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Optional;
 import java.util.Set;
 
 public final class NoOpLockWatchManager extends LockWatchManagerInternal {
+    private static final SafeLogger log = SafeLoggerFactory.get(NoOpLockWatchManager.class);
+
     private final LockWatchCache cache;
 
     private NoOpLockWatchManager(LockWatchCache cache) {
@@ -72,6 +76,12 @@ public final class NoOpLockWatchManager extends LockWatchManagerInternal {
     TransactionsLockWatchUpdate getUpdateForTransactions(
             Set<Long> startTimestamps, Optional<LockWatchVersion> version) {
         return cache.getEventCache().getUpdateForTransactions(startTimestamps, version);
+    }
+
+    @Override
+    void dumpState() {
+        log.info("NoOpLockWatchManager does not directly store any state, dumping cache state.");
+        cache.dumpState();
     }
 
     @Override

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
@@ -79,9 +79,9 @@ public final class NoOpLockWatchManager extends LockWatchManagerInternal {
     }
 
     @Override
-    void dumpState() {
-        log.info("Dumping state from NoOpLockWatchManager");
-        cache.dumpState();
+    void logState() {
+        log.info("Logging state from NoOpLockWatchManager");
+        cache.logState();
     }
 
     @Override

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
@@ -80,7 +80,7 @@ public final class NoOpLockWatchManager extends LockWatchManagerInternal {
 
     @Override
     void dumpState() {
-        log.info("NoOpLockWatchManager does not directly store any state, dumping cache state.");
+        log.info("Dumping state from NoOpLockWatchManager");
         cache.dumpState();
     }
 

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
@@ -231,7 +231,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 .collect(Collectors.toList()));
 
         assertThat(ColumnFamilyDefinitions.isMatchingCf(
-                        kvs.getCfForTable(NEVER_SEEN, getMetadata(), FOUR_DAYS_IN_SECONDS), clusterSideCf))
+                kvs.getCfForTable(NEVER_SEEN, getMetadata(), FOUR_DAYS_IN_SECONDS), clusterSideCf))
                 .as("After serialization and deserialization to database, Cf metadata did not match.")
                 .isTrue();
     }
@@ -256,10 +256,8 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
     @SuppressWarnings("CompileTimeConstant")
     public void shouldNotErrorForTimestampTableWhenCreatingCassandraKvs() {
         verify(logger, atLeast(0))
-                .error(
-                        startsWith("Found a table {} that did not have persisted"),
-                        assertArg(
-                                (Arg<String> arg) -> assertThat(arg.getValue()).doesNotContain("timestamp")));
+                .error(startsWith("Found a table {} that did not have persisted"),
+                        assertArg((Arg<String> arg) -> assertThat(arg.getValue()).doesNotContain("timestamp")));
     }
 
     @Test
@@ -494,20 +492,20 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
 
         keyValueService.putUnlessExists(userTable, ImmutableMap.of(CELL, sad));
         assertThat(keyValueService
-                        .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
-                        .get(CELL)
-                        .getContents())
+                .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
+                .get(CELL)
+                .getContents())
                 .containsExactly(sad);
 
         keyValueService.setOnce(userTable, ImmutableMap.of(CELL, happy));
         assertThat(keyValueService
-                        .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
-                        .get(CELL)
-                        .getContents())
+                .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
+                .get(CELL)
+                .getContents())
                 .containsExactly(happy);
         assertThat(keyValueService
-                        .getAllTimestamps(userTable, ImmutableSet.of(CELL), Long.MAX_VALUE)
-                        .size())
+                .getAllTimestamps(userTable, ImmutableSet.of(CELL), Long.MAX_VALUE)
+                .size())
                 .isEqualTo(1);
         keyValueService.truncateTable(userTable);
     }
@@ -667,9 +665,9 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
         Cell nextTestCell = Cell.create(row(1), column(1));
 
         assertThatThrownBy(() -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                        TEST_TABLE,
-                        firstTestCell.getRowName(),
-                        ImmutableMap.of(firstTestCell, val(0, 0), nextTestCell, val(0, 1)))))
+                TEST_TABLE,
+                firstTestCell.getRowName(),
+                ImmutableMap.of(firstTestCell, val(0, 0), nextTestCell, val(0, 1)))))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Can only update cells in one row.");
     }
@@ -685,7 +683,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 1))));
 
         assertThatThrownBy(() -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                        TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))))
+                TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))))
                 .isInstanceOf(MultiCheckAndSetException.class);
 
         MultiCheckAndSetException ex = catchThrowableOfType(
@@ -810,7 +808,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 .setComment("")
                 .setColumn_metadata(new ArrayList<>())
                 .setTriggers(new ArrayList<>())
-                .setKey_alias(new byte[] {0x6B, 0x65, 0x79})
+                .setKey_alias(new byte[]{0x6B, 0x65, 0x79})
                 .setComparator_type("org.apache.cassandra.db.marshal.CompositeType"
                         + "(org.apache.cassandra.db.marshal.BytesType,org.apache.cassandra.db.marshal.LongType)")
                 .setCompaction_strategy_options(new HashMap<>())

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/FilteringValueCacheSnapshot.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/FilteringValueCacheSnapshot.java
@@ -23,12 +23,14 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.lock.LockDescriptor;
 import com.palantir.lock.watch.CommitUpdate;
 import com.palantir.lock.watch.CommitUpdate.Visitor;
+import com.palantir.logsafe.Unsafe;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.immutables.value.Value;
 
+@Unsafe
 final class FilteringValueCacheSnapshot implements ValueCacheSnapshot {
     private final ValueCacheSnapshot delegate;
     private final LockedCells lockedCells;
@@ -66,6 +68,7 @@ final class FilteringValueCacheSnapshot implements ValueCacheSnapshot {
         return delegate.hasAnyTablesWatched();
     }
 
+    @Unsafe
     @Override
     public String toString() {
         return MoreObjects.toStringHelper("FilteredValueCacheSnapshot")

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/FilteringValueCacheSnapshot.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/FilteringValueCacheSnapshot.java
@@ -16,6 +16,7 @@
 
 package com.palantir.atlasdb.keyvalue.api.cache;
 
+import com.google.common.base.MoreObjects;
 import com.palantir.atlasdb.keyvalue.api.AtlasLockDescriptorUtils;
 import com.palantir.atlasdb.keyvalue.api.CellReference;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
@@ -63,6 +64,15 @@ final class FilteringValueCacheSnapshot implements ValueCacheSnapshot {
     @Override
     public boolean hasAnyTablesWatched() {
         return delegate.hasAnyTablesWatched();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper("FilteredValueCacheSnapshot")
+                .omitNullValues()
+                .add("delegate", delegate)
+                .add("lockedCells", lockedCells)
+                .toString();
     }
 
     private static LockedCells toLockedCells(CommitUpdate commitUpdate) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -172,7 +172,7 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
     }
 
     @Override
-    public void dumpState() {
+    public synchronized void dumpState() {
         log.info("Dumping state from LockWatchValueScopingCacheImpl", SafeArg.of("currentVersion", currentVersion));
         valueStore.dumpState();
         snapshotStore.dumpState();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -171,6 +171,13 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
         ensureStateRemoved(startTimestamp);
     }
 
+    @Override
+    public void dumpState() {
+        log.info("Dumping state from LockWatchValueScopingCacheImpl", SafeArg.of("currentVersion", currentVersion));
+        valueStore.dumpState();
+        snapshotStore.dumpState();
+    }
+
     /**
      * Retrieval of transaction scoped caches (read-only or otherwise) does not need to be synchronised. The main
      * reason for this is that the only race condition that could conceivably occur is for the state to not exist here

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCacheImpl.java
@@ -172,10 +172,10 @@ public final class LockWatchValueScopingCacheImpl implements LockWatchValueScopi
     }
 
     @Override
-    public synchronized void dumpState() {
-        log.info("Dumping state from LockWatchValueScopingCacheImpl", SafeArg.of("currentVersion", currentVersion));
-        valueStore.dumpState();
-        snapshotStore.dumpState();
+    public synchronized void logState() {
+        log.info("Logging state from LockWatchValueScopingCacheImpl", SafeArg.of("currentVersion", currentVersion));
+        valueStore.logState();
+        snapshotStore.logState();
     }
 
     /**

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
@@ -44,4 +44,6 @@ public interface SnapshotStore {
     void removeTimestamp(StartTimestamp timestamp);
 
     void reset();
+
+    void dumpState();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStore.java
@@ -45,5 +45,5 @@ public interface SnapshotStore {
 
     void reset();
 
-    void dumpState();
+    void logState();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImpl.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.atlasdb.keyvalue.api.watch.Sequence;
 import com.palantir.atlasdb.keyvalue.api.watch.StartTimestamp;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
@@ -103,6 +104,17 @@ final class SnapshotStoreImpl implements SnapshotStore {
         snapshotMap.clear();
         liveSequences.clear();
         timestampMap.clear();
+    }
+
+    @Override
+    public void dumpState() {
+        log.info(
+                "Dumping state from SnapshotStoreImpl",
+                UnsafeArg.of("snapshotMap", snapshotMap),
+                SafeArg.of("liveSequences", liveSequences),
+                SafeArg.of("timestampMap", timestampMap),
+                SafeArg.of("minimumUnusedSnapshots", minimumUnusedSnapshots),
+                SafeArg.of("maximumSize", maximumSize));
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/SnapshotStoreImpl.java
@@ -107,9 +107,9 @@ final class SnapshotStoreImpl implements SnapshotStore {
     }
 
     @Override
-    public void dumpState() {
+    public void logState() {
         log.info(
-                "Dumping state from SnapshotStoreImpl",
+                "Logging state from SnapshotStoreImpl",
                 UnsafeArg.of("snapshotMap", snapshotMap),
                 SafeArg.of("liveSequences", liveSequences),
                 SafeArg.of("timestampMap", timestampMap),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueCacheSnapshot.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueCacheSnapshot.java
@@ -18,8 +18,10 @@ package com.palantir.atlasdb.keyvalue.api.cache;
 
 import com.palantir.atlasdb.keyvalue.api.CellReference;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.logsafe.Unsafe;
 import java.util.Optional;
 
+@Unsafe
 public interface ValueCacheSnapshot {
     Optional<CacheEntry> getValue(CellReference cellReference);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueCacheSnapshotImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueCacheSnapshotImpl.java
@@ -19,12 +19,13 @@ package com.palantir.atlasdb.keyvalue.api.cache;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.keyvalue.api.CellReference;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.logsafe.Unsafe;
 import io.vavr.collection.Map;
 import io.vavr.collection.Set;
 import java.util.Optional;
 import org.immutables.value.Value;
 
-@Value.Immutable
+@Unsafe @Value.Immutable
 public interface ValueCacheSnapshotImpl extends ValueCacheSnapshot {
     Map<CellReference, CacheEntry> values();
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueCacheSnapshotImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueCacheSnapshotImpl.java
@@ -25,7 +25,8 @@ import io.vavr.collection.Set;
 import java.util.Optional;
 import org.immutables.value.Value;
 
-@Unsafe @Value.Immutable
+@Unsafe
+@Value.Immutable
 public interface ValueCacheSnapshotImpl extends ValueCacheSnapshot {
     Map<CellReference, CacheEntry> values();
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueStore.java
@@ -31,4 +31,6 @@ interface ValueStore {
     void putValue(CellReference cellReference, CacheValue value);
 
     ValueCacheSnapshot getSnapshot();
+
+    void dumpState();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueStore.java
@@ -32,5 +32,5 @@ interface ValueStore {
 
     ValueCacheSnapshot getSnapshot();
 
-    void dumpState();
+    void logState();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueStoreImpl.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.keyvalue.api.cache;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Weigher;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.keyvalue.api.AtlasLockDescriptorUtils;
 import com.palantir.atlasdb.keyvalue.api.AtlasLockDescriptorUtils.TableRefAndRemainder;
@@ -127,11 +128,11 @@ final class ValueStoreImpl implements ValueStore {
     }
 
     @Override
-    public void dumpState() {
+    public void logState() {
         log.info(
-                "Dumping state from ValueStoreImpl",
+                "Logging state from ValueStoreImpl",
                 UnsafeArg.of("allowedTables", allowedTables),
-                UnsafeArg.of("loadedValues", new java.util.HashMap<>(loadedValues.asMap())),
+                UnsafeArg.of("loadedValues", ImmutableMap.copyOf(loadedValues.asMap())),
                 UnsafeArg.of("watchedTables", watchedTables.getSnapshot().toJavaSet()),
                 UnsafeArg.of("values", values.getSnapshot().toJavaMap()));
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueStoreImpl.java
@@ -129,7 +129,7 @@ final class ValueStoreImpl implements ValueStore {
     @Override
     public void dumpState() {
         log.info(
-                "Dumping ValueStoreImpl state",
+                "Dumping state from ValueStoreImpl",
                 UnsafeArg.of("allowedTables", allowedTables),
                 UnsafeArg.of("loadedValues", new java.util.HashMap<>(loadedValues.asMap())),
                 UnsafeArg.of("watchedTables", watchedTables.getSnapshot().toJavaSet()),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueStoreImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/ValueStoreImpl.java
@@ -34,6 +34,8 @@ import com.palantir.lock.watch.UnlockEvent;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.HashSet;
 import java.util.Optional;
@@ -50,6 +52,8 @@ final class ValueStoreImpl implements ValueStore {
      * names more costly.
      */
     static final int CACHE_OVERHEAD = 128;
+
+    private static final SafeLogger log = SafeLoggerFactory.get(ValueStoreImpl.class);
 
     private final StructureHolder<io.vavr.collection.Map<CellReference, CacheEntry>> values;
     private final StructureHolder<io.vavr.collection.Set<TableReference>> watchedTables;
@@ -120,6 +124,16 @@ final class ValueStoreImpl implements ValueStore {
     @Override
     public ValueCacheSnapshot getSnapshot() {
         return ValueCacheSnapshotImpl.of(values.getSnapshot(), watchedTables.getSnapshot(), allowedTables);
+    }
+
+    @Override
+    public void dumpState() {
+        log.info(
+                "Dumping ValueStoreImpl state",
+                UnsafeArg.of("allowedTables", allowedTables),
+                UnsafeArg.of("loadedValues", new java.util.HashMap<>(loadedValues.asMap())),
+                UnsafeArg.of("watchedTables", watchedTables.getSnapshot().toJavaSet()),
+                UnsafeArg.of("values", values.getSnapshot().toJavaMap()));
     }
 
     private void putLockedCell(CellReference cellReference) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLockWatchSnapshot.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLockWatchSnapshot.java
@@ -102,8 +102,8 @@ final class ClientLockWatchSnapshot {
     ClientLockWatchSnapshotState getStateForDiagnostics() {
         return ImmutableClientLockWatchSnapshotState.builder()
                 .snapshotVersion(snapshotVersion)
-                .locked(new HashSet<>(locked))
-                .watches(new HashSet<>(watches))
+                .locked(ImmutableSet.copyOf(locked))
+                .watches(ImmutableSet.copyOf(watches))
                 .build();
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLockWatchSnapshot.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLockWatchSnapshot.java
@@ -29,16 +29,12 @@ import com.palantir.lock.watch.UnlockEvent;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.Unsafe;
-import com.palantir.logsafe.UnsafeArg;
-import com.palantir.logsafe.logger.SafeLogger;
-import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
 final class ClientLockWatchSnapshot {
-    private static final SafeLogger log = SafeLoggerFactory.get(ClientLockWatchSnapshot.class);
     private final Set<LockWatchReferences.LockWatchReference> watches;
     private final Set<LockDescriptor> locked;
     private final EventVisitor visitor;
@@ -96,14 +92,6 @@ final class ClientLockWatchSnapshot {
         snapshotVersion = Optional.empty();
         watches.clear();
         locked.clear();
-    }
-
-    void dumpState() {
-        log.info(
-                "Dumping state from ClientLockWatchSnapshot",
-                UnsafeArg.of("watches", new HashSet<>(watches)),
-                UnsafeArg.of("locked", new HashSet<>(locked)),
-                UnsafeArg.of("snapshotVersion", snapshotVersion));
     }
 
     Optional<LockWatchVersion> getSnapshotVersion() {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLockWatchSnapshot.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLockWatchSnapshot.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.keyvalue.api.watch;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.palantir.lock.LockDescriptor;
@@ -29,12 +28,17 @@ import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.lock.watch.UnlockEvent;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.Unsafe;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
 final class ClientLockWatchSnapshot {
+    private static final SafeLogger log = SafeLoggerFactory.get(ClientLockWatchSnapshot.class);
     private final Set<LockWatchReferences.LockWatchReference> watches;
     private final Set<LockDescriptor> locked;
     private final EventVisitor visitor;
@@ -94,16 +98,24 @@ final class ClientLockWatchSnapshot {
         locked.clear();
     }
 
+    void dumpState() {
+        log.info(
+                "Dumping state from ClientLockWatchSnapshot",
+                UnsafeArg.of("watches", new HashSet<>(watches)),
+                UnsafeArg.of("locked", new HashSet<>(locked)),
+                UnsafeArg.of("snapshotVersion", snapshotVersion));
+    }
+
     Optional<LockWatchVersion> getSnapshotVersion() {
         return snapshotVersion;
     }
 
-    @VisibleForTesting
-    ClientLockWatchSnapshotState getStateForTesting() {
+    @Unsafe
+    ClientLockWatchSnapshotState getStateForDiagnostics() {
         return ImmutableClientLockWatchSnapshotState.builder()
                 .snapshotVersion(snapshotVersion)
-                .locked(locked)
-                .watches(watches)
+                .locked(new HashSet<>(locked))
+                .watches(new HashSet<>(watches))
                 .build();
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -151,8 +151,8 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
     }
 
     @Override
-    public void dumpState() {
-        log.info("Dumping state from LockWatchEventCacheImpl", UnsafeArg.of("state", getStateForDiagnostics()));
+    public void logState() {
+        log.info("Logging state from LockWatchEventCacheImpl", UnsafeArg.of("state", getStateForDiagnostics()));
     }
 
     @Unsafe

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -30,6 +30,10 @@ import com.palantir.lock.watch.NoOpLockWatchEventCache;
 import com.palantir.lock.watch.TransactionUpdate;
 import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Unsafe;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -39,6 +43,8 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class LockWatchEventCacheImpl implements LockWatchEventCache {
     // The minimum number of events should be the same as Timelock's LockEventLogImpl.
     private static final int MIN_EVENTS = 1000;
+
+    private static final SafeLogger log = SafeLoggerFactory.get(LockWatchEventCacheImpl.class);
 
     private final LockWatchEventLog eventLog;
     private final TimestampStateStore timestampStateStore;
@@ -146,15 +152,14 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
 
     @Override
     public void dumpState() {
-        eventLog.dumpState();
-        timestampStateStore.dumpState();
+        log.info("Dumping state from LockWatchEventCacheImpl", UnsafeArg.of("state", getStateForDiagnostics()));
     }
 
-    @VisibleForTesting
-    synchronized LockWatchEventCacheState getStateForTesting() {
+    @Unsafe
+    synchronized LockWatchEventCacheState getStateForDiagnostics() {
         return ImmutableLockWatchEventCacheState.builder()
-                .timestampStoreState(timestampStateStore.getStateForTesting())
-                .logState(eventLog.getStateForTesting())
+                .timestampStoreState(timestampStateStore.getStateForDiagnostics())
+                .logState(eventLog.getStateForDiagnostics())
                 .build();
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -155,6 +155,7 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
         log.info("Logging state from LockWatchEventCacheImpl", UnsafeArg.of("state", getStateForDiagnostics()));
     }
 
+    @VisibleForTesting
     @Unsafe
     synchronized LockWatchEventCacheState getStateForDiagnostics() {
         return ImmutableLockWatchEventCacheState.builder()

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheImpl.java
@@ -144,6 +144,12 @@ public final class LockWatchEventCacheImpl implements LockWatchEventCache {
         }
     }
 
+    @Override
+    public void dumpState() {
+        eventLog.dumpState();
+        timestampStateStore.dumpState();
+    }
+
     @VisibleForTesting
     synchronized LockWatchEventCacheState getStateForTesting() {
         return ImmutableLockWatchEventCacheState.builder()

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.keyvalue.api.watch;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.keyvalue.api.cache.CacheMetrics;
 import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
@@ -25,6 +24,7 @@ import com.palantir.lock.watch.LockWatchEvent;
 import com.palantir.lock.watch.LockWatchStateUpdate;
 import com.palantir.lock.watch.LockWatchVersion;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Unsafe;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -103,10 +103,6 @@ final class LockWatchEventLog {
         return latestVersion;
     }
 
-    void dumpState() {
-        // TODO
-    }
-
     private ClientLogEvents getEventsBetweenVersionsInternal(VersionBounds versionBounds) {
         Optional<LockWatchVersion> startVersion = versionBounds.startVersion().map(this::createStartVersion);
         LockWatchVersion currentVersion = getLatestVersionAndVerify(versionBounds.endVersion());
@@ -147,12 +143,12 @@ final class LockWatchEventLog {
         }
     }
 
-    @VisibleForTesting
-    LockWatchEventLogState getStateForTesting() {
+    @Unsafe
+    LockWatchEventLogState getStateForDiagnostics() {
         return ImmutableLockWatchEventLogState.builder()
                 .latestVersion(latestVersion)
-                .eventStoreState(eventStore.getStateForTesting())
-                .snapshotState(snapshot.getStateForTesting())
+                .eventStoreState(eventStore.getStateForDiagnostics())
+                .snapshotState(snapshot.getStateForDiagnostics())
                 .build();
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -103,6 +103,10 @@ final class LockWatchEventLog {
         return latestVersion;
     }
 
+    void dumpState() {
+        // TODO
+    }
+
     private ClientLogEvents getEventsBetweenVersionsInternal(VersionBounds versionBounds) {
         Optional<LockWatchVersion> startVersion = versionBounds.startVersion().map(this::createStartVersion);
         LockWatchVersion currentVersion = getLatestVersionAndVerify(versionBounds.endVersion());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLog.java
@@ -145,11 +145,11 @@ final class LockWatchEventLog {
 
     @Unsafe
     LockWatchEventLogState getStateForDiagnostics() {
-        return ImmutableLockWatchEventLogState.builder()
+        return runWithReadLock(() -> ImmutableLockWatchEventLogState.builder()
                 .latestVersion(latestVersion)
                 .eventStoreState(eventStore.getStateForDiagnostics())
                 .snapshotState(snapshot.getStateForDiagnostics())
-                .build();
+                .build());
     }
 
     private <T> T runWithReadLock(Supplier<T> task) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.keyvalue.api.watch;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.palantir.atlasdb.keyvalue.api.LockWatchCachingConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.cache.CacheMetrics;
@@ -41,7 +42,6 @@ import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import com.palantir.util.RateLimitedLogger;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -112,13 +112,13 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
     }
 
     @Override
-    void dumpState() {
+    void logState() {
         diagnosticLog.log(logger -> {
             logger.info(
-                    "Dumping state from LockWatchManagerImpl",
+                    "Logging state from LockWatchManagerImpl",
                     UnsafeArg.of("referencesFromSchema", referencesFromSchema),
-                    UnsafeArg.of("lockWatchReferences", new HashSet<>(lockWatchReferences)));
-            lockWatchCache.dumpState();
+                    UnsafeArg.of("lockWatchReferences", ImmutableSet.copyOf(lockWatchReferences)));
+            lockWatchCache.logState();
         });
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
@@ -115,7 +115,7 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
     void dumpState() {
         diagnosticLog.log(logger -> {
             logger.info(
-                    "Dumping LockWatchManagerImpl state",
+                    "Dumping state from LockWatchManagerImpl",
                     UnsafeArg.of("referencesFromSchema", referencesFromSchema),
                     UnsafeArg.of("lockWatchReferences", new HashSet<>(lockWatchReferences)));
             lockWatchCache.dumpState();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
@@ -40,6 +40,7 @@ import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -102,6 +103,16 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
     TransactionsLockWatchUpdate getUpdateForTransactions(
             Set<Long> startTimestamps, Optional<LockWatchVersion> version) {
         return lockWatchCache.getEventCache().getUpdateForTransactions(startTimestamps, version);
+    }
+
+    @Override
+    void dumpState() {
+        // TODO: use a rate limited logger
+        log.info(
+                "Dumping lock watch manager state",
+                UnsafeArg.of("referencesFromSchema", referencesFromSchema),
+                UnsafeArg.of("lockWatchReferences", new HashSet<>(lockWatchReferences)));
+        lockWatchCache.dumpState();
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -130,7 +130,7 @@ final class TimestampStateStore {
 
     void dumpState() {
         log.info(
-                "Dumping TimestampStateStore state",
+                "Dumping state from TimestampStateStore",
                 SafeArg.of(
                         "timestampMap",
                         KeyedStream.stream(timestampMap)

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -126,6 +126,10 @@ final class TimestampStateStore {
         livingVersions.clear();
     }
 
+    void dumpState() {
+        // TODO
+    }
+
     Optional<LockWatchVersion> getStartVersion(long startTimestamp) {
         return getTimestampInfo(startTimestamp).map(TimestampVersionInfo::version);
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -127,6 +127,7 @@ final class TimestampStateStore {
     }
 
     void dumpState() {
+        log.info("Dumping TimestampStateStore state", SafeArg.of("timestampMap", timestampMap));
         // TODO
     }
 
@@ -209,5 +210,17 @@ final class TimestampStateStore {
         static CommitInfo of(LockToken commitLockToken, LockWatchVersion commitVersion) {
             return ImmutableCommitInfo.of(commitLockToken, commitVersion);
         }
+    }
+
+    @Value.Immutable
+    interface SafeLoggableTimestampVersionInfo {
+        @Value.Parameter
+        LockWatchVersion version();
+
+        @Value.Parameter
+        Optional<LockWatchVersion> commitInfoVersion();
+
+        @Value.Parameter
+        Optional<SafeArg<?>> commitInfoTokenSafeArg();
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -34,7 +34,6 @@ import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
 import java.util.Optional;
@@ -151,10 +150,7 @@ final class TimestampStateStore {
     TimestampStateStoreState getStateForDiagnostics() {
         // This method doesn't need to read a thread-safe snapshot of timestampMap and livingVersions
         SortedSetMultimap<Sequence, StartTimestamp> living = TreeMultimap.create();
-        for (Entry<Sequence, NavigableSet<StartTimestamp>> entry : livingVersions.entrySet()) {
-            living.putAll(entry.getKey(), new TreeSet<>(entry.getValue()));
-        }
-
+        livingVersions.forEach((sequence, startTimestamps) -> living.putAll(sequence, new TreeSet<>(startTimestamps)));
         return ImmutableTimestampStateStoreState.builder()
                 .timestampMap(new TreeMap<>(timestampMap))
                 .livingVersions(living)

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStoreState.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStoreState.java
@@ -19,14 +19,15 @@ package com.palantir.atlasdb.keyvalue.api.watch;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.SortedSetMultimap;
-import java.util.Map;
+import com.palantir.atlasdb.keyvalue.api.watch.TimestampStateStore.TimestampVersionInfo;
+import java.util.NavigableMap;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableTimestampStateStoreState.class)
 @JsonDeserialize(as = ImmutableTimestampStateStoreState.class)
 interface TimestampStateStoreState {
-    Map<StartTimestamp, TimestampStateStore.TimestampVersionInfo> timestampMap();
+    NavigableMap<StartTimestamp, TimestampVersionInfo> timestampMap();
 
     SortedSetMultimap<Sequence, StartTimestamp> livingVersions();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
@@ -23,8 +23,6 @@ import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.Unsafe;
 import com.palantir.logsafe.UnsafeArg;
-import com.palantir.logsafe.logger.SafeLogger;
-import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -35,7 +33,6 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 final class VersionedEventStore {
-    private static final SafeLogger log = SafeLoggerFactory.get(VersionedEventStore.class);
     private static final boolean INCLUSIVE = true;
     private static final Sequence MAX_VERSION = Sequence.of(Long.MAX_VALUE);
 
@@ -116,10 +113,6 @@ final class VersionedEventStore {
 
     void clear() {
         eventMap.clear();
-    }
-
-    void dumpState() {
-        log.info("Dumping state from VersionedEventStore", UnsafeArg.of("eventMap", eventMap));
     }
 
     @Unsafe

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStore.java
@@ -17,6 +17,7 @@
 package com.palantir.atlasdb.keyvalue.api.watch;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedMap;
 import com.palantir.atlasdb.keyvalue.api.cache.CacheMetrics;
 import com.palantir.lock.watch.LockWatchEvent;
 import com.palantir.logsafe.Preconditions;
@@ -29,7 +30,6 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 final class VersionedEventStore {
@@ -118,7 +118,7 @@ final class VersionedEventStore {
     @Unsafe
     VersionedEventStoreState getStateForDiagnostics() {
         return ImmutableVersionedEventStoreState.builder()
-                .eventMap(new TreeMap<>(eventMap))
+                .eventMap(ImmutableSortedMap.copyOf(eventMap))
                 .build();
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLockWatchSnapshotTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/ClientLockWatchSnapshotTest.java
@@ -66,7 +66,7 @@ public class ClientLockWatchSnapshotTest {
     public void lockEventAddsDescriptors() {
         LockWatchEvents events = singleLockEvent(LOCK_DESCRIPTOR_1, SEQUENCE_1);
         snapshot.processEvents(events, INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addLocked(LOCK_DESCRIPTOR_1)
                         .snapshotVersion(LockWatchVersion.of(INITIAL_LEADER_ID, SEQUENCE_1))
@@ -80,7 +80,7 @@ public class ClientLockWatchSnapshotTest {
                         .build(SEQUENCE_1))
                 .build();
         snapshot.processEvents(events, INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addLocked(LOCK_DESCRIPTOR_1, LOCK_DESCRIPTOR_2)
                         .snapshotVersion(LockWatchVersion.of(INITIAL_LEADER_ID, SEQUENCE_1))
@@ -96,7 +96,7 @@ public class ClientLockWatchSnapshotTest {
                                 .build(SEQUENCE_2))
                 .build();
         snapshot.processEvents(events, INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addLocked(LOCK_DESCRIPTOR_1, LOCK_DESCRIPTOR_2)
                         .snapshotVersion(LockWatchVersion.of(INITIAL_LEADER_ID, SEQUENCE_2))
@@ -117,7 +117,7 @@ public class ClientLockWatchSnapshotTest {
                         ImmutableSet.of(LOCK_DESCRIPTOR_1, LOCK_DESCRIPTOR_2),
                         ImmutableSet.of()));
 
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .as("the base snapshot should not have been updated")
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addLocked(LOCK_DESCRIPTOR_1)
@@ -133,7 +133,7 @@ public class ClientLockWatchSnapshotTest {
         LockWatchEvents secondEvent = singleLockEvent(LOCK_DESCRIPTOR_2, SEQUENCE_2);
         snapshot.processEvents(secondEvent, INITIAL_LEADER_ID);
 
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addLocked(LOCK_DESCRIPTOR_1, LOCK_DESCRIPTOR_2)
                         .snapshotVersion(LockWatchVersion.of(INITIAL_LEADER_ID, SEQUENCE_2))
@@ -148,7 +148,7 @@ public class ClientLockWatchSnapshotTest {
                         UnlockEvent.builder(ONLY_LOCK_DESCRIPTOR_1).build(SEQUENCE_2))
                 .build();
         snapshot.processEvents(events, INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .snapshotVersion(LockWatchVersion.of(INITIAL_LEADER_ID, SEQUENCE_2))
                         .build());
@@ -162,7 +162,7 @@ public class ClientLockWatchSnapshotTest {
                         LockEvent.builder(ONLY_LOCK_DESCRIPTOR_1, LOCK_TOKEN_1).build(SEQUENCE_2))
                 .build();
         snapshot.processEvents(events, INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addLocked(LOCK_DESCRIPTOR_1)
                         .snapshotVersion(LockWatchVersion.of(INITIAL_LEADER_ID, SEQUENCE_2))
@@ -178,7 +178,7 @@ public class ClientLockWatchSnapshotTest {
                         UnlockEvent.builder(ONLY_LOCK_DESCRIPTOR_1).build(SEQUENCE_2))
                 .build();
         snapshot.processEvents(events, INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addLocked(LOCK_DESCRIPTOR_2)
                         .snapshotVersion(LockWatchVersion.of(INITIAL_LEADER_ID, SEQUENCE_2))
@@ -195,7 +195,7 @@ public class ClientLockWatchSnapshotTest {
                         .build())
                 .build();
         snapshot.processEvents(events, INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addWatches(ENTIRE_TABLE_REFERENCE_1)
                         .addLocked(LOCK_DESCRIPTOR_1)
@@ -213,7 +213,7 @@ public class ClientLockWatchSnapshotTest {
                         .build())
                 .build();
         snapshot.processEvents(events, INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addWatches(EXACT_ROW_REFERENCE)
                         .addLocked(LOCK_DESCRIPTOR_1)
@@ -237,7 +237,7 @@ public class ClientLockWatchSnapshotTest {
                                 .build())
                 .build();
         snapshot.processEvents(events, INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addWatches(EXACT_ROW_REFERENCE, ENTIRE_TABLE_REFERENCE_2)
                         .addLocked(LOCK_DESCRIPTOR_1, LOCK_DESCRIPTOR_2)
@@ -258,7 +258,7 @@ public class ClientLockWatchSnapshotTest {
                         UnlockEvent.builder(ImmutableSet.of(LOCK_DESCRIPTOR_2)).build(SEQUENCE_3))
                 .build();
         snapshot.processEvents(events, INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addWatches(ENTIRE_TABLE_REFERENCE_1, EXACT_ROW_REFERENCE)
                         .addLocked(LOCK_DESCRIPTOR_1)
@@ -269,10 +269,10 @@ public class ClientLockWatchSnapshotTest {
     @Test
     public void resetClearsAllTrackedState() {
         snapshot.processEvents(singleLockEvent(LOCK_DESCRIPTOR_1, SEQUENCE_1), INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isNotEqualTo(ImmutableClientLockWatchSnapshotState.builder().build());
         snapshot.reset();
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder().build());
     }
 
@@ -301,7 +301,7 @@ public class ClientLockWatchSnapshotTest {
 
         LockWatchEvents initialEvent = singleLockEvent(LOCK_DESCRIPTOR_1, sequenceNumber);
         snapshot.processEvents(initialEvent, INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addLocked(LOCK_DESCRIPTOR_1)
                         .snapshotVersion(LockWatchVersion.of(INITIAL_LEADER_ID, sequenceNumber))
@@ -327,7 +327,7 @@ public class ClientLockWatchSnapshotTest {
         snapshot.reset();
         LockWatchEvents eventFromDifferentLeader = singleLockEvent(LOCK_DESCRIPTOR_2, SEQUENCE_1);
         snapshot.processEvents(eventFromDifferentLeader, DIFFERENT_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addLocked(LOCK_DESCRIPTOR_2)
                         .snapshotVersion(LockWatchVersion.of(DIFFERENT_LEADER_ID, SEQUENCE_1))
@@ -351,14 +351,14 @@ public class ClientLockWatchSnapshotTest {
 
         snapshot.processEvents(singleLockEvent(LOCK_DESCRIPTOR_2, SEQUENCE_2), INITIAL_LEADER_ID);
         snapshot.processEvents(singleUnlockEvent(LOCK_DESCRIPTOR_2, SEQUENCE_3), INITIAL_LEADER_ID);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addLocked(LOCK_DESCRIPTOR_1)
                         .snapshotVersion(LockWatchVersion.of(INITIAL_LEADER_ID, SEQUENCE_3))
                         .build());
 
         snapshot.resetWithSnapshot(snapshotWithBothLocked);
-        assertThat(snapshot.getStateForTesting())
+        assertThat(snapshot.getStateForDiagnostics())
                 .isEqualTo(ImmutableClientLockWatchSnapshotState.builder()
                         .addLocked(LOCK_DESCRIPTOR_1, LOCK_DESCRIPTOR_2)
                         .snapshotVersion(LockWatchVersion.of(INITIAL_LEADER_ID, SEQUENCE_2))

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/DuplicatingLockWatchEventCache.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/DuplicatingLockWatchEventCache.java
@@ -79,6 +79,11 @@ final class DuplicatingLockWatchEventCache implements LockWatchEventCache {
     }
 
     @Override
+    public void dumpState() {
+        mainCache.dumpState();
+    }
+
+    @Override
     public CommitUpdate getEventUpdate(long startTs) {
         return mainCache.getEventUpdate(startTs);
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/DuplicatingLockWatchEventCache.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/DuplicatingLockWatchEventCache.java
@@ -79,8 +79,9 @@ final class DuplicatingLockWatchEventCache implements LockWatchEventCache {
     }
 
     @Override
-    public void dumpState() {
-        mainCache.dumpState();
+    public void logState() {
+        mainCache.logState();
+        secondaryCache.logState();
     }
 
     @Override

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventCacheIntegrationTest.java
@@ -140,7 +140,7 @@ public class LockWatchEventCacheIntegrationTest {
                 .registerModule(new GuavaModule());
         try {
             Path path = Paths.get(BASE + testInfo.getTestMethod().get().getName() + "/event-cache-" + part + ".json");
-            LockWatchEventCacheState eventCacheState = realEventCache.getStateForTesting();
+            LockWatchEventCacheState eventCacheState = realEventCache.getStateForDiagnostics();
 
             if (MODE.isDev()) {
                 mapper.writeValue(path.toFile(), eventCacheState);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLogTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchEventLogTest.java
@@ -160,7 +160,7 @@ public final class LockWatchEventLogTest {
         assertThat(cacheUpdate.shouldClearCache()).isTrue();
         assertThat(cacheUpdate.getVersion()).hasValue(initialLeaderAtSequenceOne);
         assertThat(eventLog.getLatestKnownVersion()).hasValue(initialLeaderAtSequenceOne);
-        assertThat(eventLog.getStateForTesting())
+        assertThat(eventLog.getStateForDiagnostics())
                 .isEqualTo(ImmutableLockWatchEventLogState.builder()
                         .latestVersion(initialLeaderAtSequenceOne)
                         .snapshotState(SNAPSHOT_STATE_VERSION_1)
@@ -180,7 +180,7 @@ public final class LockWatchEventLogTest {
         assertThat(cacheUpdate.shouldClearCache()).isFalse();
         assertThat(cacheUpdate.getVersion()).hasValue(initialLeaderAtSequenceTwo);
         assertThat(eventLog.getLatestKnownVersion()).hasValue(initialLeaderAtSequenceTwo);
-        assertThat(eventLog.getStateForTesting())
+        assertThat(eventLog.getStateForDiagnostics())
                 .isEqualTo(ImmutableLockWatchEventLogState.builder()
                         .latestVersion(initialLeaderAtSequenceTwo)
                         .snapshotState(SNAPSHOT_STATE_VERSION_1)
@@ -199,7 +199,7 @@ public final class LockWatchEventLogTest {
         assertThat(cacheUpdate.shouldClearCache()).isFalse();
         assertThat(cacheUpdate.getVersion()).hasValue(initialLeaderAtSequenceSix);
         assertThat(eventLog.getLatestKnownVersion()).hasValue(initialLeaderAtSequenceSix);
-        assertThat(eventLog.getStateForTesting())
+        assertThat(eventLog.getStateForDiagnostics())
                 .isEqualTo(ImmutableLockWatchEventLogState.builder()
                         .latestVersion(initialLeaderAtSequenceSix)
                         .snapshotState(SNAPSHOT_STATE_VERSION_5)
@@ -219,7 +219,7 @@ public final class LockWatchEventLogTest {
         assertThat(secondSnapshotUpdateResult.shouldClearCache()).isTrue();
         assertThat(secondSnapshotUpdateResult.getVersion()).hasValue(differentLeaderAtSequenceOne);
         assertThat(eventLog.getLatestKnownVersion()).hasValue(differentLeaderAtSequenceOne);
-        assertThat(eventLog.getStateForTesting())
+        assertThat(eventLog.getStateForDiagnostics())
                 .isEqualTo(ImmutableLockWatchEventLogState.builder()
                         .latestVersion(differentLeaderAtSequenceOne)
                         .snapshotState(ImmutableClientLockWatchSnapshotState.builder()
@@ -245,7 +245,7 @@ public final class LockWatchEventLogTest {
         assertThat(spanningUpdate.shouldClearCache()).isFalse();
         assertThat(spanningUpdate.getVersion()).hasValue(initialLeaderAtSequenceFour);
         assertThat(eventLog.getLatestKnownVersion()).hasValue(initialLeaderAtSequenceFour);
-        assertThat(eventLog.getStateForTesting())
+        assertThat(eventLog.getStateForDiagnostics())
                 .isEqualTo(ImmutableLockWatchEventLogState.builder()
                         .latestVersion(initialLeaderAtSequenceFour)
                         .snapshotState(SNAPSHOT_STATE_VERSION_1)
@@ -277,7 +277,7 @@ public final class LockWatchEventLogTest {
         assertThat(oldUpdate.shouldClearCache()).isFalse();
         assertThat(oldUpdate.getVersion()).hasValue(initialLeaderAtSequenceTwo);
         assertThat(eventLog.getLatestKnownVersion()).hasValue(initialLeaderAtSequenceThree);
-        assertThat(eventLog.getStateForTesting())
+        assertThat(eventLog.getStateForDiagnostics())
                 .isEqualTo(ImmutableLockWatchEventLogState.builder()
                         .latestVersion(initialLeaderAtSequenceThree)
                         .snapshotState(SNAPSHOT_STATE_VERSION_1)
@@ -344,7 +344,7 @@ public final class LockWatchEventLogTest {
         assertThat(cacheUpdate.shouldClearCache()).isTrue();
         assertThat(cacheUpdate.getVersion()).hasValue(initialLeaderAtSequenceSix);
         assertThat(eventLog.getLatestKnownVersion()).hasValue(initialLeaderAtSequenceSix);
-        assertThat(eventLog.getStateForTesting())
+        assertThat(eventLog.getStateForDiagnostics())
                 .isEqualTo(ImmutableLockWatchEventLogState.builder()
                         .latestVersion(initialLeaderAtSequenceSix)
                         .snapshotState(ImmutableClientLockWatchSnapshotState.builder()
@@ -365,7 +365,7 @@ public final class LockWatchEventLogTest {
         LockWatchVersion initialLeaderAtSequenceFour = LockWatchVersion.of(INITIAL_LEADER, SEQUENCE_4);
 
         assertThat(eventLog.getLatestKnownVersion()).hasValue(initialLeaderAtSequenceFour);
-        assertThat(eventLog.getStateForTesting())
+        assertThat(eventLog.getStateForDiagnostics())
                 .isEqualTo(ImmutableLockWatchEventLogState.builder()
                         .latestVersion(initialLeaderAtSequenceFour)
                         .snapshotState(ImmutableClientLockWatchSnapshotState.builder()

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/VersionedEventStoreTest.java
@@ -136,7 +136,7 @@ public final class VersionedEventStoreTest {
         LockWatchEvents events = eventStore.retentionEvents(Optional.empty());
         assertThat(events.events()).isEmpty();
         assertThat(events.versionRange()).isEmpty();
-        assertThat(eventStore.getStateForTesting().eventMap().keySet()).containsExactlyInAnyOrder(SEQ_1);
+        assertThat(eventStore.getStateForDiagnostics().eventMap().keySet()).containsExactlyInAnyOrder(SEQ_1);
     }
 
     @Test
@@ -144,12 +144,12 @@ public final class VersionedEventStoreTest {
         eventStore.putAll(makeEvents(EVENT_1, EVENT_2, EVENT_3, EVENT_4));
         LockWatchEvents eventsRetentionedBeforeMinSeq = eventStore.retentionEvents(Optional.of(SEQ_MIN));
         assertThat(eventsRetentionedBeforeMinSeq.events()).isEmpty();
-        assertThat(eventStore.getStateForTesting().eventMap().keySet())
+        assertThat(eventStore.getStateForDiagnostics().eventMap().keySet())
                 .containsExactlyInAnyOrder(SEQ_1, SEQ_2, SEQ_3, SEQ_4);
 
         LockWatchEvents eventsRetentionedBeforeFirstSeq = eventStore.retentionEvents(Optional.of(SEQ_1));
         assertThat(eventsRetentionedBeforeFirstSeq.events()).isEmpty();
-        assertThat(eventStore.getStateForTesting().eventMap().keySet())
+        assertThat(eventStore.getStateForDiagnostics().eventMap().keySet())
                 .containsExactlyInAnyOrder(SEQ_1, SEQ_2, SEQ_3, SEQ_4);
     }
 
@@ -161,7 +161,7 @@ public final class VersionedEventStoreTest {
         assertThat(events.events().stream().map(LockWatchEvent::sequence).map(Sequence::of))
                 .containsExactly(SEQ_1, SEQ_2);
         assertThat(events.versionRange()).contains(Range.closed(EVENT_1.sequence(), EVENT_2.sequence()));
-        assertThat(eventStore.getStateForTesting().eventMap().firstKey()).isEqualTo(SEQ_3);
+        assertThat(eventStore.getStateForDiagnostics().eventMap().firstKey()).isEqualTo(SEQ_3);
     }
 
     @Test
@@ -172,7 +172,7 @@ public final class VersionedEventStoreTest {
         assertThat(events.events().stream().map(LockWatchEvent::sequence).map(Sequence::of))
                 .containsExactly(SEQ_1);
         assertThat(events.versionRange()).contains(Range.closed(EVENT_1.sequence(), EVENT_1.sequence()));
-        assertThat(eventStore.getStateForTesting().eventMap().firstKey()).isEqualTo(SEQ_2);
+        assertThat(eventStore.getStateForDiagnostics().eventMap().firstKey()).isEqualTo(SEQ_2);
     }
 
     @Test
@@ -183,12 +183,12 @@ public final class VersionedEventStoreTest {
         assertThat(events.events().stream().map(LockWatchEvent::sequence).map(Sequence::of))
                 .containsExactly(SEQ_1);
         assertThat(events.versionRange()).contains(Range.closed(EVENT_1.sequence(), EVENT_1.sequence()));
-        assertThat(eventStore.getStateForTesting().eventMap().firstKey()).isEqualTo(SEQ_2);
+        assertThat(eventStore.getStateForDiagnostics().eventMap().firstKey()).isEqualTo(SEQ_2);
 
         LockWatchEvents newEvents = eventStore.retentionEvents(Optional.of(SEQ_4));
         assertThat(newEvents.events().stream().map(LockWatchEvent::sequence).map(Sequence::of))
                 .containsExactly(SEQ_2, SEQ_3);
-        assertThat(eventStore.getStateForTesting().eventMap().firstKey()).isEqualTo(SEQ_4);
+        assertThat(eventStore.getStateForDiagnostics().eventMap().firstKey()).isEqualTo(SEQ_4);
     }
 
     @Test

--- a/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
@@ -16,6 +16,7 @@
 
 package com.palantir.lock.client;
 
+import com.google.common.base.MoreObjects;
 import com.palantir.atlasdb.timelock.api.ConjureLockToken;
 import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.v2.Lease;
@@ -82,5 +83,14 @@ public final class LeasedLockToken implements LockToken {
     @Override
     public SafeArg<?> toSafeArg(String name) {
         return SafeArg.of(name, serverToken);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper("LeasedLockToken")
+                .omitNullValues()
+                .add("serverToken", serverToken)
+                .add("requestId", requestId)
+                .toString();
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
@@ -22,11 +22,13 @@ import com.palantir.lock.v2.LeaderTime;
 import com.palantir.lock.v2.Lease;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.tritium.ids.UniqueIds;
 import java.util.UUID;
 import javax.annotation.concurrent.GuardedBy;
 
+@Safe
 public final class LeasedLockToken implements LockToken {
     private final ConjureLockToken serverToken;
     private final UUID requestId;
@@ -85,6 +87,7 @@ public final class LeasedLockToken implements LockToken {
         return SafeArg.of(name, serverToken);
     }
 
+    @Safe
     @Override
     public String toString() {
         return MoreObjects.toStringHelper("LeasedLockToken")

--- a/lock-api/src/main/java/com/palantir/lock/client/LockTokenShare.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockTokenShare.java
@@ -16,9 +16,11 @@
 
 package com.palantir.lock.client;
 
+import com.google.common.base.MoreObjects;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.Unsafe;
 import com.palantir.tritium.ids.UniqueIds;
 import java.util.Optional;
 import java.util.UUID;
@@ -88,6 +90,16 @@ final class LockTokenShare implements LockToken {
             referenceCount--;
             return referenceCount == 0;
         }
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper("LockShareToken")
+                .omitNullValues()
+                .add("requestId", requestId)
+                .add("sharedLockToken", sharedLockToken)
+                .add("unlocked", unlocked)
+                .toString();
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/LockTokenShare.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockTokenShare.java
@@ -20,7 +20,6 @@ import com.google.common.base.MoreObjects;
 import com.palantir.lock.v2.LockToken;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.Unsafe;
 import com.palantir.tritium.ids.UniqueIds;
 import java.util.Optional;
 import java.util.UUID;

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCache.java
@@ -32,5 +32,5 @@ public interface LockWatchCache {
 
     LockWatchValueCache getValueCache();
 
-    void dumpState();
+    void logState();
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCache.java
@@ -31,4 +31,6 @@ public interface LockWatchCache {
     LockWatchEventCache getEventCache();
 
     LockWatchValueCache getValueCache();
+
+    void dumpState();
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCacheImpl.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCacheImpl.java
@@ -70,8 +70,8 @@ public final class LockWatchCacheImpl implements LockWatchCache {
     }
 
     @Override
-    public void dumpState() {
-        eventCache.dumpState();
-        valueCache.dumpState();
+    public void logState() {
+        eventCache.logState();
+        valueCache.logState();
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCacheImpl.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCacheImpl.java
@@ -68,4 +68,10 @@ public final class LockWatchCacheImpl implements LockWatchCache {
     public LockWatchValueCache getValueCache() {
         return valueCache;
     }
+
+    @Override
+    public void dumpState() {
+        eventCache.dumpState();
+        valueCache.dumpState();
+    }
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
@@ -73,5 +73,5 @@ public interface LockWatchEventCache {
      */
     void removeTransactionStateFromCache(long startTimestamp);
 
-    void dumpState();
+    void logState();
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchEventCache.java
@@ -72,4 +72,6 @@ public interface LockWatchEventCache {
      * still-held version, and therefore may trigger retention in the underlying event log.
      */
     void removeTransactionStateFromCache(long startTimestamp);
+
+    void dumpState();
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchValueCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchValueCache.java
@@ -27,5 +27,5 @@ public interface LockWatchValueCache {
 
     void onSuccessfulCommit(long startTimestamp);
 
-    void dumpState();
+    void logState();
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchValueCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchValueCache.java
@@ -26,4 +26,6 @@ public interface LockWatchValueCache {
     void ensureStateRemoved(long startTimestamp);
 
     void onSuccessfulCommit(long startTimestamp);
+
+    void dumpState();
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
@@ -79,8 +79,8 @@ public class NoOpLockWatchEventCache implements LockWatchEventCache {
     public void removeTransactionStateFromCache(long startTimestamp) {}
 
     @Override
-    public void dumpState() {
-        log.info("Dumping state from NoOpLockWatchEventCache", SafeArg.of("currentVersion", currentVersion));
+    public void logState() {
+        log.info("Logging state from NoOpLockWatchEventCache", SafeArg.of("currentVersion", currentVersion));
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
@@ -80,7 +80,7 @@ public class NoOpLockWatchEventCache implements LockWatchEventCache {
 
     @Override
     public void dumpState() {
-        log.info("Dumping NoOpLockWatchEventCache state", SafeArg.of("currentVersion", currentVersion));
+        log.info("Dumping state from NoOpLockWatchEventCache", SafeArg.of("currentVersion", currentVersion));
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchEventCache.java
@@ -16,6 +16,9 @@
 
 package com.palantir.lock.watch;
 
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -26,6 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 @SuppressWarnings("FinalClass") // mocks
 public class NoOpLockWatchEventCache implements LockWatchEventCache {
+    private static final SafeLogger log = SafeLoggerFactory.get(NoOpLockWatchEventCache.class);
     private static final LockWatchVersion FAKE_VERSION = LockWatchVersion.of(UUID.randomUUID(), -1L);
     private volatile Optional<LockWatchVersion> currentVersion = Optional.empty();
 
@@ -73,6 +77,11 @@ public class NoOpLockWatchEventCache implements LockWatchEventCache {
 
     @Override
     public void removeTransactionStateFromCache(long startTimestamp) {}
+
+    @Override
+    public void dumpState() {
+        log.info("Dumping NoOpLockWatchEventCache state", SafeArg.of("currentVersion", currentVersion));
+    }
 
     @Override
     public CommitUpdate getEventUpdate(long startTs) {

--- a/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchValueCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchValueCache.java
@@ -34,4 +34,7 @@ public class NoOpLockWatchValueCache implements LockWatchValueCache {
 
     @Override
     public void onSuccessfulCommit(long startTimestamp) {}
+
+    @Override
+    public void dumpState() {}
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchValueCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchValueCache.java
@@ -16,9 +16,13 @@
 
 package com.palantir.lock.watch;
 
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Set;
 
 public class NoOpLockWatchValueCache implements LockWatchValueCache {
+    private static final SafeLogger log = SafeLoggerFactory.get(NoOpLockWatchValueCache.class);
+
     public static LockWatchValueCache create() {
         return new NoOpLockWatchValueCache();
     }
@@ -36,5 +40,7 @@ public class NoOpLockWatchValueCache implements LockWatchValueCache {
     public void onSuccessfulCommit(long startTimestamp) {}
 
     @Override
-    public void dumpState() {}
+    public void logState() {
+        log.info("Logging state from NoOpLockWatchValueCache");
+    }
 }


### PR DESCRIPTION
## General
**Before this PR**:
There was no way to dump lock watch state in Atlas clients.


**After this PR**:
LockWatchManager exposes a method to dump internal state.

==COMMIT_MSG==
Expose a lock watch manager dump state method
==COMMIT_MSG==

**Priority**:
P1
**Concerns / possible downsides (what feedback would you like?)**:
Similar to https://github.com/palantir/atlasdb/pull/7190
- Safe logging
- Avoiding any incidental performance degradation
- Big log lines
- Avoiding double-logging (the dependency graph here makes it so that can easily happen)
- Noise / rate limiting of logs

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
Yes

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
Internal testing

**What was existing testing like? What have you done to improve it?**:
Internal testing

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
Code should only be reading from concurrent data structures, this is for logging so we do not care about full internal consistency. I also tried to snapshot structures / copy them deeply. I want to avoid the infra holding onto some references (you could imagine the loggers buffer message and args until some later point).

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
One of the methods is synchronized. This is fine as it's a one-off.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Internal testing

**Has the safety of all log arguments been decided correctly?**:
Yes, but please check

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Internal testing

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Recall and rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No. Upstream callers should only call this on namespaces that we are examining in incidents.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
N/A

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
