### PR TITLE
Add endpoint API definition to dump timelock lock watch internals

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -29,6 +29,7 @@ import com.palantir.atlasdb.http.NotCurrentLeaderExceptionMapper;
 import com.palantir.atlasdb.http.RedirectRetryTargeter;
 import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.timelock.AsyncTimelockService;
+import com.palantir.atlasdb.timelock.ConjureLockWatchDiagnosticsResource;
 import com.palantir.atlasdb.timelock.ConjureLockWatchingResource;
 import com.palantir.atlasdb.timelock.ConjureTimelockResource;
 import com.palantir.atlasdb.timelock.TimeLockServices;
@@ -369,6 +370,9 @@ public class TimeLockAgent {
                     MultiClientConjureTimelockResource.undertow(redirectRetryTargeter, asyncTimelockServiceGetter));
             NonConjureTimelockResources.createUndertowServices(namespaces, redirectRetryTargeter)
                     .forEach(service -> registerCorruptionHandlerWrappedService(presentUndertowRegistrar, service));
+            registerCorruptionHandlerWrappedService(
+                    presentUndertowRegistrar,
+                    ConjureLockWatchDiagnosticsResource.undertow(redirectRetryTargeter, asyncTimelockServiceGetter));
         } else {
             registrar.accept(ConjureTimelockResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
             registrar.accept(ConjureLockWatchingResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
@@ -377,6 +381,8 @@ public class TimeLockAgent {
             registrar.accept(
                     MultiClientConjureTimelockResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
             NonConjureTimelockResources.createJerseyResources(namespaces).forEach(registrar);
+            registrar.accept(
+                    ConjureLockWatchDiagnosticsResource.jersey(redirectRetryTargeter, asyncTimelockServiceGetter));
         }
     }
 

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -371,6 +371,20 @@ services:
           request: LockWatchRequest
         tags:
           - server-request-context
+  ConjureLockWatchDiagnosticsService:
+    name: Lock Watch Diagnostics service
+    default-auth: header
+    package: com.palantir.atlasdb.timelock.lock.watch
+    base-path: /lw/diagnostics
+    endpoints:
+        dumpState:
+          http: GET /dumpState/{namespace}
+          args:
+              namespace:
+                  type: string
+                  safety: safe
+          tags:
+            - server-request-context
   MultiClientConjureTimelockService:
     name: Multi Client Timelock Service
     default-auth: header

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -377,8 +377,8 @@ services:
     package: com.palantir.atlasdb.timelock.lock.watch
     base-path: /lw/diagnostics
     endpoints:
-      dumpState:
-        http: GET /dumpState/{namespace}
+      logState:
+        http: POST /logState/{namespace}
         args:
           namespace:
             type: string

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -377,14 +377,14 @@ services:
     package: com.palantir.atlasdb.timelock.lock.watch
     base-path: /lw/diagnostics
     endpoints:
-        dumpState:
-          http: GET /dumpState/{namespace}
-          args:
-              namespace:
-                  type: string
-                  safety: safe
-          tags:
-            - server-request-context
+      dumpState:
+        http: GET /dumpState/{namespace}
+        args:
+          namespace:
+            type: string
+            safety: safe
+        tags:
+          - server-request-context
   MultiClientConjureTimelockService:
     name: Multi Client Timelock Service
     default-auth: header

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -299,8 +299,8 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     }
 
     @Override
-    public void dumpState() {
-        lockService.getLockWatchingService().dumpState();
+    public void logState() {
+        lockService.getLockWatchingService().logState();
     }
 
     private static LockWatchVersion fromConjure(ConjureIdentifiedVersion conjure) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -298,6 +298,11 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
         lockService.getLockWatchingService().registerUnlock(locksUnlocked);
     }
 
+    @Override
+    public void dumpState() {
+        lockService.getLockWatchingService().dumpState();
+    }
+
     private static LockWatchVersion fromConjure(ConjureIdentifiedVersion conjure) {
         return LockWatchVersion.of(conjure.getId(), conjure.getVersion());
     }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureLockWatchDiagnosticsResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureLockWatchDiagnosticsResource.java
@@ -1,0 +1,80 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.palantir.atlasdb.futures.AtlasFutures;
+import com.palantir.atlasdb.http.RedirectRetryTargeter;
+import com.palantir.atlasdb.timelock.lock.watch.ConjureLockWatchDiagnosticsService;
+import com.palantir.atlasdb.timelock.lock.watch.ConjureLockWatchDiagnosticsServiceEndpoints;
+import com.palantir.atlasdb.timelock.lock.watch.UndertowConjureLockWatchDiagnosticsService;
+import com.palantir.conjure.java.undertow.lib.RequestContext;
+import com.palantir.conjure.java.undertow.lib.UndertowService;
+import com.palantir.tokens.auth.AuthHeader;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+public final class ConjureLockWatchDiagnosticsResource implements UndertowConjureLockWatchDiagnosticsService {
+    private final ConjureResourceExceptionHandler exceptionHandler;
+    private final BiFunction<String, Optional<String>, AsyncTimelockService> timelockServices;
+
+    private ConjureLockWatchDiagnosticsResource(
+            RedirectRetryTargeter redirectRetryTargeter,
+            BiFunction<String, Optional<String>, AsyncTimelockService> timelockServices) {
+        this.exceptionHandler = new ConjureResourceExceptionHandler(redirectRetryTargeter);
+        this.timelockServices = timelockServices;
+    }
+
+    public static UndertowService undertow(
+            RedirectRetryTargeter redirectRetryTargeter,
+            BiFunction<String, Optional<String>, AsyncTimelockService> timelockServices) {
+        return ConjureLockWatchDiagnosticsServiceEndpoints.of(
+                new ConjureLockWatchDiagnosticsResource(redirectRetryTargeter, timelockServices));
+    }
+
+    public static ConjureLockWatchDiagnosticsService jersey(
+            RedirectRetryTargeter redirectRetryTargeter,
+            BiFunction<String, Optional<String>, AsyncTimelockService> timelockServices) {
+        return new JerseyAdapter(new ConjureLockWatchDiagnosticsResource(redirectRetryTargeter, timelockServices));
+    }
+
+    @Override
+    public ListenableFuture<Void> dumpState(AuthHeader authHeader, String namespace, RequestContext requestContext) {
+        return exceptionHandler.handleExceptions(() -> dumpStateSync(namespace, requestContext));
+    }
+
+    private ListenableFuture<Void> dumpStateSync(String namespace, RequestContext context) {
+        timelockServices
+                .apply(namespace, TimelockNamespaces.toUserAgent(context))
+                .dumpState();
+        return Futures.immediateFuture(null);
+    }
+
+    public static final class JerseyAdapter implements ConjureLockWatchDiagnosticsService {
+        private final ConjureLockWatchDiagnosticsResource resource;
+
+        private JerseyAdapter(ConjureLockWatchDiagnosticsResource resource) {
+            this.resource = resource;
+        }
+
+        @Override
+        public void dumpState(AuthHeader authHeader, String namespace) {
+            AtlasFutures.getUnchecked(resource.dumpState(authHeader, namespace, null));
+        }
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureLockWatchDiagnosticsResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/ConjureLockWatchDiagnosticsResource.java
@@ -59,15 +59,13 @@ public final class ConjureLockWatchDiagnosticsResource implements UndertowConjur
 
     @Override
     public ListenableFuture<Void> logState(AuthHeader authHeader, String namespace, RequestContext requestContext) {
-        return exceptionHandler.handleExceptions(() -> logStateSync(namespace, requestContext));
-    }
-
-    private ListenableFuture<Void> logStateSync(String namespace, RequestContext context) {
-        log.info("Logging state for namespace {}", SafeArg.of("namespace", namespace));
-        timelockServices
-                .apply(namespace, TimelockNamespaces.toUserAgent(context))
-                .logState();
-        return Futures.immediateFuture(null);
+        return exceptionHandler.handleExceptions(() -> {
+            log.info("Logging state for namespace {}", SafeArg.of("namespace", namespace));
+            timelockServices
+                    .apply(namespace, TimelockNamespaces.toUserAgent(requestContext))
+                    .logState();
+            return Futures.immediateFuture(null);
+        });
     }
 
     public static final class JerseyAdapter implements ConjureLockWatchDiagnosticsService {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLog.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLog.java
@@ -39,4 +39,6 @@ public interface LockEventLog {
     void logUnlock(Set<LockDescriptor> locksUnlocked);
 
     void logLockWatchCreated(LockWatches newWatches);
+
+    void dumpState();
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLog.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLog.java
@@ -40,5 +40,5 @@ public interface LockEventLog {
 
     void logLockWatchCreated(LockWatches newWatches);
 
-    void dumpState();
+    void logState();
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
@@ -85,6 +85,11 @@ public class LockEventLogImpl implements LockEventLog {
         slidingWindow.add(LockWatchCreatedEvent.builder(newWatches.references(), openLocks));
     }
 
+    @Override
+    public void dumpState() {
+        // TODO(aalouane): implement!
+    }
+
     private Optional<LockWatchStateUpdate> tryGetNextEvents(Optional<LockWatchVersion> fromVersion) {
         if (!fromVersion.isPresent() || !fromVersion.get().id().equals(logId)) {
             return Optional.empty();

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockEventLogImpl.java
@@ -86,7 +86,7 @@ public class LockEventLogImpl implements LockEventLog {
     }
 
     @Override
-    public void dumpState() {
+    public void logState() {
         // TODO(aalouane): implement!
     }
 

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingService.java
@@ -39,5 +39,5 @@ public interface LockWatchingService extends LockWatchStarter {
 
     void registerUnlock(Set<LockDescriptor> locksUnlocked);
 
-    void dumpState();
+    void logState();
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingService.java
@@ -38,4 +38,6 @@ public interface LockWatchingService extends LockWatchStarter {
     void registerLock(Set<LockDescriptor> locksTakenOut, LockToken token, Optional<LockRequestMetadata> metadata);
 
     void registerUnlock(Set<LockDescriptor> locksUnlocked);
+
+    void dumpState();
 }

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
@@ -125,8 +125,8 @@ public class LockWatchingServiceImpl implements LockWatchingService {
     }
 
     @Override
-    public void dumpState() {
-        lockEventLog.dumpState();
+    public void logState() {
+        lockEventLog.logState();
     }
 
     private synchronized Optional<LockWatches> addToWatches(LockWatchRequest request) {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/watch/LockWatchingServiceImpl.java
@@ -124,6 +124,11 @@ public class LockWatchingServiceImpl implements LockWatchingService {
         runIfDescriptorsMatchLockWatches(unlocked, lockEventLog::logUnlock);
     }
 
+    @Override
+    public void dumpState() {
+        lockEventLog.dumpState();
+    }
+
     private synchronized Optional<LockWatches> addToWatches(LockWatchRequest request) {
         LockWatches oldWatches = watches.get();
         Optional<LockWatches> newWatches = filterNewWatches(request, oldWatches);


### PR DESCRIPTION
API endpoint definition for https://github.com/palantir/atlasdb/pull/7190 with a no-op implementation.