### PR TITLE
Log servers when checking the new service invariant

### DIFF
--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -57,7 +57,6 @@ import com.palantir.dialogue.clients.DialogueClients;
 import com.palantir.lock.LockService;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
-import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
@@ -449,8 +448,8 @@ public class TimeLockAgent {
         if (!install.paxos().ignoreNewServiceCheck()) {
             log.info(
                     "Verifying the new service invariant",
-                    UnsafeArg.of("localServer", cluster.localServer()),
-                    UnsafeArg.of("clusterMembers", cluster.clusterMembers()));
+                    SafeArg.of("localServer", cluster.localServer()),
+                    SafeArg.of("clusterMembers", cluster.clusterMembers()));
             TimeLockPersistenceInvariants.checkPersistenceConsistentWithState(
                     install.isNewService() || cluster.isNewServiceNode(),
                     install.paxos().doDataDirectoriesExist());

--- a/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
+++ b/timelock-agent/src/main/java/com/palantir/timelock/paxos/TimeLockAgent.java
@@ -57,6 +57,7 @@ import com.palantir.dialogue.clients.DialogueClients;
 import com.palantir.lock.LockService;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
@@ -446,6 +447,10 @@ public class TimeLockAgent {
     @VisibleForTesting
     static void verifyIsNewServiceInvariant(TimeLockInstallConfiguration install, ClusterConfiguration cluster) {
         if (!install.paxos().ignoreNewServiceCheck()) {
+            log.info(
+                    "Verifying the new service invariant",
+                    UnsafeArg.of("localServer", cluster.localServer()),
+                    UnsafeArg.of("clusterMembers", cluster.clusterMembers()));
             TimeLockPersistenceInvariants.checkPersistenceConsistentWithState(
                     install.isNewService() || cluster.isNewServiceNode(),
                     install.paxos().doDataDirectoriesExist());


### PR DESCRIPTION
## General
**Before this PR**:
It is not always clear whether the provided local server in cluster config matches what discovery wants. I would like to quickly check (or have checked) if the local server was provided correctly.

**After this PR**:
Log servers when checking the new service invariant
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P2
**Concerns / possible downsides (what feedback would you like?)**:
Do not log?
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
N/A
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Logs
**Has the safety of all log arguments been decided correctly?**:
Yes, see concerns
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Logs missing
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Recall and rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
