### PR TITLE
Trigger the TimeLock diagnostics RPC on `LockWatchManager::logState`

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -151,6 +151,19 @@ acceptedBreaks:
       new: "method com.palantir.lock.LockState com.palantir.atlasdb.factory.timelock.TimeoutSensitiveLockRpcClient::getLockState(java.lang.String,\
         \ com.palantir.lock.LockDescriptor)"
       justification: "LockRpcClient#getLockState is broken"
+  "0.1127.0":
+    com.palantir.atlasdb:atlasdb-config:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method com.palantir.atlasdb.factory.TimeLockHelperServices com.palantir.atlasdb.factory.TimeLockHelperServices::create(java.lang.String,\
+        \ com.palantir.atlasdb.util.MetricsManager, java.util.Set<com.palantir.atlasdb.table.description.Schema>,\
+        \ com.palantir.lock.client.LockWatchStarter, com.palantir.atlasdb.keyvalue.api.LockWatchCachingConfig,\
+        \ java.util.function.Supplier<java.util.Optional<com.palantir.lock.client.RequestBatchersFactory.MultiClientRequestBatchers>>)"
+      new: "method com.palantir.atlasdb.factory.TimeLockHelperServices com.palantir.atlasdb.factory.TimeLockHelperServices::create(java.lang.String,\
+        \ com.palantir.atlasdb.util.MetricsManager, java.util.Set<com.palantir.atlasdb.table.description.Schema>,\
+        \ com.palantir.lock.client.LockWatchStarter, com.palantir.atlasdb.keyvalue.api.LockWatchCachingConfig,\
+        \ java.util.function.Supplier<java.util.Optional<com.palantir.lock.client.RequestBatchersFactory.MultiClientRequestBatchers>>,\
+        \ com.palantir.lock.client.LockWatchTimeLockDiagnosticsLogger)"
+      justification: "used in atlas only"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbDialogueServiceProvider.java
@@ -35,6 +35,7 @@ import com.palantir.atlasdb.http.v2.UnknownRemoteDebuggingProxy;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.ConjureTimelockServiceBlocking;
 import com.palantir.atlasdb.timelock.api.MultiClientConjureTimelockServiceBlocking;
+import com.palantir.atlasdb.timelock.lock.watch.ConjureLockWatchDiagnosticsServiceBlocking;
 import com.palantir.atlasdb.timelock.lock.watch.ConjureLockWatchingServiceBlocking;
 import com.palantir.atlasdb.util.AtlasDbMetrics;
 import com.palantir.conjure.java.api.config.service.UserAgent;
@@ -170,6 +171,15 @@ public final class AtlasDbDialogueServiceProvider {
                 taggedMetricRegistry,
                 ConjureLockWatchingServiceBlocking.class,
                 wrapInProxy(ConjureLockWatchingServiceBlocking.class, blockingService));
+    }
+
+    ConjureLockWatchDiagnosticsServiceBlocking getConjureLockWatchDiagnosticsService() {
+        ConjureLockWatchDiagnosticsServiceBlocking blockingService =
+                dialogueClientFactory.get(ConjureLockWatchDiagnosticsServiceBlocking.class, TIMELOCK_SHORT_TIMEOUT);
+        return AtlasDbMetrics.instrumentWithTaggedMetrics(
+                taggedMetricRegistry,
+                ConjureLockWatchDiagnosticsServiceBlocking.class,
+                wrapInProxy(ConjureLockWatchDiagnosticsServiceBlocking.class, blockingService));
     }
 
     private <T> T createDialogueProxyWithShortTimeout(Class<T> type) {

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DefaultLockAndTimestampServiceFactory.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/DefaultLockAndTimestampServiceFactory.java
@@ -48,6 +48,7 @@ import com.palantir.lock.client.LegacyLockTokenUnlocker;
 import com.palantir.lock.client.LockTokenUnlocker;
 import com.palantir.lock.client.MultiClientTimeLockUnlocker;
 import com.palantir.lock.client.NamespacedCoalescingLeaderTimeGetter;
+import com.palantir.lock.client.NamespacedConjureLockWatchTimeLockDiagnosticsService;
 import com.palantir.lock.client.NamespacedConjureLockWatchingService;
 import com.palantir.lock.client.NamespacedConjureTimelockService;
 import com.palantir.lock.client.NamespacedLockTokenUnlocker;
@@ -332,6 +333,10 @@ public final class DefaultLockAndTimestampServiceFactory implements LockAndTimes
         NamespacedConjureLockWatchingService lockWatchingService = new NamespacedConjureLockWatchingService(
                 serviceProvider.getConjureLockWatchingService(), timelockNamespace);
 
+        NamespacedConjureLockWatchTimeLockDiagnosticsService lockWatchDiagnosticsService =
+                new NamespacedConjureLockWatchTimeLockDiagnosticsService(
+                        serviceProvider.getConjureLockWatchDiagnosticsService(), timelockNamespace);
+
         Supplier<InternalMultiClientConjureTimelockService> multiClientTimelockServiceSupplier =
                 getMultiClientTimelockServiceSupplier(serviceProvider);
 
@@ -341,7 +346,13 @@ public final class DefaultLockAndTimestampServiceFactory implements LockAndTimes
                         batcherProviders.startTransactions().getBatcher(multiClientTimelockServiceSupplier)));
 
         TimeLockHelperServices timeLockHelperServices = TimeLockHelperServices.create(
-                timelockNamespace, metricsManager, schemas, lockWatchingService, cachingConfig, requestBatcherProvider);
+                timelockNamespace,
+                metricsManager,
+                schemas,
+                lockWatchingService,
+                cachingConfig,
+                requestBatcherProvider,
+                lockWatchDiagnosticsService);
         LockWatchManagerInternal lockWatchManager = timeLockHelperServices.lockWatchManager();
 
         RemoteTimelockServiceAdapter remoteTimelockServiceAdapter = RemoteTimelockServiceAdapter.create(

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TimeLockHelperServices.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TimeLockHelperServices.java
@@ -23,6 +23,7 @@ import com.palantir.atlasdb.table.description.Schema;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.lock.client.LockWatchStarter;
+import com.palantir.lock.client.LockWatchTimeLockDiagnosticsLogger;
 import com.palantir.lock.client.RequestBatchersFactory;
 import com.palantir.lock.watch.LockWatchCache;
 import java.util.Optional;
@@ -42,10 +43,11 @@ public interface TimeLockHelperServices {
             Set<Schema> schemas,
             LockWatchStarter lockWatchStarter,
             LockWatchCachingConfig lockWatchCachingConfig,
-            Supplier<Optional<RequestBatchersFactory.MultiClientRequestBatchers>> requestBatcherProvider) {
+            Supplier<Optional<RequestBatchersFactory.MultiClientRequestBatchers>> requestBatcherProvider,
+            LockWatchTimeLockDiagnosticsLogger lockWatchTimeLockDiagnosticsLogger) {
 
-        LockWatchManagerInternal lockWatchManager =
-                LockWatchManagerImpl.create(metricsManager, schemas, lockWatchStarter, lockWatchCachingConfig);
+        LockWatchManagerInternal lockWatchManager = LockWatchManagerImpl.create(
+                metricsManager, schemas, lockWatchStarter, lockWatchCachingConfig, lockWatchTimeLockDiagnosticsLogger);
         LockWatchCache lockWatchCache = lockWatchManager.getCache();
 
         RequestBatchersFactory requestBatchersFactory =

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.keyvalue.api.watch;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.atlasdb.keyvalue.api.LockWatchCachingConfig;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.cache.CacheMetrics;
@@ -29,6 +30,7 @@ import com.palantir.atlasdb.timelock.api.LockWatchRequest;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.client.LockWatchStarter;
+import com.palantir.lock.client.LockWatchTimeLockDiagnosticsLogger;
 import com.palantir.lock.watch.CommitUpdate;
 import com.palantir.lock.watch.LockWatchCache;
 import com.palantir.lock.watch.LockWatchCacheImpl;
@@ -41,7 +43,6 @@ import com.palantir.lock.watch.TransactionsLockWatchUpdate;
 import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import com.palantir.util.RateLimitedLogger;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -53,10 +54,10 @@ import java.util.stream.Collectors;
 public final class LockWatchManagerImpl extends LockWatchManagerInternal {
     private static final SafeLogger log = SafeLoggerFactory.get(LockWatchManagerImpl.class);
 
-    // Log at most 1 line every 2 minutes. Diagnostics are expected to be triggered
+    // Trigger diagnostics at most 1 line every 2 minutes. This is expected only
     // on exceptional circumstances and a one-off basis. This de-duplicates when we
     // need diagnostics on large clusters.
-    private static final RateLimitedLogger diagnosticLog = new RateLimitedLogger(log, 1 / 120.0);
+    private static final RateLimiter DIAGNOSTICS_RATE_LIMITER = RateLimiter.create(1 / 120.0);
 
     private final Set<LockWatchReferences.LockWatchReference> referencesFromSchema;
     private final Set<LockWatchReferences.LockWatchReference> lockWatchReferences = ConcurrentHashMap.newKeySet();
@@ -65,17 +66,20 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
     private final LockWatchStarter lockWatchingService;
     private final ScheduledExecutorService executorService = PTExecutors.newSingleThreadScheduledExecutor();
     private final ScheduledFuture<?> refreshTask;
+    private final LockWatchTimeLockDiagnosticsLogger lockWatchTimeLockDiagnosticsLogger;
 
     @VisibleForTesting
     LockWatchManagerImpl(
             Set<LockWatchReference> referencesFromSchema,
             LockWatchEventCache eventCache,
             LockWatchValueScopingCache valueCache,
-            LockWatchStarter lockWatchingService) {
+            LockWatchStarter lockWatchingService,
+            LockWatchTimeLockDiagnosticsLogger lockWatchTimeLockDiagnosticsLogger) {
         this.referencesFromSchema = referencesFromSchema;
         this.lockWatchCache = new LockWatchCacheImpl(eventCache, valueCache);
         this.valueScopingCache = valueCache;
         this.lockWatchingService = lockWatchingService;
+        this.lockWatchTimeLockDiagnosticsLogger = lockWatchTimeLockDiagnosticsLogger;
         lockWatchReferences.addAll(referencesFromSchema);
         refreshTask = executorService.scheduleWithFixedDelay(this::registerWatchesWithTimelock, 0, 5, TimeUnit.SECONDS);
     }
@@ -84,7 +88,8 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
             MetricsManager metricsManager,
             Set<Schema> schemas,
             LockWatchStarter lockWatchingService,
-            LockWatchCachingConfig config) {
+            LockWatchCachingConfig config,
+            LockWatchTimeLockDiagnosticsLogger lockWatchTimeLockDiagnosticsLogger) {
         Set<LockWatchReference> referencesFromSchema = schemas.stream()
                 .map(Schema::getLockWatches)
                 .flatMap(Set::stream)
@@ -97,7 +102,8 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
         LockWatchEventCache eventCache = LockWatchEventCacheImpl.create(metrics, config.maxEvents());
         LockWatchValueScopingCache valueCache = LockWatchValueScopingCacheImpl.create(
                 eventCache, metrics, config.cacheSize(), config.validationProbability(), watchedTablesFromSchema);
-        return new LockWatchManagerImpl(referencesFromSchema, eventCache, valueCache, lockWatchingService);
+        return new LockWatchManagerImpl(
+                referencesFromSchema, eventCache, valueCache, lockWatchingService, lockWatchTimeLockDiagnosticsLogger);
     }
 
     @Override
@@ -113,13 +119,14 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
 
     @Override
     public void logState() {
-        diagnosticLog.log(logger -> {
-            logger.info(
+        if (DIAGNOSTICS_RATE_LIMITER.tryAcquire()) {
+            log.info(
                     "Logging state from LockWatchManagerImpl",
                     UnsafeArg.of("referencesFromSchema", referencesFromSchema),
                     UnsafeArg.of("lockWatchReferences", ImmutableSet.copyOf(lockWatchReferences)));
             lockWatchCache.logState();
-        });
+            lockWatchTimeLockDiagnosticsLogger.logState();
+        }
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
@@ -125,7 +125,7 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
                     UnsafeArg.of("referencesFromSchema", referencesFromSchema),
                     UnsafeArg.of("lockWatchReferences", ImmutableSet.copyOf(lockWatchReferences)));
             lockWatchCache.logState();
-            lockWatchTimeLockDiagnosticsLogger.logState();
+            lockWatchTimeLockDiagnosticsLogger.logStateOnTimeLockServer();
         }
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImplTest.java
@@ -72,7 +72,7 @@ public final class LockWatchManagerImplTest {
     @BeforeEach
     public void before() {
         manager = new LockWatchManagerImpl(
-                ImmutableSet.of(fromSchema), lockWatchEventCache, valueScopingCache, lockWatchingService);
+                ImmutableSet.of(fromSchema), lockWatchEventCache, valueScopingCache, lockWatchingService, () -> {});
     }
 
     @Test
@@ -84,7 +84,8 @@ public final class LockWatchManagerImplTest {
                 MetricsManagers.createForTests(),
                 ImmutableSet.of(schema),
                 lockWatchingService,
-                LockWatchCachingConfig.builder().build());
+                LockWatchCachingConfig.builder().build(),
+                () -> {});
         Awaitility.await("waiting for thread to start watching")
                 .atMost(Duration.ofSeconds(5))
                 .pollInterval(Duration.ofMillis(100L))

--- a/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/AbstractInMemoryTimelockExtension.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/timelock/paxos/AbstractInMemoryTimelockExtension.java
@@ -153,7 +153,8 @@ public abstract class AbstractInMemoryTimelockExtension implements TimeLockServi
                 ImmutableSet.of(),
                 delegate.getTimelockService(),
                 LockWatchCachingConfig.builder().build(),
-                Optional::empty);
+                Optional::empty,
+                () -> {});
 
         RedirectRetryTargeter redirectRetryTargeter = timeLockAgent.redirectRetryTargeter();
         ConjureTimelockService conjureTimelockService = ConjureTimelockResource.jersey(

--- a/lock-api/src/main/java/com/palantir/lock/client/LockWatchTimeLockDiagnosticsLogger.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockWatchTimeLockDiagnosticsLogger.java
@@ -17,5 +17,5 @@
 package com.palantir.lock.client;
 
 public interface LockWatchTimeLockDiagnosticsLogger {
-    void logState();
+    void logStateOnTimeLockServer();
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/LockWatchTimeLockDiagnosticsLogger.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LockWatchTimeLockDiagnosticsLogger.java
@@ -1,0 +1,21 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+public interface LockWatchTimeLockDiagnosticsLogger {
+    void logState();
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureLockWatchTimeLockDiagnosticsService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureLockWatchTimeLockDiagnosticsService.java
@@ -31,6 +31,7 @@ public final class NamespacedConjureLockWatchTimeLockDiagnosticsService implemen
         this.namespace = namespace;
     }
 
+    @Override
     public void logState() {
         lockWatchDiagnosticsService.logState(AUTH_HEADER, namespace);
     }

--- a/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureLockWatchTimeLockDiagnosticsService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureLockWatchTimeLockDiagnosticsService.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client;
+
+import com.palantir.atlasdb.timelock.lock.watch.ConjureLockWatchDiagnosticsServiceBlocking;
+import com.palantir.tokens.auth.AuthHeader;
+
+public final class NamespacedConjureLockWatchTimeLockDiagnosticsService implements LockWatchTimeLockDiagnosticsLogger {
+    private static final AuthHeader AUTH_HEADER = AuthHeader.valueOf("Bearer omitted");
+
+    private final String namespace;
+    private final ConjureLockWatchDiagnosticsServiceBlocking lockWatchDiagnosticsService;
+
+    public NamespacedConjureLockWatchTimeLockDiagnosticsService(
+            ConjureLockWatchDiagnosticsServiceBlocking lockWatchDiagnosticsService, String namespace) {
+        this.lockWatchDiagnosticsService = lockWatchDiagnosticsService;
+        this.namespace = namespace;
+    }
+
+    public void logState() {
+        lockWatchDiagnosticsService.logState(AUTH_HEADER, namespace);
+    }
+}

--- a/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureLockWatchTimeLockDiagnosticsService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/NamespacedConjureLockWatchTimeLockDiagnosticsService.java
@@ -32,7 +32,7 @@ public final class NamespacedConjureLockWatchTimeLockDiagnosticsService implemen
     }
 
     @Override
-    public void logState() {
+    public void logStateOnTimeLockServer() {
         lockWatchDiagnosticsService.logState(AUTH_HEADER, namespace);
     }
 }


### PR DESCRIPTION
## General
**Before this PR**:
#7194 added a TimeLock API to dump server side lock watch state and #7192 added a client-side method to dump client side lock watch state. The TimeLock API needs to be hit somewhere.
**After this PR**:
The client-side lock watch state logging code path also triggers an RPC for server-side state logging.
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P1
**Concerns / possible downsides (what feedback would you like?)**:
See PR comments
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
N/A
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Internal testing
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Internal testing
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Recall and rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
It should not. The RPC call is rate-limited.
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
