### PR TITLE
[ASTS] Bucket Assignment I: SweepBucketStore API

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
@@ -119,6 +119,24 @@ public enum TargetedSweepSchema implements AtlasSchema {
                 conflictHandler(ConflictHandler.IGNORE_ALL);
             }
         });
+
+        schema.addTableDefinition("sweepBuckets", new TableDefinition() {
+            {
+                javaTableName("SweepBuckets");
+                allSafeForLoggingByDefault();
+                rowName();
+                hashFirstRowComponent();
+                // This component is signed, because to avoid doing BIG RANGE SCANS (tm), I plan to store some
+                // additional metadata using the -1 bucket.
+                rowComponent("majorBucketIdentifier", ValueType.VAR_SIGNED_LONG);
+                dynamicColumns();
+                columnComponent("minorBucketIdentifier", ValueType.VAR_LONG);
+
+                // we do our own cleanup
+                sweepStrategy(TableMetadataPersistence.SweepStrategy.NOTHING);
+                conflictHandler(ConflictHandler.IGNORE_ALL);
+            }
+        });
     }
 
     private static void addTableIdentifierTables(Schema schema) {

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/TargetedSweepSchema.java
@@ -131,6 +131,7 @@ public enum TargetedSweepSchema implements AtlasSchema {
                 rowComponent("majorBucketIdentifier", ValueType.VAR_SIGNED_LONG);
                 dynamicColumns();
                 columnComponent("minorBucketIdentifier", ValueType.VAR_LONG);
+                value(ValueType.BLOB);
 
                 // we do our own cleanup
                 sweepStrategy(TableMetadataPersistence.SweepStrategy.NOTHING);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucket/SweepBucketStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucket/SweepBucketStore.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucket;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SweepBucketStore {
+    /**
+     * Retrieves the range of timestamps associated with the given bucket identifier, or an empty optional if the
+     * bucket does not exist.
+     */
+    Optional<SweepableBucketRange> getSweepBucketRange(long bucketIdentifier);
+
+    /**
+     * Retrieves a list of buckets corresponding to the lowest buckets the sweep bucket store knows about, that are
+     * at least as high as the provided AtlasDB timestamp.
+     */
+    List<Long> getFirstLiveBuckets(long lowerBoundTimestamp);
+
+    /**
+     * Closes the currently open bucket at the provided timestamp, if it is greater than the start timestamp of the
+     * bucket. If it is not, is a no-op.
+     */
+    void appendSweepBucketRange(long timestamp);
+
+    /**
+     * Deletes a sweep bucket from the sweep bucket store. The onus is on the user to ensure that this is a safe
+     * operation, and externally referenced state relating to the bucket in question has already been cleaned up.
+     */
+    void deleteSweepBucket(long bucketIdentifier);
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucket/SweepBucketStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucket/SweepBucketStore.java
@@ -19,28 +19,33 @@ package com.palantir.atlasdb.sweep.asts.bucket;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Stores information about the ranges of timestamps associated with given bucket identifiers.
+ */
 public interface SweepBucketStore {
     /**
      * Retrieves the range of timestamps associated with the given bucket identifier, or an empty optional if the
      * bucket does not exist.
      */
-    Optional<SweepableBucketRange> getSweepBucketRange(long bucketIdentifier);
+    Optional<SweepableBucketRange> getBucketRange(long bucketIdentifier);
 
     /**
      * Retrieves a list of buckets corresponding to the lowest buckets the sweep bucket store knows about, that are
-     * at least as high as the provided AtlasDB timestamp.
+     * at least as high as the provided AtlasDB timestamp. This list is guaranteed to be sorted in increasing bucket
+     * order.
      */
-    List<Long> getFirstLiveBuckets(long lowerBoundTimestamp);
+    List<Long> getFirstLiveBuckets(long lowerBoundTimestamp, int limit);
 
     /**
-     * Closes the currently open bucket at the provided timestamp, if it is greater than the start timestamp of the
-     * bucket. If it is not, is a no-op.
+     * Attempts to set progress for the provided bucket identifier to the provided range. May return false, if
+     * progress was not set to said range (e.g., because this would attempt to change a bucket that had already
+     * been closed, or re-open a bucket).
      */
-    void appendSweepBucketRange(long timestamp);
+    boolean trySetBucketRange(long bucketIdentifier, SweepableBucketRange range);
 
     /**
      * Deletes a sweep bucket from the sweep bucket store. The onus is on the user to ensure that this is a safe
-     * operation, and externally referenced state relating to the bucket in question has already been cleaned up.
+     * operation, and that externally referenced state relating to the bucket in question has already been cleaned up.
      */
-    void deleteSweepBucket(long bucketIdentifier);
+    void deleteBucket(long bucketIdentifier);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucket/SweepableBucketRange.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucket/SweepableBucketRange.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucket;
+
+import java.util.OptionalLong;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface SweepableBucketRange {
+    long start();
+
+    OptionalLong end();
+
+    default boolean isClosedRange() {
+        return end().isPresent();
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**: Sweep bucket store APIs aren't defined.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
SweepBucketStore APIs are defined.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
- Is this right?
- Is this implementable?
- It's intentional I haven't generated the schema classes yet, that I'll do in its own PR.
- This is based on top of `jkong/asts-atomica` because the deleteFromAtomicTable will likely be needed in the implementation of the sweep bucket store.

More seriously @mdaudali I think this should be sufficient to unblock your other work, though you should check this.

**Is documentation needed?**: No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
Not much of interest here, just APIs.

## Execution
Not much of interest here, just APIs. Nothing should change.

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Maybe, if the parallelism we want is so high that it's not really feasible to write the bucket names everywhere. I think it's pretty clear if we do run into that that we're in a bad spot though.

## Development Process
**Where should we start reviewing?**: SweepBucketStore

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
