### PR TITLE
[ASTS][Bucket Retriever] Debouncing bucket retrieval requests

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/CandidateSweepableBucketRetriever.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/CandidateSweepableBucketRetriever.java
@@ -18,14 +18,26 @@ package com.palantir.atlasdb.sweep.asts;
 
 import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
 import com.palantir.refreshable.Disposable;
-import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 // A push model - decouples asking for updates from the logic of debouncing requests.
 // Simplifies the coordinator, since it can just repeatedly _ask_ for updates whenever it thinks it's useful to do so
 // but we can rate limit it down.
 public interface CandidateSweepableBucketRetriever {
+    /**
+     * Requests an update to the set of buckets. This method will return immediately. There is no guarantee that
+     * a refresh will occur after the method is called, as this is simply a hint.
+     */
     void requestUpdate();
 
-    Disposable subscribeToChanges(Consumer<List<SweepableBucket>> task);
+    /**
+     * Registers a callback that will execute after each refresh, including whenever the set of buckets remains constant
+     * across refreshes.
+     * <p>
+     * Callbacks will be executed in the order they are registered. If a callback fails, subsequent callbacks will not
+     * be executed. If a callback is slow, it will block subsequent callbacks, and may result in subsequent refreshes
+     * being delayed.
+     */
+    Disposable subscribeToChanges(Consumer<Set<SweepableBucket>> task);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/CandidateSweepableBucketRetriever.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/CandidateSweepableBucketRetriever.java
@@ -35,9 +35,8 @@ public interface CandidateSweepableBucketRetriever {
      * Registers a callback that will execute after each refresh, including whenever the set of buckets remains constant
      * across refreshes.
      * <p>
-     * Callbacks will be executed in the order they are registered. If a callback fails, subsequent callbacks will not
-     * be executed. If a callback is slow, it will block subsequent callbacks, and may result in subsequent refreshes
-     * being delayed.
+     * There are no guarantees in the order that callbacks are executed. If any callback fails, it is not guaranteed
+     * that other callbacks will be executed. Moreover, slow callbacks may delay subsequent refreshes.
      */
     Disposable subscribeToChanges(Consumer<Set<SweepableBucket>> task);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetriever.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetriever.java
@@ -152,9 +152,7 @@ public final class DefaultCandidateSweepableBucketRetriever implements Candidate
     // in tests from zero to one millis (see the reason above coalescing supplier)
     private boolean isWithinDebounceWindow() {
         TimestampedSweepableBuckets existing = underlyingRefreshable.get();
-        // TODO: Check that this is inclusive still.
-        return existing != null
-                && existing.noRefreshBeforeInclusive().compareTo(Instant.now(clock)) >= 0; // >= 0 => isAfterOrEqual
+        return existing != null && !Instant.now(clock).isAfter(existing.noRefreshBeforeInclusive());
     }
 
     @Value.Immutable

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetriever.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetriever.java
@@ -1,0 +1,179 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
+import com.palantir.common.concurrent.CoalescingSupplier;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.refreshable.Disposable;
+import com.palantir.refreshable.Refreshable;
+import com.palantir.refreshable.SettableRefreshable;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.immutables.value.Value;
+
+// The overall design of this class is to effectively debounce requests to update the sweepable buckets.
+// By abstracting away the logic of how and when the buckets will be updated, downstream classes can call requestUpdate
+// without needing to do any bookkeeping of their own.
+public final class DefaultCandidateSweepableBucketRetriever implements CandidateSweepableBucketRetriever {
+    private final SafeLogger log = SafeLoggerFactory.get(DefaultCandidateSweepableBucketRetriever.class);
+    private final SweepableBucketRetriever sweepableBucketRetriever;
+    private final CoalescingSupplier<Void> supplier;
+    private final SettableRefreshable<TimestampedSweepableBuckets> underlyingRefreshable = Refreshable.create(null);
+
+    // This should be non-zero - see the comment above the coalescing supplier in the constructor.
+    // But we've not preconditioning on it since zero is acceptable for testing.
+    private final Refreshable<Duration> minimumDurationBetweenRefresh;
+    // We use a supplier for the jitter (rather than directly using ThreadLocalRandom) to make testing simpler.
+    private final Supplier<Long> jitterMillisGenerator;
+
+    // Passed in for testing
+    private final Clock clock;
+
+    // We use a jitter to prevent thundering herd issues at the macro scale. The underlying SweepableBucketRetriever
+    // should have jitter between requests, but we also want to have the batch requests be scheduled at different times
+    // across nodes.
+
+    // This is a field because we want to have a constant jitter for the duration of the refresh, rather than
+    // having each requested update use a different jitter and having an inconsistent debounce window.
+    private volatile long jitterMillis;
+
+    @VisibleForTesting
+    DefaultCandidateSweepableBucketRetriever(
+            SweepableBucketRetriever sweepableBucketRetriever,
+            Refreshable<Duration> minimumDurationBetweenRefresh,
+            Clock clock,
+            Supplier<Long> jitterMillisGenerator) {
+        this.sweepableBucketRetriever = sweepableBucketRetriever;
+        this.minimumDurationBetweenRefresh = minimumDurationBetweenRefresh;
+        this.clock = clock;
+
+        // Coalescing Supplier doesn't have the exact semantics we want - for requests that come in after the
+        // computation has started, they will trigger a new computation after the first one is complete. However,
+        // we would like to have the request to be a no-op if there's already one in progress (rather than trigger
+        // a new request).
+        // Despite that, it's simpler to use the battle tested coalescing supplier, and mitigate this with the already
+        // needed minimumDurationBetweenRefresh, since the next iteration will happen straight after
+        // which should still be within the debounce window.
+        this.supplier = new CoalescingSupplier<>(this::getNext);
+        this.jitterMillisGenerator = jitterMillisGenerator;
+        this.jitterMillis = jitterMillisGenerator.get();
+    }
+
+    public static CandidateSweepableBucketRetriever create(
+            SweepableBucketRetriever sweepableBucketRetriever,
+            Refreshable<Duration> debouncerDuration,
+            Refreshable<Duration> maxJitter,
+            Clock clock) {
+        return new DefaultCandidateSweepableBucketRetriever(sweepableBucketRetriever, debouncerDuration, clock, () -> {
+            // This is not full jitter. I chose to require a minimum delay, because we simply _do not need_ to refresh
+            // buckets that quickly, and the scans over the database aren't precisely free.
+            // This jitter only really matters for things calling requestUpdate frequently (as opposed to the background
+            // task, which should have its own jitter)
+            return ThreadLocalRandom.current().nextLong(0, maxJitter.get().toMillis());
+        });
+    }
+
+    @Override
+    public void requestUpdate() {
+        if (isWithinDebounceWindow()) {
+            return; // Quick escape hatch -  we check again in getNext but there's no point spinning up a task on
+            // an executor if we know it's going to fail.
+        }
+
+        supplier.getAsync();
+    }
+
+    @Override
+    public Disposable subscribeToChanges(Consumer<Set<SweepableBucket>> task) {
+        // The refreshable stores a Timestamped list, so that new updates trigger a subscription update, even if
+        // the list of sweepable buckets is the same across refreshes - refreshable would otherwise skip the subscriber
+        // update if the underlying value is equal.
+        return underlyingRefreshable.subscribe(value -> {
+            if (value != null) {
+                task.accept(value.sweepableBuckets());
+            }
+        });
+    }
+
+    // We have to return _something_ to get Coalescing supplier to be typed.
+    // We process and store the value within the context of the coalescing supplier, as we would otherwise set the
+    // refreshable value too late, and so it's possible to have another round before you update the refreshable
+    // This is especially important given that it's highly likely the coalescing supplier will immediately execute
+    // straight after the first one completes, given the semantics described at the top of this class.
+    private Void getNext() {
+        if (isWithinDebounceWindow()) {
+            return null;
+        }
+        try {
+            Set<SweepableBucket> sweepableBuckets = sweepableBucketRetriever.getSweepableBuckets();
+            // TODO(mdaudali): We may want to cap the number of buckets being logged, or simply log the number of
+            //  buckets once we actually ship this, to avoid destroying our logging infrastructure.
+            //  For now, the telemetry will be useful.
+            log.info("Retrieved sweepable buckets.", SafeArg.of("buckets", sweepableBuckets));
+            underlyingRefreshable.update(ImmutableTimestampedSweepableBuckets.builder()
+                    .sweepableBuckets(sweepableBuckets)
+                    .timestamp(Instant.now(clock))
+                    .build());
+
+            updateJitter();
+        } catch (Exception e) {
+            // It possibly indicates a bug because in the current implementation, it's expected that the underlying
+            // sweepable bucket retriever will fail silently on a given shard, rather than bubbling up the exception.
+            log.warn(
+                    "There was an error retrieving the latest sweep buckets. The next request to update the"
+                            + " sweepable buckets will retry the operation, but this likely indicates a bug.",
+                    e);
+        }
+        return null;
+    }
+
+    // Note: This window is inclusive (so you cannot issue a refresh at timestamp + duration + jitter exactly)
+    // There was no particular reason why this was chosen, but if you change it, you'll need to change min delay
+    // in tests from zero to one millis (see the reason above coalescing supplier)
+    private boolean isWithinDebounceWindow() {
+        TimestampedSweepableBuckets existing = underlyingRefreshable.get();
+        return existing != null
+                && existing.timestamp()
+                                .plus(minimumDurationBetweenRefresh.get())
+                                .plusMillis(jitterMillis)
+                                .compareTo(Instant.now(clock))
+                        >= 0; // >= 0 => isAfterOrEqual
+    }
+
+    private void updateJitter() {
+        jitterMillis = jitterMillisGenerator.get();
+        log.trace("Next refresh will have new jitter", SafeArg.of("jitter", jitterMillis));
+    }
+
+    @Value.Immutable
+    interface TimestampedSweepableBuckets {
+        @Value.Parameter
+        Set<SweepableBucket> sweepableBuckets();
+
+        @Value.Parameter
+        Instant timestamp();
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetrieverTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetrieverTest.java
@@ -286,7 +286,7 @@ class DefaultCandidateSweepableBucketRetrieverTest {
     }
 
     @Test
-    public void newMinimumDurationAppliesImmediately() {
+    public void newMinimumDurationAppliesAfterNextRefresh() {
         AtomicInteger numCallbacks = new AtomicInteger();
         CandidateSweepableBucketRetriever candidateSweepableBucketRetriever = candidateRetriever(WITH_BUCKETS);
 
@@ -304,7 +304,16 @@ class DefaultCandidateSweepableBucketRetrieverTest {
         tickTime(Duration.ofMillis(1)); // Inclusive wait.
         minimumDurationBetweenRefresh.update(Duration.ZERO);
         candidateSweepableBucketRetriever.requestUpdate();
+        // New update hasn't applied
+        tryWaitUntilAsserted(() -> assertThat(numCallbacks).hasValue(1));
+
+        tickTime(Duration.ofDays(1)); // The old minimum duration
+        candidateSweepableBucketRetriever.requestUpdate();
         tryWaitUntilAsserted(() -> assertThat(numCallbacks).hasValue(2));
+
+        tickTime(Duration.ofMillis(1)); // Now the new min duration is applied
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(numCallbacks).hasValue(3));
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetrieverTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetrieverTest.java
@@ -1,0 +1,367 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+
+import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.table.description.SweeperStrategy;
+import com.palantir.refreshable.Disposable;
+import com.palantir.refreshable.Refreshable;
+import com.palantir.refreshable.SettableRefreshable;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ThrowingRunnable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultCandidateSweepableBucketRetrieverTest {
+    private static final Set<SweepableBucket> BUCKETS = Set.of(
+            SweepableBucket.of(ShardAndStrategy.of(1, SweeperStrategy.CONSERVATIVE), 1),
+            SweepableBucket.of(ShardAndStrategy.of(2, SweeperStrategy.THOROUGH), 2));
+    private static final SweepableBucketRetriever WITH_BUCKETS = () -> BUCKETS;
+
+    private final SettableRefreshable<Duration> minimumDurationBetweenRefresh = Refreshable.create(Duration.ZERO);
+    private final SettableRefreshable<Long> jitter = Refreshable.create(0L);
+
+    private volatile Duration currentTime = Duration.ZERO;
+
+    @Mock
+    private Clock clock;
+
+    @BeforeEach
+    public void before() {
+        lenient().when(clock.instant()).thenAnswer(invocation -> Instant.ofEpochMilli(currentTime.toMillis()));
+    }
+
+    @Test
+    public void addingSubscriberBeforeRetrieverRunsDoesNotCallSubscriber() {
+        AtomicInteger counter = new AtomicInteger();
+        CandidateSweepableBucketRetriever candidateBucketRetriever = candidateRetriever(WITH_BUCKETS);
+        candidateBucketRetriever.subscribeToChanges(_ignored -> counter.incrementAndGet());
+
+        // It's possible for this to spuriously pass if the subscriber is called after the test checks the counter,
+        // as there's no other way to know when the task is complete. This issue does plague other tests that assert
+        // "nothing happening". The tryWaitUntilAsserted method adds a minor delay before checking, which should help
+        // catch a bad implementation early.
+        tryWaitUntilAsserted(() -> assertThat(counter.get()).isEqualTo(0));
+    }
+
+    @Test
+    public void firstCallRequestsNewBucketsAndUpdatesAllSubscribersInOrder() {
+        List<Integer> callbackTracker = new ArrayList<>();
+        CandidateSweepableBucketRetriever candidateBucketRetriever = candidateRetriever(WITH_BUCKETS);
+
+        candidateBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(() -> callbackTracker.add(1), BUCKETS));
+        candidateBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(() -> callbackTracker.add(2), BUCKETS));
+
+        candidateBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(callbackTracker).isEqualTo(List.of(1, 2)));
+    }
+
+    @Test
+    public void refreshingToTheSameBucketListStillUpdatesSubscribers() {
+        AtomicInteger counter = new AtomicInteger();
+        CandidateSweepableBucketRetriever candidateBucketRetriever = candidateRetriever(WITH_BUCKETS);
+
+        candidateBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(counter::incrementAndGet, BUCKETS));
+
+        candidateBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(1));
+
+        tickTime(Duration.ofMillis(1));
+        candidateBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(2));
+    }
+
+    @Test
+    public void failedRequestDoesNotUpdateSubscriber() {
+        AtomicInteger counter = new AtomicInteger();
+        CandidateSweepableBucketRetriever candidateSweepableBucketRetriever = candidateRetriever(() -> {
+            throw new RuntimeException("FAILED");
+        });
+
+        candidateSweepableBucketRetriever.subscribeToChanges(_ignored -> counter.incrementAndGet());
+        candidateSweepableBucketRetriever.requestUpdate();
+
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(0));
+    }
+
+    @Test
+    public void failedRequestDoesNotBlockSubsequentRequestFromStartingWithinDelay() {
+        AtomicInteger counter = new AtomicInteger();
+        AtomicBoolean shouldFail = new AtomicBoolean(true);
+
+        CandidateSweepableBucketRetriever candidateSweepableBucketRetriever = candidateRetriever(() -> {
+            if (shouldFail.get()) {
+                throw new RuntimeException("FAILED");
+            }
+            return BUCKETS;
+        });
+
+        minimumDurationBetweenRefresh.update(Duration.ofDays(1));
+        candidateSweepableBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(counter::incrementAndGet, BUCKETS));
+        candidateSweepableBucketRetriever.requestUpdate();
+
+        shouldFail.set(false);
+        // Despite the 1-day wait between refreshes - we should be able to refresh given the previous failure.
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(1));
+    }
+
+    @Test // Note, interestingly this also showed the bug on the callback coming after the coalescing supplier
+    public void subsequentRequestsWhileRetrievingBucketsDoNothing() throws InterruptedException {
+        AtomicInteger numCallbacks = new AtomicInteger();
+        AtomicInteger numRequests = new AtomicInteger();
+        CountDownLatch latch = new CountDownLatch(1);
+        CountDownLatch hasStarted = new CountDownLatch(1);
+
+        CandidateSweepableBucketRetriever candidateSweepableBucketRetriever = candidateRetriever(() -> {
+            hasStarted.countDown();
+            awaitLatch(latch);
+            numRequests.incrementAndGet();
+            return BUCKETS;
+        });
+        candidateSweepableBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(numCallbacks::incrementAndGet, BUCKETS));
+
+        candidateSweepableBucketRetriever.requestUpdate();
+        assertThat(hasStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+        candidateSweepableBucketRetriever.requestUpdate();
+
+        latch.countDown();
+        tryWaitUntilAsserted(() -> assertThat(numCallbacks).hasValue(1));
+        assertThat(numRequests).hasValue(1);
+    }
+
+    @Test
+    public void firstRequestAfterDebounceDurationPassesRetrievesBuckets() {
+        List<Integer> callbackTracker = new ArrayList<>();
+        AtomicReference<Set<SweepableBucket>> buckets = new AtomicReference<>(Set.of());
+        CandidateSweepableBucketRetriever candidateSweepableBucketRetriever = candidateRetriever(buckets::get);
+
+        minimumDurationBetweenRefresh.update(Duration.ofDays(1));
+        candidateSweepableBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(() -> callbackTracker.add(1), Set.of()));
+        candidateSweepableBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(() -> callbackTracker.add(2), BUCKETS));
+
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(callbackTracker).isEqualTo(List.of(1)));
+
+        tickTime(minimumDurationBetweenRefresh.get().plusMillis(1));
+        buckets.set(BUCKETS);
+
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(callbackTracker).isEqualTo(List.of(1, 2)));
+    }
+
+    @Test
+    public void subsequentRequestsAfterRetrievingBucketsBeforeDebounceDurationDoesNothing() {
+        AtomicInteger numCallbacks = new AtomicInteger();
+        AtomicInteger numRequests = new AtomicInteger();
+        CandidateSweepableBucketRetriever candidateSweepableBucketRetriever = candidateRetriever(() -> {
+            numRequests.incrementAndGet();
+            return BUCKETS;
+        });
+        candidateSweepableBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(numCallbacks::incrementAndGet, BUCKETS));
+
+        minimumDurationBetweenRefresh.update(Duration.ofDays(1));
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(numCallbacks).hasValue(1));
+
+        candidateSweepableBucketRetriever.requestUpdate();
+        candidateSweepableBucketRetriever.requestUpdate();
+
+        assertThat(numCallbacks).hasValue(1);
+        assertThat(numRequests).hasValue(1);
+    }
+
+    @Test
+    public void debounceDurationAddsJitter() {
+        AtomicInteger counter = new AtomicInteger();
+        minimumDurationBetweenRefresh.update(Duration.ofMillis(854));
+        jitter.update(786L);
+        CandidateSweepableBucketRetriever candidateSweepableBucketRetriever = candidateRetriever(WITH_BUCKETS);
+        candidateSweepableBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(counter::incrementAndGet, BUCKETS));
+
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(1));
+        tickTime(minimumDurationBetweenRefresh
+                .get()
+                .plusMillis(jitter.get())); // The wait is inclusive, so we still shouldn't trigger another run
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(1));
+
+        tickTime(Duration.ofMillis(1));
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(2));
+    }
+
+    @Test
+    public void jitterDoesNotChangeUntilSuccessfulRefresh() {
+        AtomicInteger counter = new AtomicInteger();
+        minimumDurationBetweenRefresh.update(Duration.ofMillis(100));
+        jitter.update(11L);
+
+        CandidateSweepableBucketRetriever candidateSweepableBucketRetriever = candidateRetriever(WITH_BUCKETS);
+        candidateSweepableBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(counter::incrementAndGet, BUCKETS));
+
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(1));
+
+        jitter.update(0L);
+        tickTime(
+                minimumDurationBetweenRefresh
+                        .get()); // If we were using the new jitter, this would cause us to have a successful update,
+        // but we're not.
+        candidateSweepableBucketRetriever.requestUpdate();
+
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(1));
+
+        tickTime(Duration.ofMillis(12L));
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(2));
+    }
+
+    @Test
+    public void debounceDurationJitterChangesAfterEachRefresh() {
+        AtomicInteger counter = new AtomicInteger();
+        minimumDurationBetweenRefresh.update(Duration.ofMillis(100));
+        jitter.update(11L);
+        CandidateSweepableBucketRetriever candidateSweepableBucketRetriever = candidateRetriever(WITH_BUCKETS);
+        candidateSweepableBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(counter::incrementAndGet, BUCKETS));
+
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(1));
+
+        tickTime(minimumDurationBetweenRefresh.get().plusMillis(jitter.get() + 1));
+        jitter.update(25L); // not used until after the refresh succeeds
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(2));
+
+        tickTime(minimumDurationBetweenRefresh.get().plusMillis(jitter.get() + 1));
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(3));
+    }
+
+    @Test
+    public void newMinimumDurationAppliesImmediately() {
+        AtomicInteger numCallbacks = new AtomicInteger();
+        CandidateSweepableBucketRetriever candidateSweepableBucketRetriever = candidateRetriever(WITH_BUCKETS);
+
+        minimumDurationBetweenRefresh.update(Duration.ofDays(1));
+        candidateSweepableBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(numCallbacks::incrementAndGet, BUCKETS));
+
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(numCallbacks).hasValue(1));
+
+        // This should no-op
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(numCallbacks).hasValue(1));
+
+        tickTime(Duration.ofMillis(1)); // Inclusive wait.
+        minimumDurationBetweenRefresh.update(Duration.ZERO);
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(numCallbacks).hasValue(2));
+    }
+
+    @Test
+    public void disposedCallbackNoLongerRuns() {
+        AtomicInteger counter = new AtomicInteger();
+        CandidateSweepableBucketRetriever candidateSweepableBucketRetriever = candidateRetriever(WITH_BUCKETS);
+
+        Disposable disposable = candidateSweepableBucketRetriever.subscribeToChanges(
+                runCallbackIfBucketsMatchExpected(counter::incrementAndGet, BUCKETS));
+        candidateSweepableBucketRetriever.subscribeToChanges(runCallbackIfBucketsMatchExpected(
+                () -> {
+                    counter.addAndGet(2);
+                },
+                BUCKETS));
+
+        candidateSweepableBucketRetriever.requestUpdate();
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(3));
+
+        tickTime(Duration.ofMillis(1));
+        disposable.dispose();
+        candidateSweepableBucketRetriever.requestUpdate();
+        // Incremented by 2, not 1 + 2.
+        tryWaitUntilAsserted(() -> assertThat(counter).hasValue(5));
+    }
+
+    private Consumer<Set<SweepableBucket>> runCallbackIfBucketsMatchExpected(
+            Runnable task, Set<SweepableBucket> expected) {
+        return buckets -> {
+            if (buckets.equals(expected)) {
+                task.run();
+            }
+        };
+    }
+
+    private void awaitLatch(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    // Necessary because the coalescing supplier runs things in an executor, so you have to deal with
+    // context switching delays
+    private void tryWaitUntilAsserted(ThrowingRunnable task) {
+        Awaitility.await()
+                .atMost(Duration.ofMillis(100))
+                .pollInterval(Duration.ofMillis(10))
+                .untilAsserted(task);
+    }
+
+    private CandidateSweepableBucketRetriever candidateRetriever(SweepableBucketRetriever retriever) {
+        return new DefaultCandidateSweepableBucketRetriever(retriever, minimumDurationBetweenRefresh, clock, jitter);
+    }
+
+    private synchronized void tickTime(Duration duration) {
+        currentTime = currentTime.plus(duration);
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**: There's no way to debounce requests to retrieve buckets. We want to be able to trigger a refresh from multiple sources (e.g., background task, or when all the current buckets are processed), without having both of those doing bookkeeping of their own (and anyway, unless they share state, their bookkeeping won't be aligned).

**After this PR**:
Implements a mechanism to debounce requests by decoupling requests from updates.
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: 
Have I got this right? Lots and lots of comments - still open for discussion on the jitter thread we were having (around full vs extra jitter for this in particular)

**Is documentation needed?**: No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
Coalescing supplier works
**What was existing testing like? What have you done to improve it?**:
Added a bunch more tests.
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
Relies on the correctness of coalescing supplier. Added comments around why updating the refreshable is done where it is.
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Debouncing works
**Has the safety of all log arguments been decided correctly?**:
I believe buckets are safe (just the identifiers!)
**Will this change significantly affect our spending on metrics or logs?**:
It'll emit large log lines, but we can rollback on how much we log after we've started deploying it.
**How would I tell that this PR does not work in production? (monitors, etc.)**:
When we ship it, either debouncing doesn't debounce, or we debounce too aggressively
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Turn off ASTS
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No - this is to help with scale!!!
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
See above
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
I don't think so - we may adjust the debounce time
## Development Process
**Where should we start reviewing?**:
DCSBR
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
It's mostly comments and tests!!
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
