### PR TITLE
Set target server type primary

### DIFF
--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
@@ -87,6 +87,7 @@ public abstract class PostgresConnectionConfig extends ConnectionConfig {
         props.setProperty("password", getDbPassword().unmasked());
 
         props.setProperty("tcpKeepAlive", "true");
+        props.setProperty("targetServerType", "primary");
         props.setProperty("socketTimeout", Integer.toString(getSocketTimeoutSeconds()));
 
         props.setProperty("connectTimeout", Integer.toString(getConnectionTimeoutSeconds()));

--- a/changelog/@unreleased/pr-7222.v2.yml
+++ b/changelog/@unreleased/pr-7222.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Set target server type primary
+  links:
+  - https://github.com/palantir/atlasdb/pull/7222


### PR DESCRIPTION
Per postgres [docs](https://jdbc.postgresql.org/documentation/use/), this will ensure the connection we recieve allows writes.