### PR TITLE
No expectations metrics unless on a debug log level

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ExpectationsMetricsReporter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ExpectationsMetricsReporter.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.transaction.impl;
+
+import com.palantir.atlasdb.transaction.api.expectations.ExpectationsData;
+import com.palantir.atlasdb.transaction.expectations.ExpectationsMetrics;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+
+/**
+ * This enum exists we don't have to enable full SnapshotTransaction debug logging to get expectations metrics.
+ * It is possible to nest inside SnapshotTransaction, but the class is already quite large.
+ */
+enum ExpectationsMetricsReporter {
+    INSTANCE;
+
+    private static final SafeLogger log = SafeLoggerFactory.get(ExpectationsMetricsReporter.class);
+
+    void reportExpectationsCollectedData(ExpectationsData expectationsData, ExpectationsMetrics metrics) {
+        if (log.isDebugEnabled()) {
+            reportExpectationsCollectedDataInternal(expectationsData, metrics);
+        }
+    }
+
+    private void reportExpectationsCollectedDataInternal(
+            ExpectationsData expectationsData, ExpectationsMetrics metrics) {
+        metrics.ageMillis().update(expectationsData.ageMillis());
+        metrics.bytesRead().update(expectationsData.readInfo().bytesRead());
+        metrics.kvsReads().update(expectationsData.readInfo().kvsCalls());
+
+        expectationsData
+                .readInfo()
+                .maximumBytesKvsCallInfo()
+                .ifPresent(kvsCallReadInfo ->
+                        metrics.mostKvsBytesReadInSingleCall().update(kvsCallReadInfo.bytesRead()));
+
+        metrics.cellCommitLocksRequested()
+                .update(expectationsData.commitLockInfo().cellCommitLocksRequested());
+        metrics.rowCommitLocksRequested()
+                .update(expectationsData.commitLockInfo().rowCommitLocksRequested());
+        metrics.changeMetadataBuffered()
+                .update(expectationsData.writeMetadataInfo().changeMetadataBuffered());
+        metrics.cellChangeMetadataSent()
+                .update(expectationsData.writeMetadataInfo().cellChangeMetadataSent());
+        metrics.rowChangeMetadataSent()
+                .update(expectationsData.writeMetadataInfo().rowChangeMetadataSent());
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -2706,26 +2706,7 @@ public class SnapshotTransaction extends AbstractTransaction
 
     @VisibleForTesting
     static void reportExpectationsCollectedData(ExpectationsData expectationsData, ExpectationsMetrics metrics) {
-        metrics.ageMillis().update(expectationsData.ageMillis());
-        metrics.bytesRead().update(expectationsData.readInfo().bytesRead());
-        metrics.kvsReads().update(expectationsData.readInfo().kvsCalls());
-
-        expectationsData
-                .readInfo()
-                .maximumBytesKvsCallInfo()
-                .ifPresent(kvsCallReadInfo ->
-                        metrics.mostKvsBytesReadInSingleCall().update(kvsCallReadInfo.bytesRead()));
-
-        metrics.cellCommitLocksRequested()
-                .update(expectationsData.commitLockInfo().cellCommitLocksRequested());
-        metrics.rowCommitLocksRequested()
-                .update(expectationsData.commitLockInfo().rowCommitLocksRequested());
-        metrics.changeMetadataBuffered()
-                .update(expectationsData.writeMetadataInfo().changeMetadataBuffered());
-        metrics.cellChangeMetadataSent()
-                .update(expectationsData.writeMetadataInfo().cellChangeMetadataSent());
-        metrics.rowChangeMetadataSent()
-                .update(expectationsData.writeMetadataInfo().rowChangeMetadataSent());
+        ExpectationsMetricsReporter.INSTANCE.reportExpectationsCollectedData(expectationsData, metrics);
     }
 
     private long getStartTimestamp() {

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -250,12 +250,7 @@ public class SnapshotTransactionManagerTest {
         TaggedMetricRegistry registry = snapshotTransactionManager.metricsManager.getTaggedRegistry();
         assertThat(registry.getMetrics().keySet().stream().map(MetricName::safeName))
                 .contains(SETUP_TASK_METRIC_NAME)
-                .contains(FINISH_TASK_METRIC_NAME)
-                .contains("expectations.bytesRead")
-                .contains("expectations.kvsReads")
-                .contains("expectations.ageMillis")
-                .contains("expectations.cellCommitLocksRequested")
-                .contains("expectations.rowCommitLocksRequested");
+                .contains(FINISH_TASK_METRIC_NAME);
         assertThat(registry.timer(MetricName.builder()
                                 .safeName(SETUP_TASK_METRIC_NAME)
                                 .build())


### PR DESCRIPTION
## General
**Before this PR**:
Expectations metrics (from the TEX work) contribute to the metric load of AtlasDB using service, without demonstrably being used or providing signal.
**After this PR**:
Move the reporting of expectations metrics under a debug flag.

**Priority**:
P2
**Concerns / possible downsides (what feedback would you like?)**:
I'm open to other ways of either:
- Deciding to report metrics or not: I used debug logging because otherwise for any metric we want to limit, we'd need a new config flag and that would be too much. Logging configs are supported in java services.
- Deciding under what logger to report these and whether to inline it in SnapshotTransaction. It is possible to either create a logger in ST with a string name to distinguish from ST, or use an inner class.

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A

**What was existing testing like? What have you done to improve it?**:
Internal testing

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Dev stack

**Has the safety of all log arguments been decided correctly?**:
N/A

**Will this change significantly affect our spending on metrics or logs?**:
Should lessen it

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Dev stack

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
