### PR TITLE
Do not track metrics for the non-sweepable sweep strategy

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/SweeperStrategy.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/SweeperStrategy.java
@@ -23,6 +23,10 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
+/**
+ * If sweep metrics are required for a particular strategy, the strategy should be included in
+ * {@link com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics.MetricsConfiguration#trackedSweeperStrategies()}.
+ */
 public enum SweeperStrategy implements Persistable {
     CONSERVATIVE {
         @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/metrics/TargetedSweepMetrics.java
@@ -417,7 +417,7 @@ public class TargetedSweepMetrics {
          */
         @Value.Default
         default Set<SweeperStrategy> trackedSweeperStrategies() {
-            return ImmutableSet.copyOf(SweeperStrategy.values());
+            return ImmutableSet.of(SweeperStrategy.CONSERVATIVE, SweeperStrategy.THOROUGH);
         }
 
         /**


### PR DESCRIPTION
## General
**Before this PR**:
We produce sweep metrics for the non sweepable sweep strategy.
**After this PR**:
Do not track metrics for the non-sweepable sweep strategy ==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P2
**Concerns / possible downsides (what feedback would you like?)**:
Is it fine to not have these metrics? The new sweep strategy was added in https://github.com/palantir/atlasdb/pull/6220. From reading the PR, it looks like this was added to guarantee writes to the queue in all cases (even with no sweep strategy). Thus, the metrics are likely not in use.

**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
N/A
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Dev stack
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
Should slightly decrease
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Dev stack
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
