### PR TITLE
Re-wire `InstrumentedCassandraClient` telemetry in c* pooling setup

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -183,6 +183,43 @@ acceptedBreaks:
     - code: "java.method.removed"
       old: "method void com.palantir.atlasdb.keyvalue.api.watch.NoOpLockWatchManager::removeTransactionStateFromCache(long)"
       justification: "Internal API"
+  "0.1150.0":
+    com.palantir.atlasdb:atlasdb-cassandra:
+    - code: "java.class.nowFinal"
+      old: "class com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService"
+      new: "class com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService"
+      justification: "Unused outside atlas"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void com.palantir.atlasdb.keyvalue.cassandra.CassandraClientFactory::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer, com.palantir.atlasdb.keyvalue.cassandra.CassandraClientFactory.CassandraClientConfig)"
+      new: "method void com.palantir.atlasdb.keyvalue.cassandra.CassandraClientFactory::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer, com.palantir.atlasdb.keyvalue.cassandra.CassandraClientFactory.CassandraClientConfig,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraClientInstrumentation)"
+      justification: "Unused outside atlas"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer, com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig,\
+        \ int, com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics)"
+      new: "method void com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer, com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig,\
+        \ int, com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraClientInstrumentation)"
+      justification: "Unused outside atlas"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void com.palantir.atlasdb.keyvalue.cassandra.InstrumentedCassandraClient::<init>(com.palantir.atlasdb.keyvalue.cassandra.CassandraClient,\
+        \ ===com.palantir.tritium.metrics.registry.TaggedMetricRegistry===)"
+      new: "parameter void com.palantir.atlasdb.keyvalue.cassandra.InstrumentedCassandraClient::<init>(com.palantir.atlasdb.keyvalue.cassandra.CassandraClient,\
+        \ ===com.palantir.atlasdb.keyvalue.cassandra.CassandraClientInstrumentation===)"
+      justification: "Unused outside atlas"
+    - code: "java.method.visibilityReduced"
+      old: "method void com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig, com.palantir.refreshable.Refreshable<com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig>,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.Blacklist, com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics)"
+      new: "method void com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraService::<init>(com.palantir.atlasdb.util.MetricsManager,\
+        \ com.palantir.atlasdb.cassandra.CassandraKeyValueServiceConfig, com.palantir.refreshable.Refreshable<com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig>,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.Blacklist, com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics,\
+        \ com.palantir.atlasdb.keyvalue.cassandra.CassandraClientInstrumentation)"
+      justification: "Unused outside atlas"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactory.java
@@ -78,15 +78,20 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
     private final SSLSocketFactory sslSocketFactory;
     private final TimedRunner timedRunner;
     private final TSocketFactory tSocketFactory;
+    private final CassandraClientInstrumentation cassandraClientInstrumentation;
 
     public CassandraClientFactory(
-            MetricsManager metricsManager, CassandraServer cassandraServer, CassandraClientConfig clientConfig) {
+            MetricsManager metricsManager,
+            CassandraServer cassandraServer,
+            CassandraClientConfig clientConfig,
+            CassandraClientInstrumentation cassandraClientInstrumentation) {
         this.metricsManager = metricsManager;
         this.cassandraServer = cassandraServer;
         this.clientConfig = clientConfig;
         this.sslSocketFactory = createSslSocketFactory(clientConfig.sslConfiguration());
         this.timedRunner = TimedRunner.create(clientConfig.timeoutOnConnectionClose());
         this.tSocketFactory = new InstrumentedTSocket.Factory(metricsManager);
+        this.cassandraClientInstrumentation = cassandraClientInstrumentation;
     }
 
     @Override
@@ -109,7 +114,7 @@ public class CassandraClientFactory extends BasePooledObjectFactory<CassandraCli
         client = AtlasDbMetrics.instrumentTimed(metricsManager.getRegistry(), CassandraClient.class, client);
         client = new ProfilingCassandraClient(client);
         client = new TracingCassandraClient(client);
-        client = new InstrumentedCassandraClient(client, metricsManager.getTaggedRegistry());
+        client = new InstrumentedCassandraClient(client, cassandraClientInstrumentation);
         client = QosCassandraClient.instrumentWithMetrics(client, metricsManager);
         return client;
     }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientInstrumentation.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientInstrumentation.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+public interface CassandraClientInstrumentation extends AutoCloseable {
+    void recordCellsWritten(String tableRef, long cellsWritten);
+
+    @Override
+    default void close() {}
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/UnfilteredCassandraClientInstrumentation.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/UnfilteredCassandraClientInstrumentation.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.logging.LoggingArgs;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+
+public final class UnfilteredCassandraClientInstrumentation implements CassandraClientInstrumentation {
+    private final TaggedMetricRegistry registry;
+
+    public UnfilteredCassandraClientInstrumentation(TaggedMetricRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public void recordCellsWritten(String tableRef, long cellsWritten) {
+        registry.counter(MetricName.builder()
+                        .safeName(MetricRegistry.name(CassandraClient.class, "cellsWritten"))
+                        .safeTags(ImmutableMap.of("tableRef", LoggingArgs.safeInternalTableNameOrPlaceholder(tableRef)))
+                        .build())
+                .inc(cellsWritten);
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -33,11 +33,13 @@ import com.palantir.atlasdb.cassandra.CassandraKeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.cassandra.CassandraServersConfigs.ThriftHostsExtractingVisitor;
 import com.palantir.atlasdb.keyvalue.cassandra.Blacklist;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClient;
+import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientInstrumentation;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraLogHelper;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraServerOrigin;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraUtils;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
+import com.palantir.atlasdb.keyvalue.cassandra.UnfilteredCassandraClientInstrumentation;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
@@ -79,7 +81,7 @@ import java.util.stream.Stream;
 import org.apache.cassandra.thrift.EndpointDetails;
 import org.apache.cassandra.thrift.TokenRange;
 
-public class CassandraService implements AutoCloseable {
+public final class CassandraService implements AutoCloseable {
     private static final SafeLogger log = SafeLoggerFactory.get(CassandraService.class);
     private static final Interner<ImmutableRangeMap<LightweightOppToken, ImmutableSet<CassandraServer>>>
             tokensInterner = Interners.newWeakInterner();
@@ -102,13 +104,30 @@ public class CassandraService implements AutoCloseable {
     private final Supplier<Map<String, String>> hostnameByIpSupplier;
 
     private final Random random = new Random();
+    private final CassandraClientInstrumentation cassandraClientInstrumentation;
 
-    public CassandraService(
+    public static CassandraService create(
             MetricsManager metricsManager,
             CassandraKeyValueServiceConfig config,
             Refreshable<CassandraKeyValueServiceRuntimeConfig> runtimeConfig,
             Blacklist blacklist,
             CassandraClientPoolMetrics poolMetrics) {
+        return new CassandraService(
+                metricsManager,
+                config,
+                runtimeConfig,
+                blacklist,
+                poolMetrics,
+                new UnfilteredCassandraClientInstrumentation(metricsManager.getTaggedRegistry()));
+    }
+
+    private CassandraService(
+            MetricsManager metricsManager,
+            CassandraKeyValueServiceConfig config,
+            Refreshable<CassandraKeyValueServiceRuntimeConfig> runtimeConfig,
+            Blacklist blacklist,
+            CassandraClientPoolMetrics poolMetrics,
+            CassandraClientInstrumentation cassandraClientInstrumentation) {
         this.metricsManager = metricsManager;
         this.config = config;
         this.runtimeConfig = runtimeConfig;
@@ -120,10 +139,13 @@ public class CassandraService implements AutoCloseable {
         Supplier<Map<String, String>> hostnamesByIpSupplier =
                 new HostnamesByIpSupplier(this::getAllNonBlacklistedHosts);
         this.hostnameByIpSupplier = Suppliers.memoizeWithExpiration(hostnamesByIpSupplier::get, 1, TimeUnit.MINUTES);
+        this.cassandraClientInstrumentation = cassandraClientInstrumentation;
     }
 
     @Override
-    public void close() {}
+    public void close() {
+        cassandraClientInstrumentation.close();
+    }
 
     public ImmutableMap<CassandraServer, CassandraServerOrigin> refreshTokenRangesAndGetServers() {
         // explicitly not using immutable builders to deduplicate nodes
@@ -487,7 +509,8 @@ public class CassandraService implements AutoCloseable {
 
     public CassandraClientPoolingContainer createPool(CassandraServer server) {
         int currentPoolNumber = cassandraHosts.indexOf(server) + 1;
-        return new CassandraClientPoolingContainer(metricsManager, server, config, currentPoolNumber, poolMetrics);
+        return new CassandraClientPoolingContainer(
+                metricsManager, server, config, currentPoolNumber, poolMetrics, cassandraClientInstrumentation);
     }
 
     public void addPool(CassandraServer server) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientFactoryTest.java
@@ -28,6 +28,7 @@ import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientFactory.CassandraC
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.exception.SafeSSLPeerUnverifiedException;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.cert.Certificate;
@@ -70,7 +71,8 @@ public class CassandraClientFactoryTest {
                     .enableEndpointVerification(false)
                     .keyspace("ks")
                     .timeoutOnConnectionClose(Duration.ZERO)
-                    .build());
+                    .build(),
+            new UnfilteredCassandraClientInstrumentation(new DefaultTaggedMetricRegistry()));
 
     private static final InetAddress DEFAULT_ADDRESS = mockInetAddress("1.2.3.4");
 

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -335,7 +335,7 @@ public class CassandraServiceTest {
                 config, runtimeConfig.map(CassandraKeyValueServiceRuntimeConfig::unresponsiveHostBackoffTimeSeconds));
 
         MetricsManager metricsManager = MetricsManagers.createForTests();
-        CassandraService service = new CassandraService(
+        CassandraService service = CassandraService.create(
                 metricsManager, config, runtimeConfig, blacklist, new CassandraClientPoolMetrics(metricsManager));
 
         service.cacheInitialHostsForCalculatingPoolNumber(servers);


### PR DESCRIPTION
## General
**Before this PR**:
`InstrumentedCassandraClient` telemetry was implemented correctly, but only because it updates a global singleton (i.e. the metric registry). If the metrics reporting is to be changed (e.g. top listing), it will require global processing at the level of a KVS (not a single client or a host client pool).
**After this PR**:
Re-wire `InstrumentedCassandraClient` telemetry through the c* pooling setup
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P1
**Concerns / possible downsides (what feedback would you like?)**:
I tried to implement this in a self-contained manner. Some bits will change in the next PR which implements `cellsWritten` top listing.
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No, see revapi motif
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
N/A
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Adjudication, this is largely no-op. Metrics should still flow as-is.
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Adjudication, this is largely no-op. Metrics should still flow as-is.
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback, possibly as well re-call.
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
