### PR TITLE
Asynchronously remove state from LockWatchValueScopingCacheImpl

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -156,6 +156,20 @@ acceptedBreaks:
     - code: "java.method.addedToInterface"
       new: "method <T> T com.palantir.atlasdb.transaction.service.TransactionStatus::accept(com.palantir.atlasdb.transaction.service.TransactionStatus.Visitor<T>)"
       justification: "purely addition - adding a visitor to transaction status"
+  "0.1134.0":
+    com.palantir.atlasdb:atlasdb-api:
+    - code: "java.method.abstractMethodAdded"
+      new: "method void com.palantir.atlasdb.keyvalue.api.watch.LockWatchManagerInternal::requestTransactionStateRemovalFromCache(long)"
+      justification: "Internal API"
+    - code: "java.method.addedToInterface"
+      new: "method void com.palantir.atlasdb.keyvalue.api.cache.LockWatchValueScopingCache::requestStateRemoved(long)"
+      justification: "Internal API"
+    - code: "java.method.removed"
+      old: "method void com.palantir.atlasdb.keyvalue.api.watch.LockWatchManagerInternal::removeTransactionStateFromCache(long)"
+      justification: "Internal API"
+    - code: "java.method.removed"
+      old: "method void com.palantir.atlasdb.keyvalue.api.watch.NoOpLockWatchManager::removeTransactionStateFromCache(long)"
+      justification: "Internal API"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCache.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/cache/LockWatchValueScopingCache.java
@@ -44,6 +44,13 @@ public interface LockWatchValueScopingCache extends LockWatchValueCache {
     void updateCacheWithCommitTimestampsInformation(Set<Long> startTimestamps);
 
     /**
+     * Guarantees that all relevant state for the given transaction will eventually be removed.
+     * See also {@link #ensureStateRemoved(long)}, though this does not have the eagerness guarantee of that method.
+     */
+    @Override
+    void requestStateRemoved(long startTs);
+
+    /**
      * Guarantees that all relevant state for the given transaction has been removed. If the state is already gone (by
      * calling {@link LockWatchValueScopingCache#onSuccessfulCommit(long)}, this will be a no-op. Failure to call this
      * method may result in memory leaks (particularly for aborting transactions).

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerInternal.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerInternal.java
@@ -22,7 +22,7 @@ import com.palantir.lock.watch.LockWatchCache;
 public abstract class LockWatchManagerInternal extends LockWatchManager implements AutoCloseable {
     public abstract LockWatchCache getCache();
 
-    public abstract void removeTransactionStateFromCache(long startTs);
+    public abstract void requestTransactionStateRemovalFromCache(long startTs);
 
     public abstract void onTransactionCommit(long startTs);
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/NoOpLockWatchManager.java
@@ -63,8 +63,8 @@ public final class NoOpLockWatchManager extends LockWatchManagerInternal {
     }
 
     @Override
-    public void removeTransactionStateFromCache(long startTs) {
-        cache.removeTransactionStateFromCache(startTs);
+    public void requestTransactionStateRemovalFromCache(long startTs) {
+        cache.requestTransactionStateRemovalFromCache(startTs);
     }
 
     @Override

--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
@@ -231,7 +231,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 .collect(Collectors.toList()));
 
         assertThat(ColumnFamilyDefinitions.isMatchingCf(
-                kvs.getCfForTable(NEVER_SEEN, getMetadata(), FOUR_DAYS_IN_SECONDS), clusterSideCf))
+                        kvs.getCfForTable(NEVER_SEEN, getMetadata(), FOUR_DAYS_IN_SECONDS), clusterSideCf))
                 .as("After serialization and deserialization to database, Cf metadata did not match.")
                 .isTrue();
     }
@@ -256,8 +256,10 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
     @SuppressWarnings("CompileTimeConstant")
     public void shouldNotErrorForTimestampTableWhenCreatingCassandraKvs() {
         verify(logger, atLeast(0))
-                .error(startsWith("Found a table {} that did not have persisted"),
-                        assertArg((Arg<String> arg) -> assertThat(arg.getValue()).doesNotContain("timestamp")));
+                .error(
+                        startsWith("Found a table {} that did not have persisted"),
+                        assertArg(
+                                (Arg<String> arg) -> assertThat(arg.getValue()).doesNotContain("timestamp")));
     }
 
     @Test
@@ -492,20 +494,20 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
 
         keyValueService.putUnlessExists(userTable, ImmutableMap.of(CELL, sad));
         assertThat(keyValueService
-                .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
-                .get(CELL)
-                .getContents())
+                        .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
+                        .get(CELL)
+                        .getContents())
                 .containsExactly(sad);
 
         keyValueService.setOnce(userTable, ImmutableMap.of(CELL, happy));
         assertThat(keyValueService
-                .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
-                .get(CELL)
-                .getContents())
+                        .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
+                        .get(CELL)
+                        .getContents())
                 .containsExactly(happy);
         assertThat(keyValueService
-                .getAllTimestamps(userTable, ImmutableSet.of(CELL), Long.MAX_VALUE)
-                .size())
+                        .getAllTimestamps(userTable, ImmutableSet.of(CELL), Long.MAX_VALUE)
+                        .size())
                 .isEqualTo(1);
         keyValueService.truncateTable(userTable);
     }
@@ -665,9 +667,9 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
         Cell nextTestCell = Cell.create(row(1), column(1));
 
         assertThatThrownBy(() -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                TEST_TABLE,
-                firstTestCell.getRowName(),
-                ImmutableMap.of(firstTestCell, val(0, 0), nextTestCell, val(0, 1)))))
+                        TEST_TABLE,
+                        firstTestCell.getRowName(),
+                        ImmutableMap.of(firstTestCell, val(0, 0), nextTestCell, val(0, 1)))))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Can only update cells in one row.");
     }
@@ -683,7 +685,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 1))));
 
         assertThatThrownBy(() -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))))
+                        TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))))
                 .isInstanceOf(MultiCheckAndSetException.class);
 
         MultiCheckAndSetException ex = catchThrowableOfType(
@@ -808,7 +810,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 .setComment("")
                 .setColumn_metadata(new ArrayList<>())
                 .setTriggers(new ArrayList<>())
-                .setKey_alias(new byte[]{0x6B, 0x65, 0x79})
+                .setKey_alias(new byte[] {0x6B, 0x65, 0x79})
                 .setComparator_type("org.apache.cassandra.db.marshal.CompositeType"
                         + "(org.apache.cassandra.db.marshal.BytesType,org.apache.cassandra.db.marshal.LongType)")
                 .setCompaction_strategy_options(new HashMap<>())

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImpl.java
@@ -126,6 +126,7 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
     public void close() {
         refreshTask.cancel(false);
         executorService.shutdown();
+        valueScopingCache.close();
     }
 
     @Override
@@ -147,8 +148,8 @@ public final class LockWatchManagerImpl extends LockWatchManagerInternal {
     }
 
     @Override
-    public void removeTransactionStateFromCache(long startTs) {
-        lockWatchCache.removeTransactionStateFromCache(startTs);
+    public void requestTransactionStateRemovalFromCache(long startTs) {
+        lockWatchCache.requestTransactionStateRemovalFromCache(startTs);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -236,7 +236,7 @@ import java.util.stream.Collectors;
             openTransactionCounter.inc(transactions.size());
             return transactions;
         } catch (Throwable t) {
-            responses.forEach(response -> lockWatchManager.removeTransactionStateFromCache(
+            responses.forEach(response -> lockWatchManager.requestTransactionStateRemovalFromCache(
                     response.startTimestampAndPartition().timestamp()));
             timelockService.tryUnlock(responses.stream()
                     .map(response -> response.immutableTimestamp().getLock())
@@ -279,7 +279,7 @@ import java.util.stream.Collectors;
             try {
                 result = runTaskThrowOnConflictWithCallback(wrappedTask, tx, callback);
             } finally {
-                lockWatchManager.removeTransactionStateFromCache(getTimestamp());
+                lockWatchManager.requestTransactionStateRemovalFromCache(getTimestamp());
                 postTaskContext = postTaskTimer.time();
                 timelockService.tryUnlock(ImmutableSet.of(immutableTsLock));
                 openTransactionCounter.dec();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImplTest.java
@@ -131,4 +131,10 @@ public final class LockWatchManagerImplTest {
         verify(valueScopingCache).getTransactionScopedCache(1L);
         verifyNoMoreInteractions(lockWatchEventCache);
     }
+
+    @Test
+    public void closePassesThroughCloseToValueScopingCache() {
+        manager.close();
+        verify(valueScopingCache).close();
+    }
 }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImplTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/keyvalue/api/watch/LockWatchManagerImplTest.java
@@ -120,9 +120,9 @@ public final class LockWatchManagerImplTest {
 
     @Test
     public void removeTransactionStateTest() {
-        manager.removeTransactionStateFromCache(1L);
+        manager.requestTransactionStateRemovalFromCache(1L);
         verify(lockWatchEventCache).removeTransactionStateFromCache(1L);
-        verify(valueScopingCache).ensureStateRemoved(1L);
+        verify(valueScopingCache).requestStateRemoved(1L);
     }
 
     @Test

--- a/changelog/@unreleased/pr-7243.v2.yml
+++ b/changelog/@unreleased/pr-7243.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Asynchronously remove state from LockWatchValueScopingCacheImpl
+  links:
+  - https://github.com/palantir/atlasdb/pull/7243

--- a/lock-api/src/main/java/com/palantir/lock/client/TransactionStarterHelper.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TransactionStarterHelper.java
@@ -159,6 +159,6 @@ final class TransactionStarterHelper {
         responses.stream()
                 .map(StartIdentifiedAtlasDbTransactionResponse::startTimestampAndPartition)
                 .map(TimestampAndPartition::timestamp)
-                .forEach(cache::removeTransactionStateFromCache);
+                .forEach(cache::requestTransactionStateRemovalFromCache);
     }
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCache.java
@@ -24,7 +24,7 @@ public interface LockWatchCache {
 
     void processCommitTimestampsUpdate(Collection<TransactionUpdate> transactionUpdates, LockWatchStateUpdate update);
 
-    void removeTransactionStateFromCache(long startTs);
+    void requestTransactionStateRemovalFromCache(long startTs);
 
     void onTransactionCommit(long startTs);
 

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCacheImpl.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchCacheImpl.java
@@ -48,9 +48,9 @@ public final class LockWatchCacheImpl implements LockWatchCache {
     }
 
     @Override
-    public void removeTransactionStateFromCache(long startTs) {
+    public void requestTransactionStateRemovalFromCache(long startTs) {
         eventCache.removeTransactionStateFromCache(startTs);
-        valueCache.ensureStateRemoved(startTs);
+        valueCache.requestStateRemoved(startTs);
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/watch/LockWatchValueCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/LockWatchValueCache.java
@@ -18,14 +18,20 @@ package com.palantir.lock.watch;
 
 import java.util.Set;
 
-public interface LockWatchValueCache {
+public interface LockWatchValueCache extends AutoCloseable {
     void processStartTransactions(Set<Long> startTimestamps);
 
     void updateCacheWithCommitTimestampsInformation(Set<Long> startTimestamps);
+
+    void requestStateRemoved(long startTimestamp);
 
     void ensureStateRemoved(long startTimestamp);
 
     void onSuccessfulCommit(long startTimestamp);
 
     void logState();
+
+    // Checked exceptions not allowed.
+    @Override
+    void close();
 }

--- a/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchValueCache.java
+++ b/lock-api/src/main/java/com/palantir/lock/watch/NoOpLockWatchValueCache.java
@@ -34,6 +34,9 @@ public class NoOpLockWatchValueCache implements LockWatchValueCache {
     public void updateCacheWithCommitTimestampsInformation(Set<Long> startTimestamps) {}
 
     @Override
+    public void requestStateRemoved(long startTimestamp) {}
+
+    @Override
     public void ensureStateRemoved(long startTimestamp) {}
 
     @Override
@@ -43,4 +46,7 @@ public class NoOpLockWatchValueCache implements LockWatchValueCache {
     public void logState() {
         log.info("Logging state from NoOpLockWatchValueCache");
     }
+
+    @Override
+    public void close() {}
 }

--- a/lock-api/src/test/java/com/palantir/lock/client/MultiClientTransactionStarterTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/MultiClientTransactionStarterTest.java
@@ -145,7 +145,7 @@ public class MultiClientTransactionStarterTest {
          * server. Concretely, the queue here contains 25 demands for a response. The first one succeeds, but the
          * next four fail (and each batch size is five), and thus we get four calls to clean up.
          */
-        verify(NAMESPACE_CACHE_MAP.get(namespace), times(4)).removeTransactionStateFromCache(anyLong());
+        verify(NAMESPACE_CACHE_MAP.get(namespace), times(4)).requestTransactionStateRemovalFromCache(anyLong());
     }
 
     @Test
@@ -177,10 +177,10 @@ public class MultiClientTransactionStarterTest {
         verify(LOCK_CLEANUP_SERVICE_MAP.get(alpha), never()).unlock(any());
         verify(LOCK_CLEANUP_SERVICE_MAP.get(beta)).refreshLockLeases(any());
         verify(LOCK_CLEANUP_SERVICE_MAP.get(beta)).unlock(any());
-        verify(NAMESPACE_CACHE_MAP.get(alpha), never()).removeTransactionStateFromCache(anyLong());
+        verify(NAMESPACE_CACHE_MAP.get(alpha), never()).requestTransactionStateRemovalFromCache(anyLong());
 
         // The size of each batch is 5 here, and thus for a single batch we need to clean up five times
-        verify(NAMESPACE_CACHE_MAP.get(beta), times(5)).removeTransactionStateFromCache(anyLong());
+        verify(NAMESPACE_CACHE_MAP.get(beta), times(5)).requestTransactionStateRemovalFromCache(anyLong());
     }
 
     @Test
@@ -213,7 +213,7 @@ public class MultiClientTransactionStarterTest {
                 (ArgumentCaptor<Set<LockToken>>) ArgumentCaptor.forClass((Class) Set.class);
         verify(LOCK_CLEANUP_SERVICE_MAP.get(omega)).refreshLockLeases(refreshArgumentCaptor.capture());
         verify(LOCK_CLEANUP_SERVICE_MAP.get(omega)).unlock(eq(Collections.emptySet()));
-        verify(NAMESPACE_CACHE_MAP.get(omega)).removeTransactionStateFromCache(anyLong());
+        verify(NAMESPACE_CACHE_MAP.get(omega)).requestTransactionStateRemovalFromCache(anyLong());
         Set<LockToken> refreshedTokens = refreshArgumentCaptor.getValue();
 
         LockToken tokenShare = Futures.getUnchecked(requestForOmega.result())

--- a/lock-api/src/test/java/com/palantir/lock/watch/LockWatchCacheImplTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/LockWatchCacheImplTest.java
@@ -63,6 +63,6 @@ public class LockWatchCacheImplTest {
     public void removeTest() {
         cache.requestTransactionStateRemovalFromCache(1L);
         verify(eventCache).removeTransactionStateFromCache(1L);
-        verify(valueCache).ensureStateRemoved(1L);
+        verify(valueCache).requestStateRemoved(1L);
     }
 }

--- a/lock-api/src/test/java/com/palantir/lock/watch/LockWatchCacheImplTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/watch/LockWatchCacheImplTest.java
@@ -61,7 +61,7 @@ public class LockWatchCacheImplTest {
 
     @Test
     public void removeTest() {
-        cache.removeTransactionStateFromCache(1L);
+        cache.requestTransactionStateRemovalFromCache(1L);
         verify(eventCache).removeTransactionStateFromCache(1L);
         verify(valueCache).ensureStateRemoved(1L);
     }


### PR DESCRIPTION
## General
**Before this PR**: @jkozlowski noticed in a JFR in some internal testing work that there was extremely high contention on the LockWatchValueScopingCacheImpl, specifically in terms of blocking on starting transactions and getting commit timestamps. The amount of time spent waiting for the task to complete that _wasn't_ part of the remote call to timelock was very long.

I think this problem is known - @schlosna has mentioned this before, and I've been vaguely aware of this class as a synchronization point, though not the extent to which it degrades performance when users are trying to start a lot of transactions.

For what it's worth, this problem was worse on the internal test stack than what I would expect in production, but there's still likely to be some upside here.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
Contention on the LockWatchValueScopingCacheImpl should be decreased, as cleanup from old transactions now takes place asynchronously rather than synchronously. This should manifest as increased performance and less blocking on startTransactions and getCommitTimestamps.

LockWatchValueScopingCacheImpl works by updating two stores, the `SnapshotStore` and `CacheStore`. The former stores snapshots of the cache taken at various points in time (lock watch sequence numbers), because these snapshots might still be used by old transactions. The latter is used to keep track of caches from transactions, which might flush updates to a global cache if they successfully read things at various points in time (allowing for updates that might have taken place following their lock watch sequence numbers).

Currently, we eagerly remove a given transaction's record in these maps when transactions complete (whether successfully or otherwise). However, I claim this is not necessary.

First consider that within LockWatchValueScopingCacheImpl,
- for the snapshot store, outside of `logState()` which is a debugging endpoint and `reset()` which is used when clearing the cache, all other calls access elements for a specific sequence. 
- for the value store, outside of `reset()`, all other calls access elements for a specific timestamp.

Now, consider that for a given timestamp, calls to the get methods `getTransactionScopedCache` or `getReadOnlyTransactionScopedCacheForCommit` happen when a transaction is either live (for the former, this is `SnapshotTransaction#getCache`), or during serializable conflict checking (the latter). Also consider that, previously, `ensureStateRemoved` was either called from `onSuccessfulCommit`, which is itself strictly after a transaction successfully committed (see `SnapshotTransactionManager:231`), or was called from `LockWatchCacheImpl#removeTransactionStateFromCache`. Following this upwards, we see this called in `TransactionStarterHelper::cleanUpCaches`, which is called only by `BatchingIdentifiedAtlasDbTransactionStarter` and `MultiClientTransactionStarter` on a transaction that failed to start. In both of these cases, we know that there will not be any further calls to either of the get methods for a transaction with the relevant start timestamp. 

Thus, I claim that this will not affect correctness of the cache, and removing these old entries asynchronously (as long as they are eventually removed) is safe.

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
- The main thing here is making sure it's correct and safe to do this. I've put forth some more detailed analysis below, but this needs a check.

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: There are some changes to Lock Watch classes, but I don't believe this causes any API breaks.

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing in particular

**What was existing testing like? What have you done to improve it?**: Existing testing covers that basic workflows are not broken. I'd love to use Antithesis here, but we don't have the resources right now.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: See analysis at top of document.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: All locking that takes place is block-scoped with `synchronized`.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: a JFR

**Has the safety of all log arguments been decided correctly?**: I think so? The safe loggable purpose is a compile time constant, and I didn't use Args elsewhere.

**Will this change significantly affect our spending on metrics or logs?**: We are adding one new autobatcher, but no.

**How would I tell that this PR does not work in production? (monitors, etc.)**: performance is unchanged / traces still show large gaps between the RPC to timelock completing and the autobatcher task completing itself.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**: N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No, unless it's wrong (but see correctness section)

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: There's a TODO for how to improve the algorithm further, but this is quite unlikely to be a bottleneck.

## Development Process
**Where should we start reviewing?**: the Correctness section.

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
