### PR TITLE
Define background updating top list counter

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TopListFilteredCounter.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TopListFilteredCounter.java
@@ -65,6 +65,7 @@ final class TopListFilteredCounter<T> {
             TaggedMetricRegistry registry,
             ScheduledExecutorService executor) {
         // the tag comparator is used to provide a stable ordering of tags when they have the same count
+        // this makes reporting consistent and avoids unnecessary churn across service nodes
         Comparator<Entry<T, Long>> entryComparator =
                 Entry.<T, Long>comparingByValue(Comparator.reverseOrder()).thenComparing(Entry::getKey, tagComparator);
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TopListFilteredCounter.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TopListFilteredCounter.java
@@ -1,0 +1,123 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.codahale.metrics.Counter;
+import com.google.common.collect.Sets;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import one.util.streamex.EntryStream;
+
+final class TopListFilteredCounter<T> {
+    private static final SafeLogger log = SafeLoggerFactory.get(TopListFilteredCounter.class);
+
+    private final int maxSize;
+    private final TaggedMetricRegistry registry;
+    private final Function<T, MetricName> tagToMetricName;
+
+    private final Map<T, Counter> counters = new ConcurrentHashMap<>();
+    private final Set<T> reportedTags = ConcurrentHashMap.newKeySet();
+
+    private TopListFilteredCounter(
+            int maxSize, TaggedMetricRegistry registry, Function<T, MetricName> tagToMetricName) {
+        this.maxSize = maxSize;
+        this.registry = registry;
+        this.tagToMetricName = tagToMetricName;
+    }
+
+    static <T> TopListFilteredCounter<T> create(
+            int maxSize,
+            Duration initialDelay,
+            Duration resetInterval,
+            Function<T, MetricName> tagToMetricName,
+            TaggedMetricRegistry registry,
+            ScheduledExecutorService executor) {
+        TopListFilteredCounter<T> counter = new TopListFilteredCounter<>(maxSize, registry, tagToMetricName);
+        executor.scheduleAtFixedRate(
+                counter::resilientUpdateMetricsReporting,
+                initialDelay.toNanos(),
+                resetInterval.toNanos(),
+                TimeUnit.NANOSECONDS);
+        return counter;
+    }
+
+    void inc(T tag, long count) {
+        Counter counter = counters.computeIfAbsent(tag, unused -> new Counter());
+        counter.inc(count);
+    }
+
+    private void resilientUpdateMetricsReporting() {
+        try {
+            updateMetricsReporting();
+        } catch (RuntimeException e) {
+            log.error("Failed to update top listed counter metric", e);
+        }
+    }
+
+    private void updateMetricsReporting() {
+        Set<T> nextBatchOfTagsToReport = computeTopListTags();
+
+        deregisterTagsForMetricsProduction(Sets.difference(reportedTags, nextBatchOfTagsToReport));
+        registerTagsForMetricsProduction(Sets.difference(nextBatchOfTagsToReport, reportedTags));
+
+        reportedTags.clear();
+        reportedTags.addAll(nextBatchOfTagsToReport);
+    }
+
+    private void registerTagsForMetricsProduction(Set<T> tags) {
+        tags.forEach(this::registerTag);
+    }
+
+    private void deregisterTagsForMetricsProduction(Set<T> tags) {
+        tags.forEach(this::deregisterTag);
+    }
+
+    private void registerTag(T tag) {
+        MetricName metricName = tagToMetricName.apply(tag);
+        Counter counter = counters.get(tag);
+        // registers the counter only if no other counter is currently tracked for this metric name
+        registry.counter(metricName, () -> counter);
+    }
+
+    private void deregisterTag(T tag) {
+        MetricName metricName = tagToMetricName.apply(tag);
+        registry.remove(metricName);
+    }
+
+    private Set<T> computeTopListTags() {
+        Map<T, Long> counterSnapshots =
+                EntryStream.of(counters).mapValues(Counter::getCount).toMap();
+
+        return counterSnapshots.entrySet().stream()
+                .sorted(Entry.comparingByValue(Comparator.reverseOrder()))
+                .limit(maxSize)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TopListFilteredCounterTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TopListFilteredCounterTest.java
@@ -1,0 +1,163 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Metric;
+import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
+import com.palantir.tritium.metrics.registry.MetricName;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import one.util.streamex.EntryStream;
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.junit.jupiter.api.Test;
+
+public final class TopListFilteredCounterTest {
+    private static final Duration INITIAL_DELAY = Duration.ofMillis(10);
+    private static final Duration RESET_INTERVAL = Duration.ofMillis(100);
+
+    private static final String TAG_1 = "tag1";
+    private static final String TAG_2 = "tag2";
+    private static final String TAG_3 = "tag3";
+    private static final String TAG_4 = "tag4";
+
+    private static final MetricName METRIC_NAME_1 = createMetricNameForTag(TAG_1);
+    private static final MetricName METRIC_NAME_2 = createMetricNameForTag(TAG_2);
+    private static final MetricName METRIC_NAME_3 = createMetricNameForTag(TAG_3);
+    private static final MetricName METRIC_NAME_4 = createMetricNameForTag(TAG_4);
+
+    private final DeterministicScheduler scheduler = new DeterministicScheduler();
+    private final TaggedMetricRegistry registry = new DefaultTaggedMetricRegistry();
+
+    @Test
+    public void nothingIsReportedBeforeInitialDelay() {
+        TopListFilteredCounter<String> counter =
+                createCounterWithMaxSizeTwo(TopListFilteredCounterTest::createMetricNameForTag);
+
+        counter.inc(TAG_1, 1);
+        counter.inc(TAG_2, 2);
+
+        tick(INITIAL_DELAY.minusMillis(1));
+        assertThat(registry.getMetrics()).isEmpty();
+    }
+
+    @Test
+    public void topMetricsAreReportedAfterInitialDelay() {
+        TopListFilteredCounter<String> counter =
+                createCounterWithMaxSizeTwo(TopListFilteredCounterTest::createMetricNameForTag);
+
+        counter.inc(TAG_1, 5);
+        counter.inc(TAG_2, 2);
+        counter.inc(TAG_3, 3);
+        counter.inc(TAG_4, 0);
+        tick(INITIAL_DELAY);
+
+        assertThatAllMetricAreCountersAndHaveValues(METRIC_NAME_1, 5, METRIC_NAME_3, 3);
+    }
+
+    @Test
+    public void topMetricsAreUpdatedPeriodicallyPickingTheMaximumValuesUpToMaxSizeCount() {
+        TopListFilteredCounter<String> counter =
+                createCounterWithMaxSizeTwo(TopListFilteredCounterTest::createMetricNameForTag);
+
+        counter.inc(TAG_1, 5);
+        counter.inc(TAG_2, 1);
+        counter.inc(TAG_3, 3);
+        counter.inc(TAG_4, 0);
+        tick(INITIAL_DELAY);
+        counter.inc(TAG_1, 2);
+        counter.inc(TAG_4, 10);
+        tick(RESET_INTERVAL);
+        assertThatAllMetricAreCountersAndHaveValues(METRIC_NAME_1, 7, METRIC_NAME_4, 10);
+
+        counter.inc(TAG_3, 5);
+        tick(RESET_INTERVAL.minusMillis(1));
+        // no updates until the full period has passed
+        assertThatAllMetricAreCountersAndHaveValues(METRIC_NAME_1, 7, METRIC_NAME_4, 10);
+        tick(Duration.ofMillis(1));
+        assertThatAllMetricAreCountersAndHaveValues(METRIC_NAME_3, 8, METRIC_NAME_4, 10);
+    }
+
+    @Test
+    public void topMetricsUpdatingIsResilientToTransientException() {
+        TopListFilteredCounter<String> counter =
+                createCounterWithMaxSizeTwo(new ThrowOnFirstInvocationMetricNameCreator());
+
+        counter.inc(TAG_1, 5);
+        counter.inc(TAG_3, 1);
+        tick(INITIAL_DELAY);
+        counter.inc(TAG_2, 2);
+        tick(RESET_INTERVAL);
+
+        assertThatAllMetricAreCountersAndHaveValues(METRIC_NAME_1, 5, METRIC_NAME_2, 2);
+    }
+
+    private void assertThatAllMetricAreCountersAndHaveValues(
+            MetricName metric1, long value1, MetricName metric2, long value2) {
+        Map<MetricName, Metric> metrics = registry.getMetrics();
+        assertThatAllMetricsAreCounters(metrics);
+        assertThat(castAllMetricsToCounters(metrics))
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        metric1, value1,
+                        metric2, value2));
+    }
+
+    private TopListFilteredCounter<String> createCounterWithMaxSizeTwo(
+            Function<String, MetricName> tagToMetricNameFunction) {
+        return TopListFilteredCounter.create(
+                2, INITIAL_DELAY, RESET_INTERVAL, tagToMetricNameFunction, registry, scheduler);
+    }
+
+    private void tick(Duration duration) {
+        // it's important to use millisecond and nothing more granular
+        // as the scheduler uses that unit for internal bookkeeping
+        scheduler.tick(duration.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    private static void assertThatAllMetricsAreCounters(Map<MetricName, Metric> metrics) {
+        assertThat(metrics).allSatisfy((unused, metric) -> assertThat(metric).isInstanceOf(Counter.class));
+    }
+
+    private static Map<MetricName, Long> castAllMetricsToCounters(Map<MetricName, Metric> metrics) {
+        return EntryStream.of(metrics)
+                .mapValues(Counter.class::cast)
+                .mapValues(Counter::getCount)
+                .toMap();
+    }
+
+    private static MetricName createMetricNameForTag(String tag) {
+        return MetricName.builder().safeName("metric").putSafeTags("tag", tag).build();
+    }
+
+    private static final class ThrowOnFirstInvocationMetricNameCreator implements Function<String, MetricName> {
+        private final AtomicBoolean hasRan = new AtomicBoolean(false);
+
+        @Override
+        public MetricName apply(String s) {
+            if (hasRan.compareAndSet(false, true)) {
+                throw new RuntimeException("Weird stubbed first time failure");
+            }
+            return createMetricNameForTag(s);
+        }
+    }
+}

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TopListFilteredCounterTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/TopListFilteredCounterTest.java
@@ -24,6 +24,7 @@ import com.palantir.tritium.metrics.registry.DefaultTaggedMetricRegistry;
 import com.palantir.tritium.metrics.registry.MetricName;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.time.Duration;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -125,7 +126,13 @@ public final class TopListFilteredCounterTest {
     private TopListFilteredCounter<String> createCounterWithMaxSizeTwo(
             Function<String, MetricName> tagToMetricNameFunction) {
         return TopListFilteredCounter.create(
-                2, INITIAL_DELAY, RESET_INTERVAL, tagToMetricNameFunction, registry, scheduler);
+                2,
+                INITIAL_DELAY,
+                RESET_INTERVAL,
+                tagToMetricNameFunction,
+                Comparator.naturalOrder(),
+                registry,
+                scheduler);
     }
 
     private void tick(Duration duration) {


### PR DESCRIPTION
## General
**Before this PR**:
No way to top list metrics
**After this PR**:
Add top list counter class which dynamically registers / unregisters metrics using a background executor
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P1
**Concerns / possible downsides (what feedback would you like?)**:
We discussed a number of these offline. It would be ideal not to have to use a background executor. However, this implies defining or re-using some concurrency primitive(s) to enforce "period reactive task" semantics. This could either be using things like `memoizeWithExpiration` (though, this will have threads wait when they race the update, which only happens around the window/reset interval multiples), or constructing something (semaphore + rate limiter). I found this to be simpler for our purposes, we only pay an executor with 1 thread.
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
N/A
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
N/A
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
Added tests
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
Using
- A concurrent map for counters. It provides visibility and avoids concurrent update exceptions. This is for metrics so we do not mind the fact that other parts of the map may be modified concurrently - snapshots may not necessarily be consistent (we only care that we get up to MAX_SIZE counter names).
- A concurrent set only for visibility purposes. These are modified to by an executor which is meant to be a single thread executor.
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
No-op
**Has the safety of all log arguments been decided correctly?**:
Yes
**Will this change significantly affect our spending on metrics or logs?**:
Less load on observability infra when this is wired
**How would I tell that this PR does not work in production? (monitors, etc.)**:
No-op
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
