### PR TITLE
Wire top listed cellsWritten metric

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientInstrumentationUtils.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientInstrumentationUtils.java
@@ -16,18 +16,17 @@
 
 package com.palantir.atlasdb.keyvalue.cassandra;
 
-import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.tritium.metrics.registry.MetricName;
 
-public final class UnfilteredCassandraClientInstrumentation implements CassandraClientInstrumentation {
-    private final TaggedMetricRegistry registry;
+final class CassandraClientInstrumentationUtils {
+    private CassandraClientInstrumentationUtils() {}
 
-    public UnfilteredCassandraClientInstrumentation(TaggedMetricRegistry registry) {
-        this.registry = registry;
-    }
-
-    @Override
-    public void recordCellsWritten(String tableRef, long cellsWritten) {
-        registry.counter(CassandraClientInstrumentationUtils.createCellsWrittenMetricNameForTableTag(tableRef))
-                .inc(cellsWritten);
+    static MetricName createCellsWrittenMetricNameForTableTag(String tableTag) {
+        return MetricName.builder()
+                .safeName(MetricRegistry.name(CassandraClient.class, "cellsWritten"))
+                .safeTags(ImmutableMap.of("tableRef", tableTag))
+                .build();
     }
 }

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -434,9 +434,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
         Preconditions.checkState(
                 !getCurrentPools().isEmpty() || serversToAdd.isEmpty(),
                 "No servers were successfully added to the pool. This means we could not come to a consensus on"
-                        + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
-                        + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
-                        + " configured AtlasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
+                    + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
+                    + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
+                    + " configured AtlasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
                 SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd.keySet())));
 
         logRefreshedHosts(validatedServersToAdd, serversToShutdown, absentServers);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolImpl.java
@@ -142,7 +142,8 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
                 cassandraClientPoolMetrics,
                 cassandraTopologyValidator,
                 absentHostTracker,
-                CassandraService.create(metricsManager, config, runtimeConfig, blacklist, cassandraClientPoolMetrics));
+                CassandraService.createForTests(
+                        metricsManager, config, runtimeConfig, blacklist, cassandraClientPoolMetrics));
         cassandraClientPool.wrapper.initialize(AtlasDbConstants.DEFAULT_INITIALIZE_ASYNC);
         return cassandraClientPool;
     }
@@ -433,9 +434,9 @@ public class CassandraClientPoolImpl implements CassandraClientPool {
         Preconditions.checkState(
                 !getCurrentPools().isEmpty() || serversToAdd.isEmpty(),
                 "No servers were successfully added to the pool. This means we could not come to a consensus on"
-                    + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
-                    + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
-                    + " configured AtlasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
+                        + " cluster topology, and the client cannot connect as there are no valid hosts. This state should"
+                        + " be transient (<5 minutes), and if it is not, indicates that the user may have accidentally"
+                        + " configured AtlasDB to use two separate Cassandra clusters (i.e., user-led split brain).",
                 SafeArg.of("serversToAdd", CassandraLogHelper.collectionOfHosts(serversToAdd.keySet())));
 
         logRefreshedHosts(validatedServersToAdd, serversToShutdown, absentServers);

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/FilteredCassandraClientInstrumentation.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/FilteredCassandraClientInstrumentation.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.palantir.atlasdb.logging.LoggingArgs;
+import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+public final class FilteredCassandraClientInstrumentation implements CassandraClientInstrumentation {
+    private final TopListFilteredCounter<String> cellsWrittenCounter;
+    private final ExecutorService executorService;
+
+    private FilteredCassandraClientInstrumentation(
+            TopListFilteredCounter<String> cellsWrittenCounter, ExecutorService executorService) {
+        this.cellsWrittenCounter = cellsWrittenCounter;
+        this.executorService = executorService;
+    }
+
+    public static CassandraClientInstrumentation create(
+            TaggedMetricRegistry registry, ScheduledExecutorService executor) {
+        TopListFilteredCounter<String> cellsWritten = TopListFilteredCounter.create(
+                2,
+                Duration.ofSeconds(5),
+                Duration.ofSeconds(15),
+                CassandraClientInstrumentationUtils::createCellsWrittenMetricNameForTableTag,
+                registry,
+                executor);
+
+        return new FilteredCassandraClientInstrumentation(cellsWritten, executor);
+    }
+
+    @Override
+    public void recordCellsWritten(String tableRef, long cellsWritten) {
+        String tableTag = LoggingArgs.safeInternalTableNameOrPlaceholder(tableRef);
+        cellsWrittenCounter.inc(tableTag, cellsWritten);
+    }
+
+    @Override
+    public void close() {
+        executorService.shutdownNow();
+    }
+}

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/FilteredCassandraClientInstrumentation.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/FilteredCassandraClientInstrumentation.java
@@ -35,7 +35,7 @@ public final class FilteredCassandraClientInstrumentation implements CassandraCl
     public static CassandraClientInstrumentation create(
             TaggedMetricRegistry registry, ScheduledExecutorService executor) {
         TopListFilteredCounter<String> cellsWritten = TopListFilteredCounter.create(
-                2,
+                5,
                 Duration.ofSeconds(5),
                 Duration.ofSeconds(15),
                 CassandraClientInstrumentationUtils::createCellsWrittenMetricNameForTableTag,

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/FilteredCassandraClientInstrumentation.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/FilteredCassandraClientInstrumentation.java
@@ -19,6 +19,7 @@ package com.palantir.atlasdb.keyvalue.cassandra;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import java.time.Duration;
+import java.util.Comparator;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -39,6 +40,7 @@ public final class FilteredCassandraClientInstrumentation implements CassandraCl
                 Duration.ofSeconds(5),
                 Duration.ofSeconds(15),
                 CassandraClientInstrumentationUtils::createCellsWrittenMetricNameForTableTag,
+                Comparator.<String>naturalOrder(),
                 registry,
                 executor);
 

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraService.java
@@ -38,11 +38,13 @@ import com.palantir.atlasdb.keyvalue.cassandra.CassandraClientPoolingContainer;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraLogHelper;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraServerOrigin;
 import com.palantir.atlasdb.keyvalue.cassandra.CassandraUtils;
+import com.palantir.atlasdb.keyvalue.cassandra.FilteredCassandraClientInstrumentation;
 import com.palantir.atlasdb.keyvalue.cassandra.LightweightOppToken;
 import com.palantir.atlasdb.keyvalue.cassandra.UnfilteredCassandraClientInstrumentation;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.common.base.FunctionCheckedException;
 import com.palantir.common.base.Throwables;
+import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.common.exception.AtlasDbDependencyException;
 import com.palantir.common.pooling.PoolingContainer;
 import com.palantir.common.streams.KeyedStream;
@@ -107,6 +109,22 @@ public final class CassandraService implements AutoCloseable {
     private final CassandraClientInstrumentation cassandraClientInstrumentation;
 
     public static CassandraService create(
+            MetricsManager metricsManager,
+            CassandraKeyValueServiceConfig config,
+            Refreshable<CassandraKeyValueServiceRuntimeConfig> runtimeConfig,
+            Blacklist blacklist,
+            CassandraClientPoolMetrics poolMetrics) {
+        return new CassandraService(
+                metricsManager,
+                config,
+                runtimeConfig,
+                blacklist,
+                poolMetrics,
+                FilteredCassandraClientInstrumentation.create(
+                        metricsManager.getTaggedRegistry(), PTExecutors.newSingleThreadScheduledExecutor()));
+    }
+
+    public static CassandraService createForTests(
             MetricsManager metricsManager,
             CassandraKeyValueServiceConfig config,
             Refreshable<CassandraKeyValueServiceRuntimeConfig> runtimeConfig,

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/pool/CassandraServiceTest.java
@@ -335,7 +335,7 @@ public class CassandraServiceTest {
                 config, runtimeConfig.map(CassandraKeyValueServiceRuntimeConfig::unresponsiveHostBackoffTimeSeconds));
 
         MetricsManager metricsManager = MetricsManagers.createForTests();
-        CassandraService service = CassandraService.create(
+        CassandraService service = CassandraService.createForTests(
                 metricsManager, config, runtimeConfig, blacklist, new CassandraClientPoolMetrics(metricsManager));
 
         service.cacheInitialHostsForCalculatingPoolNumber(servers);


### PR DESCRIPTION
## General
**Before this PR**:
`cellsWritten` is produced all the time for all producing tables.
**After this PR**:
`cellsWritten` is produced using a top list mechanism.
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P1
**Concerns / possible downsides (what feedback would you like?)**:
See PR comments
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
N/A
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
Only wiring here. Will test the desired metric load internally.
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Only 5 series are produced per TM for cellsWritten
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
Less pressure on metrics infra
**How would I tell that this PR does not work in production? (monitors, etc.)**:
See "How would I tell this PR works in production"
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback (and recall depending on the reason)
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
