### PR TITLE
Set statement_timeout on postgres

### DIFF
--- a/atlasdb-container-test-utils/src/main/resources/docker-compose-cassandra-three-node.yml
+++ b/atlasdb-container-test-utils/src/main/resources/docker-compose-cassandra-three-node.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   cassandra1:
     image: palantirtechnologies/docker-cassandra-atlasdb:$CASSANDRA_VERSION

--- a/atlasdb-container-test-utils/src/main/resources/docker-compose-cassandra.yml
+++ b/atlasdb-container-test-utils/src/main/resources/docker-compose-cassandra.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   cassandra:
     image: palantirtechnologies/docker-cassandra-atlasdb:$CASSANDRA_VERSION

--- a/atlasdb-container-test-utils/src/main/resources/docker-compose-cassandra2.yml
+++ b/atlasdb-container-test-utils/src/main/resources/docker-compose-cassandra2.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   cassandra2:
     image: palantirtechnologies/docker-cassandra-atlasdb:$CASSANDRA_VERSION

--- a/atlasdb-container-test-utils/src/test/resources/docker-compose-nginx1.yml
+++ b/atlasdb-container-test-utils/src/test/resources/docker-compose-nginx1.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   nginx1:
     image: nginx:1.13.8-alpine

--- a/atlasdb-container-test-utils/src/test/resources/docker-compose-nginx2.yml
+++ b/atlasdb-container-test-utils/src/test/resources/docker-compose-nginx2.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   nginx2:
     image: nginx:1.13.8-alpine

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -184,7 +184,7 @@ public abstract class ConnectionConfig {
 
         getTestQuery().ifPresent(config::setConnectionTestQuery);
 
-        getSqlExceptionOverrideClass().ifPresent(c -> config.setExceptionOverrideClassName(c.getName()));
+        getSqlExceptionOverrideClass().map(Class::getName).ifPresent(config::setExceptionOverrideClassName);
 
         getConnectionInitSql().ifPresent(config::setConnectionInitSql);
 

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/ConnectionConfig.java
@@ -182,14 +182,11 @@ public abstract class ConnectionConfig {
 
         initializeFailTimeoutMillis().ifPresent(config::setInitializationFailTimeout);
 
-        if (getTestQuery().isPresent()) {
-            config.setConnectionTestQuery(getTestQuery().get());
-        }
+        getTestQuery().ifPresent(config::setConnectionTestQuery);
 
-        if (getSqlExceptionOverrideClass().isPresent()) {
-            config.setExceptionOverrideClassName(
-                    getSqlExceptionOverrideClass().get().getName());
-        }
+        getSqlExceptionOverrideClass().ifPresent(c -> config.setExceptionOverrideClassName(c.getName()));
+
+        getConnectionInitSql().ifPresent(config::setConnectionInitSql);
 
         if (!props.isEmpty()) {
             config.setDataSourceProperties(props);
@@ -214,6 +211,11 @@ public abstract class ConnectionConfig {
 
     @JsonIgnore
     public Optional<Class<? extends SQLExceptionOverride>> getSqlExceptionOverrideClass() {
+        return Optional.empty();
+    }
+
+    @JsonIgnore
+    public Optional<String> getConnectionInitSql() {
         return Optional.empty();
     }
 }

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
@@ -105,4 +105,9 @@ public abstract class PostgresConnectionConfig extends ConnectionConfig {
     public final String type() {
         return TYPE;
     }
+
+    @Override
+    public Optional<String> getConnectionInitSql() {
+        return Optional.of("SET statement_timeout = " + (getSocketTimeoutSeconds() * 1000));
+    }
 }

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
@@ -106,8 +106,18 @@ public abstract class PostgresConnectionConfig extends ConnectionConfig {
         return TYPE;
     }
 
+    /**
+     * Normally, time to retrieve the first result ~= time to retrieve all results (eg if there is a sort)
+     * but some SQL statements can deliver results incrementally (eg nested joins) in which case the socket timeout
+     * could be set low relative to the total tiem to run a statement.
+     */
+    @Value.Default
+    public int getStatementTimeoutSeconds() {
+        return getSocketTimeoutSeconds();
+    }
+
     @Override
     public Optional<String> getConnectionInitSql() {
-        return Optional.of("SET statement_timeout = " + (getSocketTimeoutSeconds() * 1000));
+        return Optional.of("SET statement_timeout = " + (getStatementTimeoutSeconds() * 1000));
     }
 }

--- a/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
+++ b/atlasdb-dbkvs-hikari/src/main/java/com/palantir/nexus/db/pool/config/PostgresConnectionConfig.java
@@ -109,7 +109,7 @@ public abstract class PostgresConnectionConfig extends ConnectionConfig {
     /**
      * Normally, time to retrieve the first result ~= time to retrieve all results (eg if there is a sort)
      * but some SQL statements can deliver results incrementally (eg nested joins) in which case the socket timeout
-     * could be set low relative to the total tiem to run a statement.
+     * could be set low relative to the total time to run a statement.
      */
     @Value.Default
     public int getStatementTimeoutSeconds() {

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/nexus/db/pool/HikariCpConnectionManagerTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/nexus/db/pool/HikariCpConnectionManagerTest.java
@@ -136,6 +136,18 @@ public class HikariCpConnectionManagerTest {
     }
 
     @Test
+    public void testStatementTimeout() throws SQLException {
+        try (Connection conn = manager.getConnection();
+                Statement stmt =
+                        conn.prepareStatement("select setting from pg_settings where name = 'statement_timeout'")) {
+            ResultSet result = stmt.getResultSet();
+            assertThat(result.next()).isTrue();
+            assertThat(result.getLong(1))
+                    .isEqualTo(DbKvsPostgresExtension.getConnectionConfig().getStatementTimeoutSeconds() * 1000);
+        }
+    }
+
+    @Test
     public void testRuntimePasswordChange() throws SQLException {
         // create a new user to avoid messing up the main user for other tests
         // make username random in case concurrent runs makes things bad

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/nexus/db/pool/HikariCpConnectionManagerTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/nexus/db/pool/HikariCpConnectionManagerTest.java
@@ -138,9 +138,8 @@ public class HikariCpConnectionManagerTest {
     @Test
     public void testStatementTimeout() throws SQLException {
         try (Connection conn = manager.getConnection();
-                Statement stmt =
-                        conn.prepareStatement("select setting from pg_settings where name = 'statement_timeout'")) {
-            ResultSet result = stmt.getResultSet();
+                Statement stmt = conn.createStatement()) {
+            ResultSet result = stmt.executeQuery("select setting from pg_settings where name = 'statement_timeout'");
             assertThat(result.next()).isTrue();
             assertThat(result.getLong(1))
                     .isEqualTo(DbKvsPostgresExtension.getConnectionConfig().getStatementTimeoutSeconds() * 1000);

--- a/atlasdb-dbkvs-tests/src/test/resources/docker-compose.oracle.yml
+++ b/atlasdb-dbkvs-tests/src/test/resources/docker-compose.oracle.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   oracle:
     image: palantirtechnologies/oracle-atlasdb:19.24.0.0

--- a/atlasdb-dbkvs-tests/src/test/resources/docker-compose.postgres.yml
+++ b/atlasdb-dbkvs-tests/src/test/resources/docker-compose.postgres.yml
@@ -1,8 +1,6 @@
-version: '2'
-
 services:
   postgres-dbkvs:
-    image: postgres:9.6-alpine
+    image: postgres:13.15-alpine
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir

--- a/atlasdb-ete-tests/docker-compose.multi-client-with-postgres-timelock-and-postgres.yml
+++ b/atlasdb-ete-tests/docker-compose.multi-client-with-postgres-timelock-and-postgres.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   timelock:
     image: palantirtechnologies/timelock-server-distribution
@@ -11,7 +9,7 @@ services:
       - "8422"
 
   postgres:
-    image: postgres:9.6-alpine
+    image: postgres:13.15-alpine
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir

--- a/atlasdb-ete-tests/docker-compose.multi-client-with-timelock-and-cassandra.yml
+++ b/atlasdb-ete-tests/docker-compose.multi-client-with-timelock-and-cassandra.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   timelock:
     image: palantirtechnologies/timelock-server-distribution

--- a/atlasdb-ete-tests/docker-compose.single-client-with-embedded-and-cassandra.yml
+++ b/atlasdb-ete-tests/docker-compose.single-client-with-embedded-and-cassandra.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   cassandra:
     image: palantirtechnologies/docker-cassandra-atlasdb:$CASSANDRA_VERSION

--- a/atlasdb-ete-tests/docker-compose.single-client-with-embedded-and-oracle.yml
+++ b/atlasdb-ete-tests/docker-compose.single-client-with-embedded-and-oracle.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   oracle:
     image: palantirtechnologies/oracle-atlasdb:19.24.0.0

--- a/atlasdb-ete-tests/docker-compose.single-client-with-embedded-and-postgres.yml
+++ b/atlasdb-ete-tests/docker-compose.single-client-with-embedded-and-postgres.yml
@@ -1,8 +1,6 @@
-version: '2'
-
 services:
   postgres:
-    image: postgres:9.6-alpine
+    image: postgres:13.15-alpine
     environment:
        POSTGRES_PASSWORD: palantir
        POSTGRES_USER: palantir

--- a/atlasdb-ete-tests/docker-compose.single-client-with-embedded-and-three-node-cassandra.yml
+++ b/atlasdb-ete-tests/docker-compose.single-client-with-embedded-and-three-node-cassandra.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   cassandra1:
     image: palantirtechnologies/docker-cassandra-atlasdb:$CASSANDRA_VERSION

--- a/atlasdb-ete-tests/docker-compose.timelock-migration.cassandra.yml
+++ b/atlasdb-ete-tests/docker-compose.timelock-migration.cassandra.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   timelock:
     image: palantirtechnologies/timelock-server-distribution

--- a/atlasdb-ete-tests/docker-compose.timelock-migration.dbkvs.yml
+++ b/atlasdb-ete-tests/docker-compose.timelock-migration.dbkvs.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   timelock:
     image: palantirtechnologies/timelock-server-distribution
@@ -11,7 +9,7 @@ services:
       - "8422"
 
   postgres:
-    image: postgres:9.6-alpine
+    image: postgres:13.15-alpine
     mem_limit: 512m
     environment:
       POSTGRES_PASSWORD: palantir

--- a/atlasdb-ete-tests/src/test/resources/cassandra-docker-compose.yml
+++ b/atlasdb-ete-tests/src/test/resources/cassandra-docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   cassandra:
     image: palantirtechnologies/docker-cassandra-atlasdb:$CASSANDRA_VERSION

--- a/atlasdb-perf/src/main/resources/cassandra-docker-compose.yml
+++ b/atlasdb-perf/src/main/resources/cassandra-docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   cassandra:
     image: palantirtechnologies/docker-cassandra-atlasdb:$CASSANDRA_VERSION

--- a/atlasdb-perf/src/main/resources/postgres-docker-compose.yml
+++ b/atlasdb-perf/src/main/resources/postgres-docker-compose.yml
@@ -1,8 +1,6 @@
-version: '2'
-
 services:
   postgres:
-    image: postgres:9.6-alpine
+    image: postgres:13.15-alpine
     container_name: atlas_perf_postgres
     environment:
        POSTGRES_PASSWORD: palantir

--- a/atlasdb-workload-server-antithesis/var/docker-compose.yml
+++ b/atlasdb-workload-server-antithesis/var/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   cassandra1:
     image: palantirtechnologies/cassandra:unspecified

--- a/changelog/@unreleased/pr-7249.v2.yml
+++ b/changelog/@unreleased/pr-7249.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Set statement_timeout for postgres at connection initialisation
+  links:
+  - https://github.com/palantir/atlasdb/pull/7249

--- a/scripts/circle-ci/common-containers.yml
+++ b/scripts/circle-ci/common-containers.yml
@@ -5,7 +5,7 @@ cassandra2:
 #  image: palantirtechnologies/docker-cassandra-atlasdb:3.7
 
 postgres:
-  image: postgres:9.6-alpine
+  image: postgres:13.15-alpine
 
 nginx:
   image: 1science/nginx

--- a/timelock-server/src/testCommon/resources/docker-compose.yml
+++ b/timelock-server/src/testCommon/resources/docker-compose.yml
@@ -1,8 +1,6 @@
-version: '2'
-
 services:
   postgres:
-    image: postgres:9.6-alpine
+    image: postgres:13.15-alpine
     environment:
       POSTGRES_PASSWORD: palantir
       POSTGRES_USER: palantir


### PR DESCRIPTION
## General
**Before this PR**:
Postgres JDBC does not respond to interrupt(), so depending on statement execution time, DB clients may not close their running statements cleanly. In some environments where clients are on ephemeral infrastructure this can lead to DB saturation as orphaned statements continue to run away in the background and new statements from replacement infra joins them. This is unlikely to be an issue in Atlas, as its statement/socket timeouts are typically short, however this change aligns with best practise.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Set statement_timeout for postgres at connection initialisation
==COMMIT_MSG==

**Priority**: Low

**Concerns / possible downsides (what feedback would you like?)**:
Connection acquisition (for Postgres) now requires and additional interaction. However, since these connections are long lived, the overhead should be immaterial as this extra statement is only executed once.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
