### PR TITLE
Bump timelock pdep version

### DIFF
--- a/lock-api-objects/build.gradle
+++ b/lock-api-objects/build.gradle
@@ -38,7 +38,7 @@ recommendedProductDependencies {
     productDependency {
         productGroup = 'com.palantir.timelock'
         productName = 'timelock-server'
-        minimumVersion = '0.1295.0'
+        minimumVersion = '0.1606.0'
         maximumVersion = '0.x.x'
     }
 }


### PR DESCRIPTION
Develop currently depends on a diagnostics API endpoint in TimeLock.

Namely https://github.com/palantir/atlasdb/pull/7194 and https://github.com/palantir/atlasdb/pull/7192 are needed in TimeLock to support https://github.com/palantir/atlasdb/pull/7217.

There is no need to re-call anything as this endpoint is for a specific use case. I can enforce a dependency on latest Atlas in the internal AtlasDB wrapper's client library PR.