### PR TITLE
[ASTS] feat(bucket-assigner): Bucket assigner state machine ADT

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketAssignerState.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketAssignerState.java
@@ -1,0 +1,152 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ImmutableStart.class, name = BucketAssignerState.Start.TYPE),
+    @JsonSubTypes.Type(value = ImmutableOpening.class, name = BucketAssignerState.Opening.TYPE),
+    @JsonSubTypes.Type(
+            value = ImmutableWaitingUntilCloseable.class,
+            name = BucketAssignerState.WaitingUntilCloseable.TYPE),
+    @JsonSubTypes.Type(value = ImmutableClosingFromOpen.class, name = BucketAssignerState.ClosingFromOpen.TYPE),
+    @JsonSubTypes.Type(value = ImmutableImmediatelyClosing.class, name = BucketAssignerState.ImmediatelyClosing.TYPE),
+})
+public interface BucketAssignerState {
+    <T> T accept(BucketAssignerState.Visitor<T> visitor);
+
+    static BucketAssignerState.Start start(long startTimestampInclusive) {
+        return ImmutableStart.of(startTimestampInclusive);
+    }
+
+    static BucketAssignerState.Opening opening(long startTimestampInclusive) {
+        return ImmutableOpening.of(startTimestampInclusive);
+    }
+
+    static BucketAssignerState.WaitingUntilCloseable waitingUntilCloseable(long startTimestampInclusive) {
+        return ImmutableWaitingUntilCloseable.of(startTimestampInclusive);
+    }
+
+    static BucketAssignerState.ClosingFromOpen closingFromOpen(
+            long startTimestampInclusive, long endTimestampExclusive) {
+        return ImmutableClosingFromOpen.of(startTimestampInclusive, endTimestampExclusive);
+    }
+
+    static BucketAssignerState.ImmediatelyClosing immediatelyClosing(
+            long startTimestampInclusive, long endTimestampExclusive) {
+        return ImmutableImmediatelyClosing.of(startTimestampInclusive, endTimestampExclusive);
+    }
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableStart.class)
+    @JsonDeserialize(as = ImmutableStart.class)
+    interface Start extends BucketAssignerState {
+        String TYPE = "start";
+
+        @Value.Parameter
+        long startTimestampInclusive();
+
+        @Override
+        default <T> T accept(BucketAssignerState.Visitor<T> visitor) {
+            return visitor.visit(this);
+        }
+    }
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableOpening.class)
+    @JsonDeserialize(as = ImmutableOpening.class)
+    interface Opening extends BucketAssignerState {
+        String TYPE = "opening";
+
+        @Value.Parameter
+        long startTimestampInclusive();
+
+        @Override
+        default <T> T accept(BucketAssignerState.Visitor<T> visitor) {
+            return visitor.visit(this);
+        }
+    }
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableWaitingUntilCloseable.class)
+    @JsonDeserialize(as = ImmutableWaitingUntilCloseable.class)
+    interface WaitingUntilCloseable extends BucketAssignerState {
+        String TYPE = "waitingUntilCloseable";
+
+        @Value.Parameter
+        long startTimestampInclusive();
+
+        @Override
+        default <T> T accept(BucketAssignerState.Visitor<T> visitor) {
+            return visitor.visit(this);
+        }
+    }
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableClosingFromOpen.class)
+    @JsonDeserialize(as = ImmutableClosingFromOpen.class)
+    interface ClosingFromOpen extends BucketAssignerState {
+        String TYPE = "closingFromOpen";
+
+        @Value.Parameter
+        long startTimestampInclusive();
+
+        @Value.Parameter
+        long endTimestampExclusive();
+
+        @Override
+        default <T> T accept(BucketAssignerState.Visitor<T> visitor) {
+            return visitor.visit(this);
+        }
+    }
+
+    @Value.Immutable
+    @JsonSerialize(as = ImmutableImmediatelyClosing.class)
+    @JsonDeserialize(as = ImmutableImmediatelyClosing.class)
+    interface ImmediatelyClosing extends BucketAssignerState {
+        String TYPE = "immediatelyClosing";
+
+        @Value.Parameter
+        long startTimestampInclusive();
+
+        @Value.Parameter
+        long endTimestampExclusive();
+
+        @Override
+        default <T> T accept(BucketAssignerState.Visitor<T> visitor) {
+            return visitor.visit(this);
+        }
+    }
+
+    interface Visitor<T> {
+        T visit(BucketAssignerState.Start start);
+
+        T visit(BucketAssignerState.Opening opening);
+
+        T visit(BucketAssignerState.WaitingUntilCloseable waitingUntilCloseable);
+
+        T visit(BucketAssignerState.ClosingFromOpen closingFromOpen);
+
+        T visit(BucketAssignerState.ImmediatelyClosing immediatelyClosing);
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketAssignerStateTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketAssignerStateTest.java
@@ -1,0 +1,73 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.BaseEncoding;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class BucketAssignerStateTest {
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMappers.newSmileServerObjectMapper();
+
+    // Think _very_ carefully about changing this without a migration.
+    private static final byte[] START_SERIALIZED =
+            BaseEncoding.base64().decode("OikKBfqDdHlwZURzdGFydJZzdGFydFRpbWVzdGFtcEluY2x1c2l2ZcL7");
+    private static final byte[] OPENING_SERIALIZED =
+            BaseEncoding.base64().decode("OikKBfqDdHlwZUZvcGVuaW5nlnN0YXJ0VGltZXN0YW1wSW5jbHVzaXZlxPs=");
+    private static final byte[] WAITING_UNTIL_CLOSED_SERIALIZED = BaseEncoding.base64()
+            .decode("OikKBfqDdHlwZVR3YWl0aW5nVW50aWxDbG9zZWFibGWWc3RhcnRUaW1lc3RhbXBJbmNsdXNpdmXG+w==");
+    private static final byte[] CLOSING_FROM_OPEN_SERIALIZED = BaseEncoding.base64()
+            .decode(
+                    "OikKBfqDdHlwZU5jbG9zaW5nRnJvbU9wZW6Wc3RhcnRUaW1lc3RhbXBJbmNsdXNpdmXIlGVuZFRpbWVzdGFtcEV4Y2x1c2l2Zcr7");
+    private static final byte[] IMMEDIATELY_CLOSING_SERIALIZED = BaseEncoding.base64()
+            .decode(
+                    "OikKBfqDdHlwZVFpbW1lZGlhdGVseUNsb3NpbmeWc3RhcnRUaW1lc3RhbXBJbmNsdXNpdmXMlGVuZFRpbWVzdGFtcEV4Y2x1c2l2Zc77");
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("bucketAssignerStates")
+    public void canRoundTripSerdeState(BucketAssignerState state, byte[] _unused) throws IOException {
+        byte[] json = OBJECT_MAPPER.writeValueAsBytes(state);
+        BucketAssignerState deserialized = OBJECT_MAPPER.readValue(json, BucketAssignerState.class);
+        assertThat(deserialized).isEqualTo(state);
+        // Adding instance of check to be _really_ sure, since a mistake here would be very painful.
+        assertThat(deserialized).isInstanceOf(state.getClass());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("bucketAssignerStates")
+    public void canDeserializeExistingVersion(BucketAssignerState bucketProgress, byte[] serializedForm)
+            throws IOException {
+        assertThat(OBJECT_MAPPER.readValue(serializedForm, BucketAssignerState.class))
+                .isEqualTo(bucketProgress);
+    }
+
+    private static Stream<Arguments> bucketAssignerStates() {
+        return Stream.of(
+                Arguments.of(BucketAssignerState.start(1), START_SERIALIZED),
+                Arguments.of(BucketAssignerState.opening(2), OPENING_SERIALIZED),
+                Arguments.of(BucketAssignerState.waitingUntilCloseable(3), WAITING_UNTIL_CLOSED_SERIALIZED),
+                Arguments.of(BucketAssignerState.closingFromOpen(4, 5), CLOSING_FROM_OPEN_SERIALIZED),
+                Arguments.of(BucketAssignerState.immediatelyClosing(6, 7), IMMEDIATELY_CLOSING_SERIALIZED));
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
Our previous assumptions that a bucket could just be a fine partition was invalidated by the sheer load on one of our internal products, where processing one fine partition at a time would mean we'd never keep up.

Instead, we've decided to bucket the timestamps into 10 minute windows. Each shard  will have the same timestamp range for a given bucket identifier (this is not necessary for correctness, but a simplification for implementation that is currently sufficient).

This PR implements the state machine ADT that will be used to keep track of where we're at in the bucket assigning process.

In particular, we have the following states:
- START - representing the fact that there are _no_ open buckets for this bucket identifier.
- OPEN - we have 0 or more open buckets for this bucket identifier, and to transition from this state, we must open all the buckets
- WAITING_FOR_CLOSE - the state we transition into after OPEN. Here, we wait until we can close the bucket - once we do so, we transition into:
- CLOSE_FROM_OPEN - we have 0 or more closed buckets. To transition from this state, we must close all the buckets.
- IMMEDIATE_CLOSE - a short circuit from START where we can immediately create a complete bucket. This saves us a bunch of CAS requests (i.e., we don't need to go from null -> (x, -1) -> (x, y) [where x,y is the start inclusive and end exclusive timestamp of the range] when we can go from null -> (x, y). 

For more information, read the internal RFCs.
**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
Not with this one, tbh.
**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
None
**What was existing testing like? What have you done to improve it?**:
Added tests for serde. It may appear trivial, but it did actually catch a mistake where I missed one set of serde tags!
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Serde works without failure
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Serde fails explicitly (great), or we start deserialising into the wrong state (BAD, hence the tests)
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
Not here.
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Not this one
## Development Process
**Where should we start reviewing?**:
BucketAssignerState
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
