### PR TITLE
[ASTS] refactor: Moving around some bucket types

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKeyValueServiceIntegrationTest.java
@@ -231,7 +231,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 .collect(Collectors.toList()));
 
         assertThat(ColumnFamilyDefinitions.isMatchingCf(
-                kvs.getCfForTable(NEVER_SEEN, getMetadata(), FOUR_DAYS_IN_SECONDS), clusterSideCf))
+                        kvs.getCfForTable(NEVER_SEEN, getMetadata(), FOUR_DAYS_IN_SECONDS), clusterSideCf))
                 .as("After serialization and deserialization to database, Cf metadata did not match.")
                 .isTrue();
     }
@@ -256,8 +256,10 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
     @SuppressWarnings("CompileTimeConstant")
     public void shouldNotErrorForTimestampTableWhenCreatingCassandraKvs() {
         verify(logger, atLeast(0))
-                .error(startsWith("Found a table {} that did not have persisted"),
-                        assertArg((Arg<String> arg) -> assertThat(arg.getValue()).doesNotContain("timestamp")));
+                .error(
+                        startsWith("Found a table {} that did not have persisted"),
+                        assertArg(
+                                (Arg<String> arg) -> assertThat(arg.getValue()).doesNotContain("timestamp")));
     }
 
     @Test
@@ -492,20 +494,20 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
 
         keyValueService.putUnlessExists(userTable, ImmutableMap.of(CELL, sad));
         assertThat(keyValueService
-                .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
-                .get(CELL)
-                .getContents())
+                        .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
+                        .get(CELL)
+                        .getContents())
                 .containsExactly(sad);
 
         keyValueService.setOnce(userTable, ImmutableMap.of(CELL, happy));
         assertThat(keyValueService
-                .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
-                .get(CELL)
-                .getContents())
+                        .get(userTable, ImmutableMap.of(CELL, Long.MAX_VALUE))
+                        .get(CELL)
+                        .getContents())
                 .containsExactly(happy);
         assertThat(keyValueService
-                .getAllTimestamps(userTable, ImmutableSet.of(CELL), Long.MAX_VALUE)
-                .size())
+                        .getAllTimestamps(userTable, ImmutableSet.of(CELL), Long.MAX_VALUE)
+                        .size())
                 .isEqualTo(1);
         keyValueService.truncateTable(userTable);
     }
@@ -665,9 +667,9 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
         Cell nextTestCell = Cell.create(row(1), column(1));
 
         assertThatThrownBy(() -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                TEST_TABLE,
-                firstTestCell.getRowName(),
-                ImmutableMap.of(firstTestCell, val(0, 0), nextTestCell, val(0, 1)))))
+                        TEST_TABLE,
+                        firstTestCell.getRowName(),
+                        ImmutableMap.of(firstTestCell, val(0, 0), nextTestCell, val(0, 1)))))
                 .isInstanceOf(SafeIllegalStateException.class)
                 .hasMessageContaining("Can only update cells in one row.");
     }
@@ -683,7 +685,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 1))));
 
         assertThatThrownBy(() -> keyValueService.multiCheckAndSet(MultiCheckAndSetRequest.newCells(
-                TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))))
+                        TEST_TABLE, nextTestCell.getRowName(), ImmutableMap.of(nextTestCell, val(0, 2)))))
                 .isInstanceOf(MultiCheckAndSetException.class);
 
         MultiCheckAndSetException ex = catchThrowableOfType(
@@ -808,7 +810,7 @@ public abstract class AbstractCassandraKeyValueServiceIntegrationTest extends Ab
                 .setComment("")
                 .setColumn_metadata(new ArrayList<>())
                 .setTriggers(new ArrayList<>())
-                .setKey_alias(new byte[]{0x6B, 0x65, 0x79})
+                .setKey_alias(new byte[] {0x6B, 0x65, 0x79})
                 .setComparator_type("org.apache.cassandra.db.marshal.CompositeType"
                         + "(org.apache.cassandra.db.marshal.BytesType,org.apache.cassandra.db.marshal.LongType)")
                 .setCompaction_strategy_options(new HashMap<>())

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/Bucket.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/Bucket.java
@@ -16,14 +16,25 @@
 
 package com.palantir.atlasdb.sweep.asts;
 
-import java.util.function.Consumer;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.logsafe.Safe;
+import org.immutables.value.Value;
 
-public interface SweepStateCoordinator {
-    SweepOutcome tryRunTaskWithBucket(Consumer<SweepableBucket> task);
+@Value.Immutable
+public abstract class Bucket {
+    @Value.Parameter
+    public abstract ShardAndStrategy shardAndStrategy();
 
-    enum SweepOutcome {
-        NOTHING_AVAILABLE,
-        NOTHING_TO_SWEEP,
-        SWEPT;
+    @Value.Parameter
+    public abstract long bucketIdentifier();
+
+    @Safe
+    @Override
+    public String toString() {
+        return shardAndStrategy().toText() + " and partition " + bucketIdentifier();
+    }
+
+    public static Bucket of(ShardAndStrategy shardAndStrategy, long bucketIdentifier) {
+        return ImmutableBucket.of(shardAndStrategy, bucketIdentifier);
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/CandidateSweepableBucketRetriever.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/CandidateSweepableBucketRetriever.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.sweep.asts;
 
-import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
 import com.palantir.refreshable.Disposable;
 import java.util.Set;
 import java.util.function.Consumer;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetriever.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetriever.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.sweep.asts;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
 import com.palantir.common.concurrent.CoalescingSupplier;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSweepStateCoordinator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSweepStateCoordinator.java
@@ -119,7 +119,7 @@ public final class DefaultSweepStateCoordinator implements SweepStateCoordinator
         Map<Integer, List<SweepableBucket>> partition = newBuckets.stream()
                 .sorted(SweepableBucketComparator.INSTANCE)
                 .collect(Collectors.groupingBy(
-                        bucket -> bucket.shardAndStrategy().shard()));
+                        bucket -> bucket.bucket().shardAndStrategy().shard()));
 
         List<Lockable<SweepableBucket>> firstBucketsOfEachShard = partition.values().stream()
                 .filter(list -> !list.isEmpty())
@@ -148,12 +148,15 @@ public final class DefaultSweepStateCoordinator implements SweepStateCoordinator
         @Override
         public int compare(SweepableBucket firstBucket, SweepableBucket secondBucket) {
             int shardComparison = Integer.compare(
-                    firstBucket.shardAndStrategy().shard(),
-                    secondBucket.shardAndStrategy().shard());
+                    firstBucket.bucket().shardAndStrategy().shard(),
+                    secondBucket.bucket().shardAndStrategy().shard());
             if (shardComparison != 0) {
                 return shardComparison;
             }
-            return Long.compare(firstBucket.bucketIdentifier(), secondBucket.bucketIdentifier());
+            return Long.compare(
+                    firstBucket.bucket().bucketIdentifier(),
+                    secondBucket.bucket().bucketIdentifier());
+            // We're explicitly not comparing timestamp range, because it's irrelevant to the algorithm
         }
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/FaultTolerantShardedRetrievalStrategy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/FaultTolerantShardedRetrievalStrategy.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.sweep.asts;
 
 import com.google.common.collect.ImmutableMap;
 import com.palantir.atlasdb.sweep.asts.ShardedSweepTimestampManager.SweepTimestamps;
-import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
 import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/ShardedRetrievalStrategy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/ShardedRetrievalStrategy.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.sweep.asts;
 
 import com.palantir.atlasdb.sweep.asts.ShardedSweepTimestampManager.SweepTimestamps;
-import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
 import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
 import java.util.List;
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/ShardedSweepableBucketRetriever.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/ShardedSweepableBucketRetriever.java
@@ -18,7 +18,6 @@ package com.palantir.atlasdb.sweep.asts;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.atlasdb.sweep.asts.ShardedSweepTimestampManager.SweepTimestamps;
-import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
 import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
 import com.palantir.atlasdb.table.description.SweeperStrategy;
 import com.palantir.common.base.RunnableCheckedException;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/SweepableBucket.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/SweepableBucket.java
@@ -16,14 +16,30 @@
 
 package com.palantir.atlasdb.sweep.asts;
 
-import java.util.function.Consumer;
+import org.immutables.value.Value;
 
-public interface SweepStateCoordinator {
-    SweepOutcome tryRunTaskWithBucket(Consumer<SweepableBucket> task);
+@Value.Immutable
+public interface SweepableBucket {
+    @Value.Parameter
+    Bucket bucket();
 
-    enum SweepOutcome {
-        NOTHING_AVAILABLE,
-        NOTHING_TO_SWEEP,
-        SWEPT;
+    @Value.Parameter
+    TimestampRange timestampRange();
+
+    static SweepableBucket of(Bucket bucket, TimestampRange timestampRange) {
+        return ImmutableSweepableBucket.of(bucket, timestampRange);
+    }
+
+    @Value.Immutable
+    interface TimestampRange {
+        @Value.Parameter
+        long startInclusive();
+
+        @Value.Parameter
+        long endExclusive();
+
+        static TimestampRange of(long startInclusive, long endExclusive) {
+            return ImmutableTimestampRange.of(startInclusive, endExclusive);
+        }
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/SweepableBucketRetriever.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/SweepableBucketRetriever.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.sweep.asts;
 
-import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
 import java.util.Set;
 
 public interface SweepableBucketRetriever {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetrieverTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultCandidateSweepableBucketRetrieverTest.java
@@ -19,7 +19,7 @@ package com.palantir.atlasdb.sweep.asts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
 
-import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
+import com.palantir.atlasdb.sweep.asts.SweepableBucket.TimestampRange;
 import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
 import com.palantir.atlasdb.table.description.SweeperStrategy;
 import com.palantir.refreshable.Disposable;
@@ -48,8 +48,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DefaultCandidateSweepableBucketRetrieverTest {
     private static final Set<SweepableBucket> BUCKETS = Set.of(
-            SweepableBucket.of(ShardAndStrategy.of(1, SweeperStrategy.CONSERVATIVE), 1),
-            SweepableBucket.of(ShardAndStrategy.of(2, SweeperStrategy.THOROUGH), 2));
+            SweepableBucket.of(
+                    Bucket.of(ShardAndStrategy.of(1, SweeperStrategy.CONSERVATIVE), 1), TimestampRange.of(1, 3)),
+            SweepableBucket.of(
+                    Bucket.of(ShardAndStrategy.of(2, SweeperStrategy.THOROUGH), 2), TimestampRange.of(4, 6)));
     private static final SweepableBucketRetriever WITH_BUCKETS = () -> BUCKETS;
 
     private final SettableRefreshable<Duration> minimumDurationBetweenRefresh = Refreshable.create(Duration.ZERO);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultSweepStateCoordinatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultSweepStateCoordinatorTest.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepOutcome;
-import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
+import com.palantir.atlasdb.sweep.asts.SweepableBucket.TimestampRange;
 import com.palantir.atlasdb.sweep.asts.locks.Lockable;
 import com.palantir.atlasdb.sweep.asts.locks.Lockable.LockedItem;
 import com.palantir.atlasdb.sweep.asts.locks.LockableFactory;
@@ -267,7 +267,9 @@ public class DefaultSweepStateCoordinatorTest {
     }
 
     private static SweepableBucket bucket(int shard, int identifier) {
-        return SweepableBucket.of(ShardAndStrategy.of(shard, SweeperStrategy.CONSERVATIVE), identifier);
+        return SweepableBucket.of(
+                Bucket.of(ShardAndStrategy.of(shard, SweeperStrategy.CONSERVATIVE), identifier),
+                TimestampRange.of(1, 3));
     }
 
     // When we have assertions _inside_ tryRunTaskWithBucket, it's possible for those tests to spuriously pass if

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/FaultTolerantShardedRetrievalStrategyTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/FaultTolerantShardedRetrievalStrategyTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.palantir.atlasdb.sweep.asts.ShardedSweepTimestampManager.SweepTimestamps;
-import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
+import com.palantir.atlasdb.sweep.asts.SweepableBucket.TimestampRange;
 import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
 import com.palantir.atlasdb.table.description.SweeperStrategy;
 import java.util.List;
@@ -55,7 +55,8 @@ public class FaultTolerantShardedRetrievalStrategyTest {
 
     @Test
     public void passesThroughSuccessfulRequest() {
-        List<SweepableBucket> buckets = List.of(SweepableBucket.of(SHARD_AND_STRATEGY, 123L));
+        List<SweepableBucket> buckets =
+                List.of(SweepableBucket.of(Bucket.of(SHARD_AND_STRATEGY, 1), TimestampRange.of(1, 3)));
         when(delegate.getSweepableBucketsForShard(SHARD_AND_STRATEGY, SWEEP_TIMESTAMPS))
                 .thenReturn(buckets);
         assertThat(strategy.getSweepableBucketsForShard(SHARD_AND_STRATEGY, SWEEP_TIMESTAMPS))

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/ShardedSweepableBucketRetrieverTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/ShardedSweepableBucketRetrieverTest.java
@@ -19,7 +19,7 @@ package com.palantir.atlasdb.sweep.asts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.atlasdb.sweep.asts.ShardedSweepTimestampManager.SweepTimestamps;
-import com.palantir.atlasdb.sweep.asts.SweepStateCoordinator.SweepableBucket;
+import com.palantir.atlasdb.sweep.asts.SweepableBucket.TimestampRange;
 import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
 import com.palantir.atlasdb.table.description.SweeperStrategy;
 import com.palantir.common.concurrent.PTExecutors;
@@ -153,7 +153,9 @@ public class ShardedSweepableBucketRetrieverTest {
 
         private static List<SweepableBucket> generateList(int shard) {
             return IntStream.range(0, new Random().nextInt(10))
-                    .mapToObj(i -> SweepableBucket.of(ShardAndStrategy.of(shard, SweeperStrategy.CONSERVATIVE), i))
+                    .mapToObj(i -> SweepableBucket.of(
+                            Bucket.of(ShardAndStrategy.of(shard, SweeperStrategy.CONSERVATIVE), i),
+                            TimestampRange.of(1, 3)))
                     .collect(Collectors.toList());
         }
     }


### PR DESCRIPTION
## General
**Before this PR**:
Need to separate out the concept of a bucket (really, a bucket identifier, which is comprised of a bucket identifier number and a shard, and so it feels like there's a better name) and a sweepable bucket (a bucket + timestamp range) 

This means I can use the bucket as a key for values (at the store interface level, we can make a more compact representation when we're storing it in the database)

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
Naming - bucket is really bucket identifier, but there's a separate bucket identifier
**Is documentation needed?**:
no

## Development Process
**Where should we start reviewing?**:
Bucket
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
