### PR TITLE
[ASTS] feat(bucket-assigner): Bucket Writer 

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketWriter.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.palantir.atlasdb.sweep.asts.SweepableBucket.TimestampRange;
+import java.util.Optional;
+
+interface BucketWriter {
+    WriteState writeToAllBuckets(
+            long bucketIdentifier, Optional<TimestampRange> oldTimestampRange, TimestampRange newTimestampRange);
+
+    enum WriteState {
+        SUCCESS,
+        FAILURE
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketWriter.java
@@ -1,0 +1,110 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
+import com.palantir.atlasdb.sweep.asts.Bucket;
+import com.palantir.atlasdb.sweep.asts.SweepableBucket.TimestampRange;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.table.description.SweeperStrategy;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.List;
+import java.util.Optional;
+
+final class DefaultBucketWriter implements BucketWriter {
+    private static final SafeLogger log = SafeLoggerFactory.get(DefaultBucketWriter.class);
+    private final SweepBucketsTable sweepBucketsTable;
+    private final List<SweeperStrategy> sweeperStrategies;
+    private final int numberOfShards;
+
+    // The list ordering needs to be consistent, even when adding new sweeper strategies. New strategies must be added
+    // to the end.
+    private DefaultBucketWriter(
+            SweepBucketsTable sweepBucketsTable, List<SweeperStrategy> sweeperStrategies, int numberOfShards) {
+        this.sweepBucketsTable = sweepBucketsTable;
+        this.sweeperStrategies = sweeperStrategies;
+        this.numberOfShards = numberOfShards;
+    }
+
+    // A static number of shards, since it will not be configurable anymore.
+    static BucketWriter create(
+            SweepBucketsTable sweepBucketsTable, List<SweeperStrategy> sweeperStrategies, int numberOfShards) {
+        return new DefaultBucketWriter(sweepBucketsTable, sweeperStrategies, numberOfShards);
+    }
+
+    @Override
+    public WriteState writeToAllBuckets(
+            long bucketIdentifier, Optional<TimestampRange> oldTimestampRange, TimestampRange newTimestampRange) {
+
+        log.info(
+                "Assigning bucket ID {} timestamp range {} from old range {}",
+                SafeArg.of("bucketIdentifier", bucketIdentifier),
+                SafeArg.of("newTimestampRange", newTimestampRange),
+                SafeArg.of("oldTimestampRange", oldTimestampRange));
+        boolean failedForContiguousPrefixOfBuckets = false;
+        // A consistent ordering (by shard number and strategy), so that retries and concurrent threads are CASing
+        // in the same order, making it easier to determine if this is potentially a retry (there was a failure at the
+        // start, implying there was a previous write), or contention (we were successful at the beginning so no
+        // previous successful attempts at writing, but now failing implying someone else is updating).
+        for (SweeperStrategy sweeperStrategy : sweeperStrategies) {
+            for (int shard = 0; shard < numberOfShards; shard++) {
+                Bucket bucket = Bucket.of(ShardAndStrategy.of(shard, sweeperStrategy), bucketIdentifier);
+                try {
+                    sweepBucketsTable.putTimestampRangeForBucket(bucket, oldTimestampRange, newTimestampRange);
+                    // reset the flag after a successful attempt, so we can differentiate between a potential abort
+                    // and contention.
+                    failedForContiguousPrefixOfBuckets = false;
+                } catch (CheckAndSetException e) {
+                    // We know there's an element in the list, otherwise we wouldn't even be here.
+                    if (shard == 0 && sweeperStrategies.get(0) == sweeperStrategy) {
+                        failedForContiguousPrefixOfBuckets = true;
+                        // This doesn't indicate anything problematic, other than someone has at least tried and
+                        // potentially failed at some point.
+                        // They may have got arbitrarily far, so we need to ignore failures from here on until the next
+                        // success
+                        log.info(
+                                "We tried to CAS the first bucket on {} with timestamp range {} from old range"
+                                        + " {}, but it failed due to a CheckAndSetException. We will continue"
+                                        + " attempting  the CAS on the rest of the buckets, as it's possible that this"
+                                        + " is the remnant of a previous attempt",
+                                SafeArg.of("shardAndStrategy", bucket.shardAndStrategy()),
+                                SafeArg.of("newTimestampRange", newTimestampRange),
+                                SafeArg.of("oldTimestampRange", oldTimestampRange),
+                                e);
+                    } else if (!failedForContiguousPrefixOfBuckets) {
+                        // This implies we're contending with someone else, and they're ahead of us. We should
+                        // stop.
+                        log.warn(
+                                "Failed to assign bucket {} to shard {} with timestamp range {} from old range {}."
+                                        + " We failed part way through, so we're likely contending with another writer."
+                                        + " This isn't an issue for correctness, but if this happens repeatedly,"
+                                        + " it's possibly worth investigating why we're losing locks so frequently.",
+                                SafeArg.of("bucket", bucket.bucketIdentifier()),
+                                SafeArg.of("shardAndStrategy", bucket.shardAndStrategy()),
+                                SafeArg.of("newTimestampRange", newTimestampRange),
+                                SafeArg.of("oldTimestampRange", oldTimestampRange),
+                                e);
+                        return WriteState.FAILURE;
+                    }
+                }
+            }
+        }
+        return WriteState.SUCCESS;
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketWriterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketWriterTest.java
@@ -1,0 +1,178 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
+import com.palantir.atlasdb.sweep.asts.Bucket;
+import com.palantir.atlasdb.sweep.asts.SweepableBucket.TimestampRange;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.BucketWriter.WriteState;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.table.description.SweeperStrategy;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public final class DefaultBucketWriterTest {
+    private static final List<SweeperStrategy> SWEEPER_STRATEGIES =
+            ImmutableList.of(SweeperStrategy.CONSERVATIVE, SweeperStrategy.THOROUGH);
+    private static final int NUMBER_OF_SHARDS = 128;
+    private static final long BUCKET_IDENTIFIER = 1;
+    private static final TimestampRange OLD_TIMESTAMP_RANGE = TimestampRange.of(1, 3);
+    private static final TimestampRange NEW_TIMESTAMP_RANGE = TimestampRange.of(4, 6);
+
+    @Mock
+    private SweepBucketsTable sweepBucketsTable;
+
+    private BucketWriter bucketWriter;
+
+    @BeforeEach
+    public void beforeEach() {
+        bucketWriter = DefaultBucketWriter.create(sweepBucketsTable, SWEEPER_STRATEGIES, NUMBER_OF_SHARDS);
+    }
+
+    @Test
+    public void writesToAllBucketsInOrder() {
+        assertThat(bucketWriter.writeToAllBuckets(
+                        BUCKET_IDENTIFIER, Optional.of(OLD_TIMESTAMP_RANGE), NEW_TIMESTAMP_RANGE))
+                .isEqualTo(WriteState.SUCCESS);
+        assertAllBucketsUpdatedInOrder(Optional.of(OLD_TIMESTAMP_RANGE));
+    }
+
+    @Test
+    // We mock "originally failing part way" by having the first N attempts throw a CAS exception,
+    // as that would imply they're not what we originally expect them to be.
+    public void successfullyWritesToAllBucketsAfterOriginallyFailingPartWay() {
+        // number was arbitrarily chosen
+        for (int i = 0; i <= 94; i++) {
+            setupThrowCompareAndSetExceptionOnWrite(SweeperStrategy.CONSERVATIVE, i);
+        }
+
+        assertThat(bucketWriter.writeToAllBuckets(
+                        BUCKET_IDENTIFIER, Optional.of(OLD_TIMESTAMP_RANGE), NEW_TIMESTAMP_RANGE))
+                .isEqualTo(WriteState.SUCCESS);
+        assertAllBucketsUpdatedInOrder(Optional.of(OLD_TIMESTAMP_RANGE));
+    }
+
+    @Test
+    public void stopsAndBubblesUpNonCompareAndSetExceptionImmediately() {
+        RuntimeException exception = new RuntimeException("failed");
+        // Lenient because mockito gets concerned when you call with parameters outside of the mocked set.
+        // as it's concerned it's a user error. When this is intentional, it instructs to mark as lenient.
+        lenient()
+                .doThrow(exception)
+                .when(sweepBucketsTable)
+                .putTimestampRangeForBucket(
+                        // number arbitrarily chosen
+                        Bucket.of(ShardAndStrategy.of(53, SweeperStrategy.CONSERVATIVE), BUCKET_IDENTIFIER),
+                        Optional.of(OLD_TIMESTAMP_RANGE),
+                        NEW_TIMESTAMP_RANGE);
+
+        assertThatThrownBy(() -> bucketWriter.writeToAllBuckets(
+                        BUCKET_IDENTIFIER, Optional.of(OLD_TIMESTAMP_RANGE), NEW_TIMESTAMP_RANGE))
+                .isEqualTo(exception);
+
+        // 54 is the number of shards in [0, 53]
+        // We _try_ to CAS the failed one, hence we include the failed one.
+        assertAllBucketsUpToShardForStrategyUpdatedInOrder(
+                SweeperStrategy.CONSERVATIVE, 54, Optional.of(OLD_TIMESTAMP_RANGE));
+    }
+
+    @Test
+    public void stopsImmediatelyAfterCompareAndSetExceptionThatDoesNotOccurAtStart() {
+        // number arbitrarily chosen
+        setupThrowCompareAndSetExceptionOnWrite(SweeperStrategy.THOROUGH, 18);
+        assertThat(bucketWriter.writeToAllBuckets(
+                        BUCKET_IDENTIFIER, Optional.of(OLD_TIMESTAMP_RANGE), NEW_TIMESTAMP_RANGE))
+                .isEqualTo(WriteState.FAILURE);
+
+        // since it's the second strategy, we should have completed all of the conservative shards.
+        assertAllBucketsUpToShardForStrategyUpdatedInOrder(
+                SweeperStrategy.CONSERVATIVE, NUMBER_OF_SHARDS, Optional.of(OLD_TIMESTAMP_RANGE));
+
+        // includes the failing shard because we did _try_ to update.
+        assertAllBucketsUpToShardForStrategyUpdatedInOrder(
+                SweeperStrategy.THOROUGH, 19, Optional.of(OLD_TIMESTAMP_RANGE));
+    }
+
+    @Test
+    public void failingOnStartOfSecondStrategyDoesNotContinue() {
+        setupThrowCompareAndSetExceptionOnWrite(SweeperStrategy.THOROUGH, 0);
+        assertThat(bucketWriter.writeToAllBuckets(
+                        BUCKET_IDENTIFIER, Optional.of(OLD_TIMESTAMP_RANGE), NEW_TIMESTAMP_RANGE))
+                .isEqualTo(WriteState.FAILURE);
+
+        assertAllBucketsUpToShardForStrategyUpdatedInOrder(
+                SweeperStrategy.CONSERVATIVE, NUMBER_OF_SHARDS, Optional.of(OLD_TIMESTAMP_RANGE));
+        assertAllBucketsUpToShardForStrategyUpdatedInOrder(
+                SweeperStrategy.THOROUGH, 1, Optional.of(OLD_TIMESTAMP_RANGE));
+    }
+
+    @Test
+    public void updatesEvenWithEmptyOriginalTimestampRange() {
+        assertThat(bucketWriter.writeToAllBuckets(BUCKET_IDENTIFIER, Optional.empty(), NEW_TIMESTAMP_RANGE))
+                .isEqualTo(WriteState.SUCCESS);
+        assertAllBucketsUpdatedInOrder(Optional.empty());
+    }
+
+    private void setupThrowCompareAndSetExceptionOnWrite(SweeperStrategy strategy, int shard) {
+        lenient()
+                .doThrow(new CheckAndSetException("failed", null))
+                .when(sweepBucketsTable)
+                .putTimestampRangeForBucket(
+                        Bucket.of(ShardAndStrategy.of(shard, strategy), BUCKET_IDENTIFIER),
+                        Optional.of(OLD_TIMESTAMP_RANGE),
+                        NEW_TIMESTAMP_RANGE);
+    }
+
+    private void assertAllBucketsUpdatedInOrder(Optional<TimestampRange> original) {
+        InOrder inOrder = inOrder(sweepBucketsTable);
+        for (SweeperStrategy sweeperStrategy : SWEEPER_STRATEGIES) {
+            assertAllBucketsUpToShardForStrategyUpdatedInOrder(inOrder, sweeperStrategy, NUMBER_OF_SHARDS, original);
+        }
+        verifyNoMoreInteractions(sweepBucketsTable);
+    }
+
+    private void assertAllBucketsUpToShardForStrategyUpdatedInOrder(
+            SweeperStrategy strategy, int numberOfShards, Optional<TimestampRange> original) {
+        InOrder inOrder = inOrder(sweepBucketsTable);
+        assertAllBucketsUpToShardForStrategyUpdatedInOrder(inOrder, strategy, numberOfShards, original);
+    }
+
+    private void assertAllBucketsUpToShardForStrategyUpdatedInOrder(
+            InOrder inOrder, SweeperStrategy strategy, int numberOfShards, Optional<TimestampRange> original) {
+        for (int i = 0; i < numberOfShards; i++) {
+            inOrder.verify(sweepBucketsTable)
+                    .putTimestampRangeForBucket(
+                            Bucket.of(ShardAndStrategy.of(i, strategy), BUCKET_IDENTIFIER),
+                            original,
+                            NEW_TIMESTAMP_RANGE);
+        }
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
As part of bucket assigner, we need to CAS updates to all (shards, strategies). While each (shard, strategy) update is atomic, updating all of them is not, so we need to have logic to safely be able to retry when there's a failure part way through, as well as detecting when there might be multiple writers.


**After this PR**: Adds a BucketWriter class to do the above.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
Flexible on naming.
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
no
**Does this PR need a schema migration?**
no
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That CAS x 256 x 2 at most is not going to destroy our database.
**What was existing testing like? What have you done to improve it?**:
Added tests!
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Updates that fail part way through can be retried successfully.
All buckets are written.
**Has the safety of all log arguments been decided correctly?**:
It's timestamp range and bucket identifiers, both I believe are safe
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
BucketAssigner makes no progress after a single failure.
We don't update all shards.
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
Yes, but we're aiming to limit with checks for contention and best effort leases to run the task on only one node.
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
If we allow more than 256 shards
## Development Process
**Where should we start reviewing?**:
DefaultBucketWriter
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
