### PR TITLE
Make log helper function "collectionOfHosts" less error prone

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -42,7 +42,7 @@ public final class CassandraLogHelper {
     // Cache instances as there should be a relatively small, generally fixed number of Cassandra servers.
     private static final Interner<HostAndIpAddress> hostAddresses = Interner.newWeakInterner();
 
-    static HostAndIpAddress host(InetSocketAddress host) {
+    public static HostAndIpAddress host(InetSocketAddress host) {
         String hostString = host.getHostString().toLowerCase(Locale.ROOT);
         InetAddress inetAddress = host.getAddress();
         String ip = (inetAddress == null) ? null : /* unresolved IP */ inetAddress.getHostAddress();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -42,7 +42,7 @@ public final class CassandraLogHelper {
     // Cache instances as there should be a relatively small, generally fixed number of Cassandra servers.
     private static final Interner<HostAndIpAddress> hostAddresses = Interner.newWeakInterner();
 
-    public static HostAndIpAddress host(InetSocketAddress host) {
+    static HostAndIpAddress host(InetSocketAddress host) {
         String hostString = host.getHostString().toLowerCase(Locale.ROOT);
         InetAddress inetAddress = host.getAddress();
         String ip = (inetAddress == null) ? null : /* unresolved IP */ inetAddress.getHostAddress();

--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraLogHelper.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.github.benmanes.caffeine.cache.Interner;
-import com.google.common.collect.Multimap;
+import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraServer;
@@ -49,16 +49,10 @@ public final class CassandraLogHelper {
         return hostAddresses.intern(ImmutableHostAndIpAddress.of(hostString, ip));
     }
 
-    // TODO(boyoruk): Remove this as it can throw IllegalStateException if there are duplicate cassandra host names
     static Collection<String> collectionOfHosts(Collection<CassandraServer> hosts) {
-        return hosts.stream().map(CassandraServer::cassandraHostName).collect(Collectors.toSet());
-    }
-
-    static List<String> tokenRangesToServer(Multimap<Set<TokenRange>, CassandraServer> tokenRangesToHost) {
-        return tokenRangesToHost.entries().stream()
-                .map(entry ->
-                        "host " + entry.getValue().cassandraHostName() + " with proxy has range " + entry.getKey())
-                .collect(Collectors.toList());
+        return hosts.stream()
+                .map(CassandraServer::cassandraHostName)
+                .collect(Collectors.toCollection(HashMultiset::create));
     }
 
     public static List<String> tokenMap(RangeMap<LightweightOppToken, ? extends Collection<CassandraServer>> tokenMap) {

--- a/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
+++ b/atlasdb-cassandra/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraClientPoolTest.java
@@ -65,6 +65,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -588,7 +589,7 @@ public final class CassandraClientPoolTest {
         Map<CassandraServer, CassandraClientPoolingContainer> allHosts =
                 ImmutableMap.<CassandraServer, CassandraClientPoolingContainer>builder()
                         .putAll(containers)
-                        .put(CASS_SERVER_3, newContainers.get(CASS_SERVER_3))
+                        .put(CASS_SERVER_3, Objects.requireNonNull(newContainers.get(CASS_SERVER_3)))
                         .buildOrThrow();
         verify(cassandraTopologyValidator)
                 .getNewHostsWithInconsistentTopologiesAndRetry(eq(expectedNewHost), eq(allHosts), any(), any());
@@ -682,9 +683,8 @@ public final class CassandraClientPoolTest {
     }
 
     static class HostBuilder {
-        private CassandraServer server;
-        private List<Exception> exceptions = new ArrayList<>();
-        private boolean returnsValue = true;
+        private final CassandraServer server;
+        private final List<Exception> exceptions = new ArrayList<>();
 
         HostBuilder(CassandraServer server) {
             this.server = server;
@@ -704,9 +704,7 @@ public final class CassandraClientPoolTest {
                 for (Exception ex : exceptions) {
                     stubbing = stubbing.thenThrow(ex);
                 }
-                if (returnsValue) {
-                    stubbing.thenReturn("Response");
-                }
+                stubbing.thenReturn("Response");
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }
@@ -806,7 +804,7 @@ public final class CassandraClientPoolTest {
     }
 
     private FunctionCheckedException<CassandraClient, Void, RuntimeException> noOp() {
-        return new FunctionCheckedException<CassandraClient, Void, RuntimeException>() {
+        return new FunctionCheckedException<>() {
             @Override
             public Void apply(CassandraClient input) throws RuntimeException {
                 return null;


### PR DESCRIPTION
## General
FLUP for https://github.com/palantir/atlasdb/pull/7195. Collecting into a set is problematic because if there are two Cassandra servers sharing the same host name, collectionOfHosts would throw an exception. This happened with the idSupportingHostIdResultMap function before, and we fixed it by removing that function. Here, we can collect into a multiset instead to prevent this exception being thrown by collectionOfHosts function. Since this is only used for logging purposes, a less error-prone approach would be better (even though it is a rare edge case to have two servers with the same name).

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P3

**Concerns / possible downsides (what feedback would you like?)**:
Just logging changes

**Is documentation needed?**:
No

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
NA

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No

**Does this PR need a schema migration?**
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
Nothing made

**What was existing testing like? What have you done to improve it?**:
Nothing changed

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
No

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
No

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Two C* server objects sharing same host name shouldn't throw exception in critical paths

**Has the safety of all log arguments been decided correctly?**:
Nothing changed

**Will this change significantly affect our spending on metrics or logs?**:
No

**How would I tell that this PR does not work in production? (monitors, etc.)**:
Two C* server objects sharing same host name throw exception in critical paths

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Yes

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
No

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No

## Development Process
**Where should we start reviewing?**:
Single class

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
No

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
