### PR TITLE
[ASTS] feat(bucket-assigner): The bucket assigner!

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/SweepableBucket.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/SweepableBucket.java
@@ -38,8 +38,14 @@ public interface SweepableBucket {
         @Value.Parameter
         long endExclusive();
 
+        // TODO(mdaudali): Should this be named closeBucket? It's really just a range, so it feels like no.
         static TimestampRange of(long startInclusive, long endExclusive) {
             return ImmutableTimestampRange.of(startInclusive, endExclusive);
+        }
+
+        static TimestampRange openBucket(long startInclusive) {
+            // Think very carefully about changing from -1 without a migration
+            return of(startInclusive, -1);
         }
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketWriter.java
@@ -25,6 +25,6 @@ interface BucketWriter {
 
     enum WriteState {
         SUCCESS,
-        FAILURE
+        FAILED_CAS
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketAssigner.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketAssigner.java
@@ -1,0 +1,240 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.palantir.atlasdb.sweep.asts.SweepableBucket.TimestampRange;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.BucketWriter.WriteState;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.DefaultBucketAssigner.IterationResult.OperationResult;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.SweepBucketAssignerStateMachineTable.BucketStateAndIdentifier;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.Function;
+import org.immutables.value.Value;
+
+public final class DefaultBucketAssigner {
+    private static final SafeLogger log = SafeLoggerFactory.get(DefaultBucketAssigner.class);
+    private static final int MAX_BUCKETS_PER_ITERATION = 5;
+
+    private final SweepBucketAssignerStateMachineTable sweepBucketAssignerStateMachineTable;
+    private final BucketAssignerMetrics metrics;
+    private final BucketWriter bucketWriter;
+    private final Function<Long, OptionalLong> closeTimestampCalculator;
+
+    @VisibleForTesting
+    DefaultBucketAssigner(
+            SweepBucketAssignerStateMachineTable sweepBucketAssignerStateMachineTable,
+            BucketWriter bucketWriter,
+            BucketAssignerMetrics metrics,
+            Function<Long, OptionalLong> closeTimestampCalculator) {
+        this.sweepBucketAssignerStateMachineTable = sweepBucketAssignerStateMachineTable;
+        this.metrics = metrics;
+        this.bucketWriter = bucketWriter;
+        this.closeTimestampCalculator = closeTimestampCalculator;
+    }
+
+    public static DefaultBucketAssigner create(
+            SweepBucketAssignerStateMachineTable sweepBucketAssignerStateMachineTable,
+            BucketWriter bucketWriter,
+            BucketAssignerMetrics metrics,
+            Function<Long, OptionalLong> closeTimestampCalculator) {
+        return new DefaultBucketAssigner(
+                sweepBucketAssignerStateMachineTable, bucketWriter, metrics, closeTimestampCalculator);
+    }
+
+    public void run() {
+        // TODO(mdaudali): Take a lock, or use Lockable<ExclusiveTask> to externalise the locking.
+        //  then, this may end up implementing Runnable.
+        IterationResult iterationResult = createNewBucket();
+
+        // We cap the number of buckets we create per iteration to avoid a single thread getting stuck creating
+        // buckets. This is a safety measure in case there's a bug in the bucket creation logic that causes it to
+        // infinitely create the same bucket or return CLOSED over and over again.
+        for (int i = 1;
+                i < MAX_BUCKETS_PER_ITERATION && iterationResult.operationResult() == OperationResult.CLOSED;
+                i++) {
+            iterationResult = createNewBucket();
+            if (i == MAX_BUCKETS_PER_ITERATION - 1 && iterationResult.operationResult() == OperationResult.CLOSED) {
+                metrics.createdMaxBucketsInSingleIteration();
+                log.warn(
+                        "Reached the maximum number of buckets created per iteration. This is most likely because"
+                            + " we're very far behind, or because there's a bug in the bucket creation logic that"
+                            + " causes it to infinitely create the same bucket or return CLOSED over and over again."
+                            + " The last bucket processed has ID {} and reached state {}",
+                        SafeArg.of("bucketIdentifier", iterationResult.bucketIdentifier()),
+                        SafeArg.of("bucketAssignerState", iterationResult.bucketAssignerState()));
+            }
+        }
+    }
+
+    private IterationResult createNewBucket() {
+        BucketStateAndIdentifier stateAndIdentifier =
+                sweepBucketAssignerStateMachineTable.getBucketStateAndIdentifier();
+        BucketStateVisitor visitor = new BucketStateVisitor(stateAndIdentifier.bucketIdentifier());
+        IterationResult iterationResult = stateAndIdentifier.state().accept(visitor);
+        metrics.operationResultForIteration(iterationResult.operationResult());
+        log.info(
+                "Processed a bucket with ID {} and reached state {}",
+                SafeArg.of("bucketIdentifier", iterationResult.bucketIdentifier()),
+                SafeArg.of("bucketAssignerState", iterationResult.bucketAssignerState()));
+        return iterationResult;
+    }
+
+    private final class BucketStateVisitor implements BucketAssignerState.Visitor<IterationResult> {
+        private final long bucketIdentifier;
+
+        private BucketStateVisitor(long bucketIdentifier) {
+            this.bucketIdentifier = bucketIdentifier;
+        }
+
+        @Override
+        public IterationResult visit(BucketAssignerState.Start start) {
+            metrics.progressedToBucketIdentifier(bucketIdentifier);
+            metrics.bucketAssignerState(start);
+            OptionalLong closeTimestamp = closeTimestampCalculator.apply(start.startTimestampInclusive());
+
+            if (closeTimestamp.isPresent()) {
+                return tryTransitionAndExecuteNextState(
+                        start,
+                        BucketAssignerState.immediatelyClosing(
+                                start.startTimestampInclusive(), closeTimestamp.orElseThrow()));
+            } else {
+                return tryTransitionAndExecuteNextState(
+                        start, BucketAssignerState.opening(start.startTimestampInclusive()));
+            }
+        }
+
+        @Override
+        public IterationResult visit(BucketAssignerState.Opening open) {
+            metrics.bucketAssignerState(open);
+            WriteState writeState = bucketWriter.writeToAllBuckets(
+                    bucketIdentifier, Optional.empty(), TimestampRange.openBucket(open.startTimestampInclusive()));
+
+            if (writeState == WriteState.FAILED_CAS) {
+                return IterationResult.of(OperationResult.CONTENTION_ON_WRITES, bucketIdentifier, open);
+            }
+
+            BucketAssignerState waitingUntilCloseable =
+                    BucketAssignerState.waitingUntilCloseable(open.startTimestampInclusive());
+            sweepBucketAssignerStateMachineTable.updateStateMachineForBucketAssigner(
+                    BucketStateAndIdentifier.of(bucketIdentifier, open),
+                    BucketStateAndIdentifier.of(bucketIdentifier, waitingUntilCloseable));
+            return IterationResult.of(OperationResult.INCOMPLETE, bucketIdentifier, waitingUntilCloseable);
+        }
+
+        @Override
+        public IterationResult visit(BucketAssignerState.WaitingUntilCloseable waitingClose) {
+            metrics.bucketAssignerState(waitingClose);
+            OptionalLong closeTimestamp = closeTimestampCalculator.apply(waitingClose.startTimestampInclusive());
+
+            if (closeTimestamp.isPresent()) {
+                return tryTransitionAndExecuteNextState(
+                        waitingClose,
+                        BucketAssignerState.closingFromOpen(
+                                waitingClose.startTimestampInclusive(), closeTimestamp.orElseThrow()));
+            } else {
+                return IterationResult.of(OperationResult.INCOMPLETE, bucketIdentifier, waitingClose);
+            }
+        }
+
+        @Override
+        public IterationResult visit(BucketAssignerState.ClosingFromOpen closingFromOpen) {
+            metrics.bucketAssignerState(closingFromOpen);
+            return tryTransitionToStartAfterClosingBuckets(
+                    Optional.of(TimestampRange.openBucket(closingFromOpen.startTimestampInclusive())),
+                    TimestampRange.of(
+                            closingFromOpen.startTimestampInclusive(), closingFromOpen.endTimestampExclusive()),
+                    closingFromOpen);
+        }
+
+        @Override
+        public IterationResult visit(BucketAssignerState.ImmediatelyClosing immediateClose) {
+            metrics.bucketAssignerState(immediateClose);
+            return tryTransitionToStartAfterClosingBuckets(
+                    Optional.empty(),
+                    TimestampRange.of(immediateClose.startTimestampInclusive(), immediateClose.endTimestampExclusive()),
+                    immediateClose);
+        }
+
+        private IterationResult tryTransitionToStartAfterClosingBuckets(
+                Optional<TimestampRange> oldTimestampRange,
+                TimestampRange newTimestampRange,
+                BucketAssignerState lastState) {
+            WriteState writeState =
+                    bucketWriter.writeToAllBuckets(bucketIdentifier, oldTimestampRange, newTimestampRange);
+
+            if (writeState == WriteState.FAILED_CAS) {
+                return IterationResult.of(OperationResult.CONTENTION_ON_WRITES, bucketIdentifier, lastState);
+            }
+
+            BucketAssignerState start = BucketAssignerState.start(newTimestampRange.endExclusive());
+            sweepBucketAssignerStateMachineTable.updateStateMachineForBucketAssigner(
+                    BucketStateAndIdentifier.of(bucketIdentifier, lastState),
+                    BucketStateAndIdentifier.of(bucketIdentifier + 1, start));
+            return IterationResult.of(OperationResult.CLOSED, bucketIdentifier, start);
+        }
+
+        private IterationResult tryTransitionAndExecuteNextState(
+                BucketAssignerState currentState, BucketAssignerState newState) {
+            sweepBucketAssignerStateMachineTable.updateStateMachineForBucketAssigner(
+                    BucketStateAndIdentifier.of(bucketIdentifier, currentState),
+                    BucketStateAndIdentifier.of(bucketIdentifier, newState));
+            return newState.accept(this);
+        }
+    }
+
+    @Value.Immutable
+    interface IterationResult {
+        @Value.Parameter
+        OperationResult operationResult();
+
+        @Value.Parameter
+        long bucketIdentifier();
+
+        @Value.Parameter
+        BucketAssignerState bucketAssignerState();
+
+        // TODO(mdaudali): Re-evaluate if this is a useful metric or not.
+        enum OperationResult {
+            // The bucket is still open (we didn't close it in this iteration)
+            INCOMPLETE,
+            // We could close the bucket in this iteration
+            CLOSED,
+            // We believe someone else is also updating the buckets, so we're stopping here.
+            CONTENTION_ON_WRITES
+        }
+
+        static IterationResult of(
+                OperationResult operationResult, long bucketIdentifier, BucketAssignerState bucketAssignerState) {
+            return ImmutableIterationResult.of(operationResult, bucketIdentifier, bucketAssignerState);
+        }
+    }
+
+    // TODO(mdaudali): This is a placeholder. I imagine that we may also use these consumers to inform autoscaling
+    interface BucketAssignerMetrics {
+        void progressedToBucketIdentifier(long bucketIdentifier);
+
+        void operationResultForIteration(OperationResult iterationStateOutcome);
+
+        void createdMaxBucketsInSingleIteration();
+
+        void bucketAssignerState(BucketAssignerState bucketAssignerState);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketWriter.java
@@ -100,7 +100,7 @@ final class DefaultBucketWriter implements BucketWriter {
                                 SafeArg.of("newTimestampRange", newTimestampRange),
                                 SafeArg.of("oldTimestampRange", oldTimestampRange),
                                 e);
-                        return WriteState.FAILURE;
+                        return WriteState.FAILED_CAS;
                     }
                 }
             }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketAssignerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketAssignerTest.java
@@ -1,0 +1,381 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.palantir.atlasdb.sweep.asts.SweepableBucket.TimestampRange;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.BucketWriter.WriteState;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.DefaultBucketAssigner.BucketAssignerMetrics;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.DefaultBucketAssigner.IterationResult.OperationResult;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.SweepBucketAssignerStateMachineTable.BucketStateAndIdentifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public final class DefaultBucketAssignerTest {
+    private static final RuntimeException RUNTIME_EXCEPTION = new RuntimeException("Something went wrong");
+
+    @Mock
+    private BucketWriter bucketWriter;
+
+    @Mock
+    private BucketAssignerMetrics metrics;
+
+    @Mock
+    private Function<Long, OptionalLong> closeTimestampCalculator;
+
+    private TestSweepBucketAssignerStateMachineTable stateTable;
+    private DefaultBucketAssigner bucketAssigner;
+
+    @BeforeEach
+    public void before() {
+        stateTable = new TestSweepBucketAssignerStateMachineTable(metrics);
+        bucketAssigner = new DefaultBucketAssigner(stateTable, bucketWriter, metrics, closeTimestampCalculator);
+    }
+
+    @Test // A single call to run - i.e., we don't do one step per call where possible
+    public void startStateTransitionsThroughToWaitingUntilCloseableIfBucketCannotBeClosedImmediately() {
+        stateTable.setInitialState(1, BucketAssignerState.start(1));
+        when(closeTimestampCalculator.apply(1L)).thenReturn(OptionalLong.empty());
+        bucketAssigner.run();
+
+        assertOperationResult(OperationResult.INCOMPLETE);
+        verify(bucketWriter).writeToAllBuckets(1, Optional.empty(), TimestampRange.openBucket(1));
+        verify(metrics).progressedToBucketIdentifier(1);
+        stateTable.assertThatStateMachineTransitionedThroughTo(
+                BucketStateAndIdentifier.of(1, BucketAssignerState.opening(1)),
+                BucketStateAndIdentifier.of(1, BucketAssignerState.waitingUntilCloseable(1)));
+    }
+
+    @Test
+    public void openingStateWritesToAllBucketsFromNoOriginalTimestampAndTransitionsToWaitingUntilCloseable() {
+        stateTable.setInitialState(1, BucketAssignerState.opening(1));
+        bucketAssigner.run();
+
+        assertOperationResult(OperationResult.INCOMPLETE);
+        verify(bucketWriter).writeToAllBuckets(1, Optional.empty(), TimestampRange.openBucket(1));
+        stateTable.assertThatStateMachineTransitionedThroughTo(
+                BucketStateAndIdentifier.of(1, BucketAssignerState.waitingUntilCloseable(1)));
+    }
+
+    @Test
+    public void waitingForCloseDoesNoTransitionIfBucketCannotBeClosed() {
+        stateTable.setInitialState(1, BucketAssignerState.waitingUntilCloseable(1));
+        when(closeTimestampCalculator.apply(1L)).thenReturn(OptionalLong.empty());
+        bucketAssigner.run();
+
+        assertOperationResult(OperationResult.INCOMPLETE);
+        verifyNoInteractions(bucketWriter);
+        stateTable.assertThatStateMachineTransitionedThroughTo(); // No transition
+    }
+
+    @Test
+    public void waitingForCloseTransitionsThroughClosingFromOpenToStartIfBucketCanBeClosed() {
+        stateTable.setInitialState(1, BucketAssignerState.waitingUntilCloseable(1));
+        when(closeTimestampCalculator.apply(1L)).thenReturn(OptionalLong.of(10));
+        when(closeTimestampCalculator.apply(10L)).thenReturn(OptionalLong.empty());
+        bucketAssigner.run();
+
+        assertOperationResult(OperationResult.CLOSED, OperationResult.INCOMPLETE);
+        verify(bucketWriter).writeToAllBuckets(1, Optional.of(TimestampRange.openBucket(1)), TimestampRange.of(1, 10));
+        stateTable.assertThatStateMachineTransitionedThroughTo(
+                BucketStateAndIdentifier.of(1, BucketAssignerState.closingFromOpen(1, 10)),
+                // 10 was chosen as the end timestamp to show that we correctly use that as the start, and not something
+                // silly like start + 1.
+                BucketStateAndIdentifier.of(2, BucketAssignerState.start(10)),
+                // We successfully closed a bucket, so we'll run another iteration eagerly.
+                BucketStateAndIdentifier.of(2, BucketAssignerState.opening(10)),
+                BucketStateAndIdentifier.of(2, BucketAssignerState.waitingUntilCloseable(10)));
+    }
+
+    @Test
+    public void closingFromOpenStateUsesOriginalStartAndEndTimestampsInsteadOfRecalculatingAndClosesBucket() {
+        stateTable.setInitialState(1, BucketAssignerState.closingFromOpen(1, 2));
+        // This mock is for the _next_ bucket.
+        when(closeTimestampCalculator.apply(2L)).thenReturn(OptionalLong.empty());
+        bucketAssigner.run();
+
+        assertOperationResult(OperationResult.CLOSED, OperationResult.INCOMPLETE);
+        verify(bucketWriter).writeToAllBuckets(1, Optional.of(TimestampRange.openBucket(1)), TimestampRange.of(1, 2));
+        // We'll start the next iteration of buckets, but stop because we can't close it.
+        stateTable.assertThatStateMachineTransitionedThroughTo(
+                BucketStateAndIdentifier.of(2, BucketAssignerState.start(2)),
+                BucketStateAndIdentifier.of(2, BucketAssignerState.opening(2)),
+                BucketStateAndIdentifier.of(2, BucketAssignerState.waitingUntilCloseable(2)));
+        verifyNoMoreInteractions(closeTimestampCalculator);
+    }
+
+    @Test
+    public void startTransitionsThroughImmediatelyClosingToStartIfBucketCanBeImmediatelyClosed() {
+        stateTable.setInitialState(1, BucketAssignerState.start(1));
+        when(closeTimestampCalculator.apply(1L)).thenReturn(OptionalLong.of(15));
+        when(closeTimestampCalculator.apply(15L)).thenReturn(OptionalLong.empty());
+        bucketAssigner.run();
+
+        assertOperationResult(OperationResult.CLOSED, OperationResult.INCOMPLETE);
+        verify(bucketWriter).writeToAllBuckets(1, Optional.empty(), TimestampRange.of(1, 15));
+        stateTable.assertThatStateMachineTransitionedThroughTo(
+                BucketStateAndIdentifier.of(1, BucketAssignerState.immediatelyClosing(1, 15)),
+                BucketStateAndIdentifier.of(2, BucketAssignerState.start(15)),
+                BucketStateAndIdentifier.of(2, BucketAssignerState.opening(15)),
+                BucketStateAndIdentifier.of(2, BucketAssignerState.waitingUntilCloseable(15)));
+    }
+
+    @Test
+    public void immediatelyClosingUsesOriginalTimestampsInsteadOfRecalculatingAndClosesBucket() {
+        stateTable.setInitialState(1, BucketAssignerState.immediatelyClosing(1, 15));
+        // This mock is for the _next_ bucket.
+        when(closeTimestampCalculator.apply(15L)).thenReturn(OptionalLong.empty());
+        bucketAssigner.run();
+
+        assertOperationResult(OperationResult.CLOSED, OperationResult.INCOMPLETE);
+        verify(bucketWriter).writeToAllBuckets(1, Optional.empty(), TimestampRange.of(1, 15));
+        stateTable.assertThatStateMachineTransitionedThroughTo(
+                BucketStateAndIdentifier.of(2, BucketAssignerState.start(15)),
+                BucketStateAndIdentifier.of(2, BucketAssignerState.opening(15)),
+                BucketStateAndIdentifier.of(2, BucketAssignerState.waitingUntilCloseable(15)));
+        verifyNoMoreInteractions(closeTimestampCalculator);
+    }
+
+    @Test
+    public void createsBucketsUpToMaxIterationsInOneRunIfAllCloseable() {
+        stateTable.setInitialState(1, BucketAssignerState.start(1));
+        when(closeTimestampCalculator.apply(1L)).thenReturn(OptionalLong.of(3));
+        when(closeTimestampCalculator.apply(3L)).thenReturn(OptionalLong.of(25));
+        when(closeTimestampCalculator.apply(25L)).thenReturn(OptionalLong.of(41));
+        when(closeTimestampCalculator.apply(41L)).thenReturn(OptionalLong.of(114));
+        when(closeTimestampCalculator.apply(114L)).thenReturn(OptionalLong.of(221));
+
+        bucketAssigner.run();
+        stateTable.assertThatStateMachineTransitionedThroughTo(
+                BucketStateAndIdentifier.of(1, BucketAssignerState.immediatelyClosing(1, 3)),
+                BucketStateAndIdentifier.of(2, BucketAssignerState.start(3)),
+                BucketStateAndIdentifier.of(2, BucketAssignerState.immediatelyClosing(3, 25)),
+                BucketStateAndIdentifier.of(3, BucketAssignerState.start(25)),
+                BucketStateAndIdentifier.of(3, BucketAssignerState.immediatelyClosing(25, 41)),
+                BucketStateAndIdentifier.of(4, BucketAssignerState.start(41)),
+                BucketStateAndIdentifier.of(4, BucketAssignerState.immediatelyClosing(41, 114)),
+                BucketStateAndIdentifier.of(5, BucketAssignerState.start(114)),
+                BucketStateAndIdentifier.of(5, BucketAssignerState.immediatelyClosing(114, 221)),
+                BucketStateAndIdentifier.of(6, BucketAssignerState.start(221)));
+        verify(metrics).progressedToBucketIdentifier(5); // We haven't entered 6 yet.
+
+        // We should not even be trying to transition to the next state after max iterations.
+        verifyNoMoreInteractions(closeTimestampCalculator);
+
+        when(closeTimestampCalculator.apply(221L)).thenReturn(OptionalLong.empty());
+        stateTable.resetInitialState(6, BucketAssignerState.start(221));
+        bucketAssigner.run();
+        verify(metrics).progressedToBucketIdentifier(6);
+        stateTable.assertThatStateMachineTransitionedThroughTo(
+                BucketStateAndIdentifier.of(6, BucketAssignerState.opening(221)),
+                BucketStateAndIdentifier.of(6, BucketAssignerState.waitingUntilCloseable(221)));
+    }
+
+    @ParameterizedTest(name = "State: {0}")
+    @MethodSource("writingStates")
+    public void statesThatWriteBucketsStayInCurrentStateIfWritesFailDueToContention(
+            BucketAssignerState state, Optional<TimestampRange> expectedOldRange, TimestampRange expectedNewRange) {
+        stateTable.setInitialState(1, state);
+        when(bucketWriter.writeToAllBuckets(1, expectedOldRange, expectedNewRange))
+                .thenReturn(WriteState.FAILED_CAS);
+
+        bucketAssigner.run();
+        assertOperationResult(OperationResult.CONTENTION_ON_WRITES);
+        stateTable.assertThatStateMachineTransitionedThroughTo(); // No transition
+    }
+
+    @ParameterizedTest(name = "State: {0}")
+    @MethodSource("writingStates")
+    public void statesThatWriteBucketsStayInCurrentStateAndBubbleUpBucketWriteException(
+            BucketAssignerState state, Optional<TimestampRange> expectedOldRange, TimestampRange expectedNewRange) {
+        stateTable.setInitialState(1, state);
+        when(bucketWriter.writeToAllBuckets(1, expectedOldRange, expectedNewRange))
+                .thenThrow(RUNTIME_EXCEPTION);
+
+        assertThatThrownBy(bucketAssigner::run).isEqualTo(RUNTIME_EXCEPTION);
+        stateTable.assertThatStateMachineTransitionedThroughTo(); // No transition
+    }
+
+    @ParameterizedTest(name = "State: {0}")
+    @MethodSource("transitionToWritingStates")
+    public void transitionsToWriteStateStayInNewStateIfWritesFailDueToContention(
+            BucketAssignerState state,
+            Optional<TimestampRange> expectedOldRange,
+            TimestampRange expectedNewRange,
+            OptionalLong closeTimestamp,
+            BucketAssignerState expectedNewState) {
+        stateTable.setInitialState(1, state);
+        when(closeTimestampCalculator.apply(1L)).thenReturn(closeTimestamp);
+        when(bucketWriter.writeToAllBuckets(1, expectedOldRange, expectedNewRange))
+                .thenReturn(WriteState.FAILED_CAS);
+
+        bucketAssigner.run();
+        assertOperationResult(OperationResult.CONTENTION_ON_WRITES);
+        stateTable.assertThatStateMachineTransitionedThroughTo(BucketStateAndIdentifier.of(1, expectedNewState));
+    }
+
+    @ParameterizedTest(name = "State: {0}")
+    @MethodSource("transitionToWritingStates")
+    public void transitionsToWriteStateStayInNewStateIfWritesFailDueToException(
+            BucketAssignerState state,
+            Optional<TimestampRange> expectedOldRange,
+            TimestampRange expectedNewRange,
+            OptionalLong closeTimestamp,
+            BucketAssignerState expectedNewState) {
+        stateTable.setInitialState(1, state);
+        when(closeTimestampCalculator.apply(1L)).thenReturn(closeTimestamp);
+        when(bucketWriter.writeToAllBuckets(1, expectedOldRange, expectedNewRange))
+                .thenThrow(RUNTIME_EXCEPTION);
+
+        assertThatThrownBy(bucketAssigner::run).isEqualTo(RUNTIME_EXCEPTION);
+        stateTable.assertThatStateMachineTransitionedThroughTo(BucketStateAndIdentifier.of(1, expectedNewState));
+    }
+
+    @ParameterizedTest(name = "State: {0}")
+    @MethodSource("transitionToWritingStates")
+    public void transitionsToWriteStateStayInNewStateIfBucketWriteThrowsException(
+            BucketAssignerState state,
+            Optional<TimestampRange> expectedOldRange,
+            TimestampRange expectedNewRange,
+            OptionalLong closeTimestamp,
+            BucketAssignerState expectedNewState) {
+        stateTable.setInitialState(1, state);
+        when(closeTimestampCalculator.apply(1L)).thenReturn(closeTimestamp);
+        when(bucketWriter.writeToAllBuckets(1, expectedOldRange, expectedNewRange))
+                .thenThrow(RUNTIME_EXCEPTION);
+
+        assertThatThrownBy(bucketAssigner::run).isEqualTo(RUNTIME_EXCEPTION);
+        stateTable.assertThatStateMachineTransitionedThroughTo(BucketStateAndIdentifier.of(1, expectedNewState));
+    }
+
+    private static Stream<Arguments> writingStates() {
+        return Stream.of(
+                Arguments.of(BucketAssignerState.opening(1), Optional.empty(), TimestampRange.openBucket(1)),
+                Arguments.of(
+                        BucketAssignerState.closingFromOpen(1, 2),
+                        Optional.of(TimestampRange.openBucket(1)),
+                        TimestampRange.of(1, 2)),
+                Arguments.of(
+                        BucketAssignerState.immediatelyClosing(1, 15), Optional.empty(), TimestampRange.of(1, 15)));
+    }
+
+    private static Stream<Arguments> transitionToWritingStates() {
+        return Stream.of(
+                Arguments.of(
+                        BucketAssignerState.start(1),
+                        Optional.empty(),
+                        TimestampRange.openBucket(1),
+                        OptionalLong.empty(),
+                        BucketAssignerState.opening(1)),
+                Arguments.of(
+                        BucketAssignerState.start(1),
+                        Optional.empty(),
+                        TimestampRange.of(1, 2),
+                        OptionalLong.of(2),
+                        BucketAssignerState.immediatelyClosing(1, 2)),
+                Arguments.of(
+                        BucketAssignerState.waitingUntilCloseable(1),
+                        Optional.of(TimestampRange.openBucket(1)),
+                        TimestampRange.of(1, 3),
+                        OptionalLong.of(3),
+                        BucketAssignerState.closingFromOpen(1, 3)));
+    }
+
+    private void assertOperationResult(OperationResult... results) {
+        InOrder inOrder = inOrder(metrics);
+        for (OperationResult result : results) {
+            inOrder.verify(metrics).operationResultForIteration(result);
+        }
+        // Not called any more times.
+        // We can't use verifyNoMoreInteractions, because that would require verifying no other interactions on the
+        // whole metrics object, which is not what we want.
+        verify(metrics, times(results.length)).operationResultForIteration(any());
+    }
+
+    private static final class TestSweepBucketAssignerStateMachineTable
+            implements SweepBucketAssignerStateMachineTable {
+        private final List<BucketStateAndIdentifier> stateTransitions = new ArrayList<>();
+        private final BucketAssignerMetrics metrics;
+
+        TestSweepBucketAssignerStateMachineTable(BucketAssignerMetrics metrics) {
+            this.metrics = metrics;
+        }
+
+        @Override
+        public void updateStateMachineForBucketAssigner(
+                BucketStateAndIdentifier original, BucketStateAndIdentifier updated) {
+            assertThat(stateTransitions).last().isEqualTo(original);
+            stateTransitions.add(updated);
+        }
+
+        @Override
+        public BucketStateAndIdentifier getBucketStateAndIdentifier() {
+            return stateTransitions.get(stateTransitions.size() - 1);
+        }
+
+        public void setInitialState(long bucketIdentifier, BucketAssignerState state) {
+            assertThat(stateTransitions).isEmpty();
+            stateTransitions.add(BucketStateAndIdentifier.of(bucketIdentifier, state));
+        }
+
+        public void assertThatStateMachineTransitionedThroughTo(BucketStateAndIdentifier... states) {
+            if (states.length == 0) {
+                assertThat(stateTransitions).hasSize(1); // first state
+                verify(metrics, times(1)).bucketAssignerState(any()); // first state
+                return;
+            }
+            List<BucketStateAndIdentifier> transitionedStatesNotIncludingInitial =
+                    stateTransitions.subList(1, stateTransitions.size());
+            assertThat(transitionedStatesNotIncludingInitial).containsExactly(states);
+            InOrder inOrder = inOrder(metrics);
+            // We can include the first state, since we would have recorded a metric on entry, but not the last state.
+            for (BucketStateAndIdentifier state : transitionedStatesNotIncludingInitial.subList(0, states.length - 1)) {
+                inOrder.verify(metrics).bucketAssignerState(state.state());
+            }
+        }
+
+        // Used if we run multiple iterations in a single state - call this to reset the current starting state,
+        // otherwise if you assert the states, you'll get states from the previous run in the assertion
+        public void resetInitialState(long bucketIdentifier, BucketAssignerState newInitialState) {
+            stateTransitions.clear();
+            stateTransitions.add(BucketStateAndIdentifier.of(bucketIdentifier, newInitialState));
+        }
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketWriterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketWriterTest.java
@@ -110,7 +110,7 @@ public final class DefaultBucketWriterTest {
         setupThrowCompareAndSetExceptionOnWrite(SweeperStrategy.THOROUGH, 18);
         assertThat(bucketWriter.writeToAllBuckets(
                         BUCKET_IDENTIFIER, Optional.of(OLD_TIMESTAMP_RANGE), NEW_TIMESTAMP_RANGE))
-                .isEqualTo(WriteState.FAILURE);
+                .isEqualTo(WriteState.FAILED_CAS);
 
         // since it's the second strategy, we should have completed all of the conservative shards.
         assertAllBucketsUpToShardForStrategyUpdatedInOrder(
@@ -126,7 +126,7 @@ public final class DefaultBucketWriterTest {
         setupThrowCompareAndSetExceptionOnWrite(SweeperStrategy.THOROUGH, 0);
         assertThat(bucketWriter.writeToAllBuckets(
                         BUCKET_IDENTIFIER, Optional.of(OLD_TIMESTAMP_RANGE), NEW_TIMESTAMP_RANGE))
-                .isEqualTo(WriteState.FAILURE);
+                .isEqualTo(WriteState.FAILED_CAS);
 
         assertAllBucketsUpToShardForStrategyUpdatedInOrder(
                 SweeperStrategy.CONSERVATIVE, NUMBER_OF_SHARDS, Optional.of(OLD_TIMESTAMP_RANGE));


### PR DESCRIPTION
## General
**Before this PR**:
There was no bucket assigner, and so we cannot dynamically create sweepable buckets of arbitrary size.
**After this PR**:
There is now! This allows us to parallelise by some function of num shards x how far behind we are, increasing our possible parallelism when there's more work
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
Check this against the internal RFC.
*I have not self-reviewed this yet (it's friday night), but the algorithm and contents of tests should be there.*

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
We're doing a bunch of CAS', and this should be fine TM
**What was existing testing like? What have you done to improve it?**:
Added a tonne
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Buckets are assigned with no gaps
**Has the safety of all log arguments been decided correctly?**:
No additional args - happy to add some logs for state transitions, but we have metrics
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Buckets aren't assigned
Buckets are assigned with gaps, leaving data behind in the database.
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
Yes. Lots of CAS
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
If we increase the number of shards, or we need to decouple away from same-timestamp-range-per-shard
## Development Process
**Where should we start reviewing?**:
DefaultBucketAssigner (There's no bucket assigner interface despite the name, but this will probably implement Runnable for use with a locking runner)
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
I could have split the state visitor, but that wouldn't have saved us too much :/
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
