### PR TITLE
[ASTS] feat(bucket-assigner): Closing time calculator

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketCloseTimestampCalculator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketCloseTimestampCalculator.java
@@ -1,0 +1,148 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.atlasdb.cleaner.PuncherStore;
+import com.palantir.lock.client.TimeLockClient;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.function.Supplier;
+
+final class DefaultBucketCloseTimestampCalculator {
+    private static final SafeLogger log = SafeLoggerFactory.get(DefaultBucketCloseTimestampCalculator.class);
+
+    @VisibleForTesting
+    static final Duration TIME_GAP_BETWEEN_BUCKET_START_AND_END = Duration.ofMinutes(10);
+
+    @VisibleForTesting
+    static final long MAX_BUCKET_SIZE_FOR_NON_PUNCHER_CLOSE = 5_000_000_000L;
+
+    @VisibleForTesting
+    static final long MIN_BUCKET_SIZE_FOR_NON_PUNCHER_CLOSE = 50_000L;
+
+    private final PuncherStore puncherStore;
+    private final Supplier<Long> freshTimestampSupplier;
+    private final Clock clock;
+
+    @VisibleForTesting
+    DefaultBucketCloseTimestampCalculator(
+            PuncherStore puncherStore, Supplier<Long> freshTimestampSupplier, Clock clock) {
+        this.puncherStore = puncherStore;
+        this.freshTimestampSupplier = freshTimestampSupplier;
+        this.clock = clock;
+    }
+
+    public static DefaultBucketCloseTimestampCalculator create(
+            PuncherStore puncherStore, TimeLockClient timeLockClient) {
+        return new DefaultBucketCloseTimestampCalculator(
+                puncherStore, timeLockClient::getFreshTimestamp, Clock.systemUTC());
+    }
+
+    // A second possible algorithm, rather than the fixed bounds above, is to (assuming the start timestamp is X):
+    //
+    // * Get your node’s wallclock time (A), and the wallclock time associated with the start timestamp (B).
+    // * Get the latest timestamp from timelock, Y.
+    // * Calculate B - A to get the number of minutes passed, then divide by 10 to get the number of 10 minute blocks
+    // * The end timestamp is X + [(Y - X) / number of blocks]
+    //
+    //
+    // This is essentially performing a linear interpolation, assuming the timestamps are uniformly distributed across
+    // the window from A → B (which is almost certainly not the case, but a good approximation).
+    //
+    // We’re explicitly not doing this algorithm now given the added complexity, but this may be implemented if the
+    // fixed parameters are too coarse.
+    public OptionalLong getBucketCloseTimestamp(long startTimestamp) {
+        long openWallClockTimeMillis = puncherStore.getMillisForTimestamp(startTimestamp);
+        long closeWallClockTimeMillis = openWallClockTimeMillis + TIME_GAP_BETWEEN_BUCKET_START_AND_END.toMillis();
+
+        if (Instant.now(clock).toEpochMilli() < closeWallClockTimeMillis) {
+            return OptionalLong.empty();
+        }
+
+        long finalLogicalTimestamp = puncherStore.get(closeWallClockTimeMillis);
+
+        // if this case happens, it's possibly clockdrift or a delayed write.
+        if (finalLogicalTimestamp <= startTimestamp) {
+            long freshTimestamp = freshTimestampSupplier.get();
+            if (freshTimestamp - startTimestamp < MIN_BUCKET_SIZE_FOR_NON_PUNCHER_CLOSE) {
+                logNonPuncherClose(
+                        "but this is not sufficiently far from the start timestamp to close the bucket.",
+                        finalLogicalTimestamp,
+                        startTimestamp,
+                        openWallClockTimeMillis,
+                        freshTimestamp);
+                return OptionalLong.empty();
+            }
+
+            long cappedTimestamp = Math.min(startTimestamp + MAX_BUCKET_SIZE_FOR_NON_PUNCHER_CLOSE, freshTimestamp);
+            if (cappedTimestamp != freshTimestamp) {
+                logNonPuncherClose(
+                        "but this is too far from the start timestamp. Proposing a capped timestamp {} instead.",
+                        finalLogicalTimestamp,
+                        startTimestamp,
+                        openWallClockTimeMillis,
+                        freshTimestamp,
+                        SafeArg.of("cappedTimestamp", cappedTimestamp));
+            } else {
+                logNonPuncherClose(
+                        "and this is sufficiently far from the start timestamp to close the bucket.",
+                        finalLogicalTimestamp,
+                        startTimestamp,
+                        openWallClockTimeMillis,
+                        freshTimestamp);
+            }
+            return OptionalLong.of(cappedTimestamp);
+        } else {
+            return OptionalLong.of(finalLogicalTimestamp);
+        }
+    }
+
+    private void logNonPuncherClose(
+            @CompileTimeConstant String logMessageSuffix,
+            long finalTimestampFromPunchTable,
+            long startTimestamp,
+            long openWallClockTimeMillis,
+            long freshTimestamp,
+            Arg<?>... additionalArgs) {
+        List<Arg<?>> args = ImmutableList.<Arg<?>>builder()
+                .add(
+                        SafeArg.of("finalTimestampFromPunchTable", finalTimestampFromPunchTable),
+                        SafeArg.of("startTimestamp", startTimestamp),
+                        SafeArg.of("timeGap", TIME_GAP_BETWEEN_BUCKET_START_AND_END),
+                        SafeArg.of("openWallClockTimeMillis", openWallClockTimeMillis),
+                        SafeArg.of("freshTimestamp", freshTimestamp))
+                .addAll(Arrays.asList(additionalArgs))
+                .build();
+        log.info(
+                "Read a logical timestamp {} from the puncher store that's less than or equal to the start timestamp"
+                        + " {}, despite requesting a time {} after the start timestamp's associated wall clock time {}."
+                        + " This is likely due to some form of clock drift, but should not be happening repeatedly.  We"
+                        + " read a fresh timestamp {}, " + logMessageSuffix,
+                args);
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketCloseTimestampCalculatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketCloseTimestampCalculatorTest.java
@@ -1,0 +1,163 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import static com.palantir.atlasdb.sweep.asts.bucketingthings.DefaultBucketCloseTimestampCalculator.MAX_BUCKET_SIZE_FOR_NON_PUNCHER_CLOSE;
+import static com.palantir.atlasdb.sweep.asts.bucketingthings.DefaultBucketCloseTimestampCalculator.MIN_BUCKET_SIZE_FOR_NON_PUNCHER_CLOSE;
+import static com.palantir.atlasdb.sweep.asts.bucketingthings.DefaultBucketCloseTimestampCalculator.TIME_GAP_BETWEEN_BUCKET_START_AND_END;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.palantir.atlasdb.cleaner.PuncherStore;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public final class DefaultBucketCloseTimestampCalculatorTest {
+    private final AtomicLong freshTimestamp = new AtomicLong(0);
+    private final FakeClock clock = new FakeClock();
+
+    @Mock
+    private PuncherStore puncherStore;
+
+    private DefaultBucketCloseTimestampCalculator bucketCloseTimestampCalculator;
+
+    @BeforeEach
+    public void setup() {
+        bucketCloseTimestampCalculator =
+                new DefaultBucketCloseTimestampCalculator(puncherStore, freshTimestamp::get, clock);
+    }
+
+    @Test
+    public void returnsEmptyIfSufficientTimeHasNotPassedSinceStartTimestamp() {
+        int startTimestamp = 18; // Arbitrarily chosen.
+        when(puncherStore.getMillisForTimestamp(startTimestamp)).thenReturn(clock.millis());
+        OptionalLong maybeEndTimestamp = bucketCloseTimestampCalculator.getBucketCloseTimestamp(startTimestamp);
+        assertThat(maybeEndTimestamp).isEmpty();
+    }
+
+    @Test
+    public void
+            returnsLogicalTimestampSufficientTimeAfterStartTimestampIfTenMinutesHasPassedAndLogicalTimestampAheadOfStart() {
+        int startTimestamp = 123;
+        when(puncherStore.getMillisForTimestamp(startTimestamp)).thenReturn(clock.millis());
+        clock.advance(TIME_GAP_BETWEEN_BUCKET_START_AND_END);
+        when(puncherStore.get(clock.millis())).thenReturn(153L);
+
+        OptionalLong maybeEndTimestamp = bucketCloseTimestampCalculator.getBucketCloseTimestamp(startTimestamp);
+        assertThat(maybeEndTimestamp).hasValue(153L);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {2300, 2315}) // less than, and equal to.
+    // This is to test what happens when the puncher store returns a timestamp less than (or equal to) the start
+    // timestamp
+    // In both of these cases, we should not use the punch table result, but instead fallback to the relevant algorithm.
+    public void
+            returnsEmptyIfSufficientTimeHasPassedPuncherTimestampBeforeStartAndLatestFreshTimestampNotFarEnoughAhead(
+                    long puncherTimestamp) {
+        int startTimestamp = 2315;
+        when(puncherStore.getMillisForTimestamp(startTimestamp)).thenReturn(clock.millis());
+        clock.advance(TIME_GAP_BETWEEN_BUCKET_START_AND_END);
+        when(puncherStore.get(clock.millis())).thenReturn(puncherTimestamp);
+
+        freshTimestamp.set(MIN_BUCKET_SIZE_FOR_NON_PUNCHER_CLOSE - 1 + startTimestamp);
+
+        OptionalLong maybeEndTimestamp = bucketCloseTimestampCalculator.getBucketCloseTimestamp(startTimestamp);
+        assertThat(maybeEndTimestamp).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {123, 35124})
+    public void
+            returnsLatestFreshTimestampIfSufficientTimeHasPassedPuncherTimestampBeforeStartAndCalculatedTimestampFarEnoughAhead(
+                    long puncherTimestamp) {
+        int startTimestamp = 35124;
+        when(puncherStore.getMillisForTimestamp(startTimestamp)).thenReturn(clock.millis());
+        clock.advance(TIME_GAP_BETWEEN_BUCKET_START_AND_END);
+        when(puncherStore.get(clock.millis())).thenReturn(puncherTimestamp);
+
+        freshTimestamp.set(MIN_BUCKET_SIZE_FOR_NON_PUNCHER_CLOSE + 1 + startTimestamp);
+
+        OptionalLong maybeEndTimestamp = bucketCloseTimestampCalculator.getBucketCloseTimestamp(startTimestamp);
+        assertThat(maybeEndTimestamp).hasValue(freshTimestamp.get());
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {98, 100})
+    public void returnsCappedTimestampIfPuncherTimestampBeforeStartAndLatestFreshTimestampIsTooFarAhead(
+            long puncherTimestamp) {
+        int startTimestamp = 100;
+        when(puncherStore.getMillisForTimestamp(startTimestamp)).thenReturn(clock.millis());
+        clock.advance(TIME_GAP_BETWEEN_BUCKET_START_AND_END);
+        when(puncherStore.get(clock.millis())).thenReturn(puncherTimestamp);
+
+        freshTimestamp.set(2 * MAX_BUCKET_SIZE_FOR_NON_PUNCHER_CLOSE);
+
+        OptionalLong maybeEndTimestamp = bucketCloseTimestampCalculator.getBucketCloseTimestamp(startTimestamp);
+        assertThat(maybeEndTimestamp).hasValue(startTimestamp + MAX_BUCKET_SIZE_FOR_NON_PUNCHER_CLOSE);
+    }
+
+    // TODO(mdaudali): Extract this into its own class if we end up needing this elsewhere.
+    private static final class FakeClock extends Clock {
+        public static final Instant BASE = Instant.parse("1999-04-20T20:15:00Z");
+
+        private final ZoneId zoneId;
+        private final AtomicReference<Instant> currentTime;
+
+        FakeClock(AtomicReference<Instant> currentTime, ZoneId zoneId) {
+            this.currentTime = currentTime;
+            this.zoneId = zoneId;
+        }
+
+        FakeClock() {
+            this(new AtomicReference<>(BASE), ZoneId.of("Europe/London"));
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return zoneId;
+        }
+
+        @Override
+        public Clock withZone(ZoneId _zone) {
+            return new FakeClock(currentTime, zoneId);
+        }
+
+        @Override
+        public Instant instant() {
+            return currentTime.get();
+        }
+
+        public FakeClock advance(Duration difference) {
+            currentTime.getAndUpdate(current -> current.plus(difference));
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
(It's easier to read in the quip, but posting here for explicitness)
In BucketAssigner, it's possible for the possible case to occur
It’s possible for the punch table to have entries the look like:


Logical timestamp	Wallclock time		
1000	12:10 am		
1513	12:00 am		
			
			
			

(Explicitly, where an older logical timestamp is associated with a later wallclock time). This can happen due to a delayed punch table write, or clock drift (e.g the node writing 1000 was ahead of the one writing 1513. This could be because the 1000 node drifted forward, or the 1513 drifted backwards).

Given this, it’s possible for the following sequence of events to occur:

1. Start on [1513, -1 {representing an open bucket})
2. Load the wallclock time for the start, to get 00:00:00. 
3. Add 10 minutes, to get 00:10:00.
4. Resolve the logical timestamp associated with that wallclock time, to get 1000, leaving us with the range [1513, 1000), which is invalid.

It does not suffice to simply fail here, as we would never recover (without overwriting / corrupting the punch table in such a way as to cause the 00:10:00 read to resolve to a higher logical timestamp).

To make progress, we propose the following additional steps:

1. Detect that the endTimestamp < startTimestamp
2. Load the latest fresh timestamp from Timelock, say Y. Y is guaranteed to be higher than the start timestamp, given Timelock’s guarantees.
3. Set the endTimestamp to be min(start + 5B, Y), with a minimum size of 50K
    1. Three explicit decisions here:
        1. We choose not to set to Y in all cases, as it’s possible for Y >> start. If we were to set the end to Y in such case, we would, in our current implementation, sweep all of [start, Y) for a given (shard, strategy) in a single thread (rather than leverage sweeping in parallel), as we only parallelise at the level of buckets.
        2. We choose start + 5B as the cutoff. The choice of 5B here was somewhat arbitrary, but it is large enough that we’re more likely to have a decent amount of data to sweep in such range, but low enough that we’ll still be able to break up large amounts of work into different buckets. Importantly, it’s larger than the amount of timestamps that large internal stack and product generates
        3. We choose a minimum size of 50K, to ensure the bucket isn’t terribly small. A somewhat arbitrary number, but it is the size of a fine partition. This is low enough that services will be able to progress past this size relatively quickly, and where they cannot, we almost certainly do not need to parallelise sweep significantly to keep up to date.
    2. While Y is almost certainly larger than the immutable timestamp, it is safe for us to use that as a bucket endpoint. This is because the sweeper task itself determines up to which point it can progress to, and so the bucket assigner is not constrained to choosing endpoints below the immutable timestamp (as is possible even without the clockdrift case).



**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
I don't think any at this point, other than verifying correctness. _(not self reviewed yet, given the time!)_

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/a
**What was existing testing like? What have you done to improve it?**:
Added tests
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Log messages appear when they need to!
**Has the safety of all log arguments been decided correctly?**:
Yes - just timestamps
**Will this change significantly affect our spending on metrics or logs?**:
No, it shouldn't!
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Closed times are just wacky
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Perhaps the thresholds need changing. I've outlined another algorithm to do so, but it's unnecessary complexity for our current needs and easy to switch over.
## Development Process
**Where should we start reviewing?**:
DefaultBucketCloseTimestampCalculator
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
