### PR TITLE
[PDS-594882] Bump timestamp cache size limit to 100k

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -70,8 +70,12 @@ import org.immutables.value.Value;
 final class TimestampStateStore {
     private static final SafeLogger log = SafeLoggerFactory.get(TimestampStateStore.class);
 
+    // The purpose of this relates to concern about the timestamp state store using excessive memory.
+    // Each mapping is associated with a long (start timestamp), three UUIDs and two longs maximum (timestamp map)
+    // and a reverse mapping of two longs in livingVersions. So even in the largest case, we have ~100 bytes per
+    // mapping, meaning that the timestamp cache size should not exceed ~10 MiB.
     @VisibleForTesting
-    static final int MAXIMUM_SIZE = 20_000;
+    static final int MAXIMUM_SIZE = 100_000;
 
     private final NavigableMap<StartTimestamp, TimestampVersionInfo> timestampMap = new ConcurrentSkipListMap<>();
     private final ConcurrentMap<Sequence, NavigableSet<StartTimestamp>> livingVersions = new ConcurrentHashMap<>();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/watch/TimestampStateStore.java
@@ -70,7 +70,7 @@ import org.immutables.value.Value;
 final class TimestampStateStore {
     private static final SafeLogger log = SafeLoggerFactory.get(TimestampStateStore.class);
 
-    // The purpose of this relates to concern about the timestamp state store using excessive memory.
+    // The purpose of this relates to a concern about the timestamp state store using excessive memory.
     // Each mapping is associated with a long (start timestamp), three UUIDs and two longs maximum (timestamp map)
     // and a reverse mapping of two longs in livingVersions. So even in the largest case, we have ~100 bytes per
     // mapping, meaning that the timestamp cache size should not exceed ~10 MiB.


### PR DESCRIPTION
## General
**Before this PR**: The timestamp cache size maxes out at 20,000; this means that in situations where user transaction tasks or the underlying database is slow and we have many transactions that end up operating in parallel, we may permanently disable the timestamp cache even when the reason for said slowness has abated.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Timestamp cache size limits are increased to 100,000. This is expected to use not more than 10 MiB of memory.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
- A probably better alternative design is to temporarily disable caching in this situation until the number of transactions has gone below the maximum, and then re-enable. However, this requires quite a bit of caution (e.g., requests to get commit timestamps must know to actually request events from the last time they were successful; critical failures during the temporarily disabled period should move the system to being permanently disabled) and so I view this as having a substantially larger scope - given resourcing concerns and that the workaround is simple once known, I prefer this solution. This will be paired with some internal work to improve the visibility of this situation.

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes 

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: That 100k is enough. We'll see errors if that's not true.

**What was existing testing like? What have you done to improve it?**: There is a test that checks that we fall back, but that uses this constant. (The cache class in general has unit tests.)

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: N/A

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**: We don't see this happen.

**Has the safety of all log arguments been decided correctly?**: N/A

**Will this change significantly affect our spending on metrics or logs?**: No

**How would I tell that this PR does not work in production? (monitors, etc.)**: This continues to happen and we see the fallback message say the size was 20k, not 100k.

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**: Rollback

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: I don't think so:  the memory usage has some estimations.

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: This is covered in the metrics section.

## Development Process
**Where should we start reviewing?**: The one file

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju
