### PR TITLE
[ASTS] fix: update name in generated code

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepBucketProgressTable.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/schema/generated/SweepBucketProgressTable.java
@@ -141,7 +141,7 @@ public final class SweepBucketProgressTable implements
      *   {@literal Long hashOfRowComponents};
      *   {@literal Long shard};
      *   {@literal Long bucketIdentifier};
-     *   {@literal byte[] sweepConservative};
+     *   {@literal byte[] strategy};
      * }
      * </pre>
      */
@@ -149,18 +149,18 @@ public final class SweepBucketProgressTable implements
         private final long hashOfRowComponents;
         private final long shard;
         private final long bucketIdentifier;
-        private final byte[] sweepConservative;
+        private final byte[] strategy;
 
-        public static SweepBucketProgressRow of(long shard, long bucketIdentifier, byte[] sweepConservative) {
-            long hashOfRowComponents = computeHashFirstComponents(shard, bucketIdentifier, sweepConservative);
-            return new SweepBucketProgressRow(hashOfRowComponents, shard, bucketIdentifier, sweepConservative);
+        public static SweepBucketProgressRow of(long shard, long bucketIdentifier, byte[] strategy) {
+            long hashOfRowComponents = computeHashFirstComponents(shard, bucketIdentifier, strategy);
+            return new SweepBucketProgressRow(hashOfRowComponents, shard, bucketIdentifier, strategy);
         }
 
-        private SweepBucketProgressRow(long hashOfRowComponents, long shard, long bucketIdentifier, byte[] sweepConservative) {
+        private SweepBucketProgressRow(long hashOfRowComponents, long shard, long bucketIdentifier, byte[] strategy) {
             this.hashOfRowComponents = hashOfRowComponents;
             this.shard = shard;
             this.bucketIdentifier = bucketIdentifier;
-            this.sweepConservative = sweepConservative;
+            this.strategy = strategy;
         }
 
         public long getShard() {
@@ -171,8 +171,8 @@ public final class SweepBucketProgressTable implements
             return bucketIdentifier;
         }
 
-        public byte[] getSweepConservative() {
-            return sweepConservative;
+        public byte[] getStrategy() {
+            return strategy;
         }
 
         public static Function<SweepBucketProgressRow, Long> getShardFun() {
@@ -193,11 +193,11 @@ public final class SweepBucketProgressTable implements
             };
         }
 
-        public static Function<SweepBucketProgressRow, byte[]> getSweepConservativeFun() {
+        public static Function<SweepBucketProgressRow, byte[]> getStrategyFun() {
             return new Function<SweepBucketProgressRow, byte[]>() {
                 @Override
                 public byte[] apply(SweepBucketProgressRow row) {
-                    return row.sweepConservative;
+                    return row.strategy;
                 }
             };
         }
@@ -207,8 +207,8 @@ public final class SweepBucketProgressTable implements
             byte[] hashOfRowComponentsBytes = PtBytes.toBytes(Long.MIN_VALUE ^ hashOfRowComponents);
             byte[] shardBytes = EncodingUtils.encodeUnsignedVarLong(shard);
             byte[] bucketIdentifierBytes = EncodingUtils.encodeUnsignedVarLong(bucketIdentifier);
-            byte[] sweepConservativeBytes = sweepConservative;
-            return EncodingUtils.add(hashOfRowComponentsBytes, shardBytes, bucketIdentifierBytes, sweepConservativeBytes);
+            byte[] strategyBytes = strategy;
+            return EncodingUtils.add(hashOfRowComponentsBytes, shardBytes, bucketIdentifierBytes, strategyBytes);
         }
 
         public static final Hydrator<SweepBucketProgressRow> BYTES_HYDRATOR = new Hydrator<SweepBucketProgressRow>() {
@@ -221,16 +221,16 @@ public final class SweepBucketProgressTable implements
                 __index += EncodingUtils.sizeOfUnsignedVarLong(shard);
                 long bucketIdentifier = EncodingUtils.decodeUnsignedVarLong(__input, __index);
                 __index += EncodingUtils.sizeOfUnsignedVarLong(bucketIdentifier);
-                byte[] sweepConservative = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
-                return new SweepBucketProgressRow(hashOfRowComponents, shard, bucketIdentifier, sweepConservative);
+                byte[] strategy = EncodingUtils.getBytesFromOffsetToEnd(__input, __index);
+                return new SweepBucketProgressRow(hashOfRowComponents, shard, bucketIdentifier, strategy);
             }
         };
 
-        public static long computeHashFirstComponents(long shard, long bucketIdentifier, byte[] sweepConservative) {
+        public static long computeHashFirstComponents(long shard, long bucketIdentifier, byte[] strategy) {
             byte[] shardBytes = EncodingUtils.encodeUnsignedVarLong(shard);
             byte[] bucketIdentifierBytes = EncodingUtils.encodeUnsignedVarLong(bucketIdentifier);
-            byte[] sweepConservativeBytes = sweepConservative;
-            return Hashing.murmur3_128().hashBytes(EncodingUtils.add(shardBytes, bucketIdentifierBytes, sweepConservativeBytes)).asLong();
+            byte[] strategyBytes = strategy;
+            return Hashing.murmur3_128().hashBytes(EncodingUtils.add(shardBytes, bucketIdentifierBytes, strategyBytes)).asLong();
         }
 
         @Override
@@ -239,7 +239,7 @@ public final class SweepBucketProgressTable implements
                 .add("hashOfRowComponents", hashOfRowComponents)
                 .add("shard", shard)
                 .add("bucketIdentifier", bucketIdentifier)
-                .add("sweepConservative", sweepConservative)
+                .add("strategy", strategy)
                 .toString();
         }
 
@@ -255,12 +255,12 @@ public final class SweepBucketProgressTable implements
                 return false;
             }
             SweepBucketProgressRow other = (SweepBucketProgressRow) obj;
-            return Objects.equals(hashOfRowComponents, other.hashOfRowComponents) && Objects.equals(shard, other.shard) && Objects.equals(bucketIdentifier, other.bucketIdentifier) && Arrays.equals(sweepConservative, other.sweepConservative);
+            return Objects.equals(hashOfRowComponents, other.hashOfRowComponents) && Objects.equals(shard, other.shard) && Objects.equals(bucketIdentifier, other.bucketIdentifier) && Arrays.equals(strategy, other.strategy);
         }
 
         @Override
         public int hashCode() {
-            return Arrays.deepHashCode(new Object[]{ hashOfRowComponents, shard, bucketIdentifier, sweepConservative });
+            return Arrays.deepHashCode(new Object[]{ hashOfRowComponents, shard, bucketIdentifier, strategy });
         }
 
         @Override
@@ -269,7 +269,7 @@ public final class SweepBucketProgressTable implements
                 .compare(this.hashOfRowComponents, o.hashOfRowComponents)
                 .compare(this.shard, o.shard)
                 .compare(this.bucketIdentifier, o.bucketIdentifier)
-                .compare(this.sweepConservative, o.sweepConservative, UnsignedBytes.lexicographicalComparator())
+                .compare(this.strategy, o.strategy, UnsignedBytes.lexicographicalComparator())
                 .result();
         }
     }
@@ -730,5 +730,5 @@ public final class SweepBucketProgressTable implements
      * {@link UnsignedBytes}
      * {@link ValueType}
      */
-    static String __CLASS_HASH = "boBsLMY3fSdKaI1RwPLdFA==";
+    static String __CLASS_HASH = "rTx91wHW58PfFODPz+Naxw==";
 }

--- a/changelog/@unreleased/pr-7279.v2.yml
+++ b/changelog/@unreleased/pr-7279.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Update name in generated code
+  links:
+  - https://github.com/palantir/atlasdb/pull/7279


### PR DESCRIPTION
## General
**Before this PR**:
https://github.com/palantir/atlasdb/pull/7200 added a new table (sweepProgressForBucket).

While it did generate the code, the generated code does not match the _actual_ schema from the latest commit in that PR  (https://github.com/palantir/atlasdb/pull/7200/files), but instead from an old commit here: https://github.com/palantir/atlasdb/pull/7200/commits/26458c20be415a53486fc19e635b4d79d77c5ba9


**After this PR**:
Regenerates the schema correctly.
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
None - we don't use this table yet.
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
