### PR TITLE
Add tracing to #putUnlessExists.

### DIFF
--- a/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
+++ b/atlasdb-cassandra/src/main/java/com/palantir/atlasdb/keyvalue/cassandra/TracingCassandraClient.java
@@ -179,6 +179,23 @@ public class TracingCassandraClient implements AutoDelegate_CassandraClient {
     }
 
     @Override
+    public CASResult put_unless_exists(
+            TableReference tableReference,
+            ByteBuffer key,
+            List<Column> updates,
+            ConsistencyLevel serial_consistency_level,
+            ConsistencyLevel commit_consistency_level)
+            throws InvalidRequestException, UnavailableException, TimedOutException, TException {
+        try (CloseableTracer trace = startLocalTrace("cassandra-thrift-client.client.put_unless_exists", sink -> {
+            sink.tableRef(tableReference);
+            sink.size("updates", updates);
+        })) {
+            return client.put_unless_exists(
+                    tableReference, key, updates, serial_consistency_level, commit_consistency_level);
+        }
+    }
+
+    @Override
     public CqlResult execute_cql3_query(CqlQuery cqlQuery, Compression compression, ConsistencyLevel consistency)
             throws InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException,
                     TException {


### PR DESCRIPTION
## General
**Before this PR**:

No traces on #putUnlessExists, which is still used all over the place.

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add tracing to #putUnlessExists.
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

Generally, we only have a single one of these in flight (it's autobatched), so we shouldn't be scared of tracing it. Certainly this is cheap, compared to put/get methods.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
