### PR TITLE
Do not fail when query contains duplicate row with local write

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -251,6 +251,32 @@ acceptedBreaks:
         \ com.palantir.atlasdb.keyvalue.cassandra.Blacklist, com.palantir.atlasdb.keyvalue.cassandra.pool.CassandraClientPoolMetrics,\
         \ com.palantir.atlasdb.keyvalue.cassandra.CassandraClientMetrics)"
       justification: "Unused outside atlas"
+  "0.1152.0":
+    com.palantir.atlasdb:atlasdb-api:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter java.util.NavigableMap<byte[], com.palantir.atlasdb.keyvalue.api.RowResult<byte[]>>\
+        \ com.palantir.atlasdb.transaction.api.snapshot.AutoDelegate_KeyValueSnapshotReader::getRows(com.palantir.atlasdb.keyvalue.api.TableReference,\
+        \ java.lang.Iterable<byte[]>, com.palantir.atlasdb.keyvalue.api.ColumnSelection,\
+        \ ===com.google.common.collect.ImmutableMap.Builder<com.palantir.atlasdb.keyvalue.api.Cell,\
+        \ byte[]>===)"
+      new: "parameter java.util.NavigableMap<byte[], com.palantir.atlasdb.keyvalue.api.RowResult<byte[]>>\
+        \ com.palantir.atlasdb.transaction.api.snapshot.AutoDelegate_KeyValueSnapshotReader::getRows(com.palantir.atlasdb.keyvalue.api.TableReference,\
+        \ java.lang.Iterable<byte[]>, com.palantir.atlasdb.keyvalue.api.ColumnSelection,\
+        \ ===java.util.Map<com.palantir.atlasdb.keyvalue.api.Cell, byte[]>===)"
+      justification: "KeyValueSnapshotReader is a relatively new API and is not widely\
+        \ used"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter java.util.NavigableMap<byte[], com.palantir.atlasdb.keyvalue.api.RowResult<byte[]>>\
+        \ com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReader::getRows(com.palantir.atlasdb.keyvalue.api.TableReference,\
+        \ java.lang.Iterable<byte[]>, com.palantir.atlasdb.keyvalue.api.ColumnSelection,\
+        \ ===com.google.common.collect.ImmutableMap.Builder<com.palantir.atlasdb.keyvalue.api.Cell,\
+        \ byte[]>===)"
+      new: "parameter java.util.NavigableMap<byte[], com.palantir.atlasdb.keyvalue.api.RowResult<byte[]>>\
+        \ com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReader::getRows(com.palantir.atlasdb.keyvalue.api.TableReference,\
+        \ java.lang.Iterable<byte[]>, com.palantir.atlasdb.keyvalue.api.ColumnSelection,\
+        \ ===java.util.Map<com.palantir.atlasdb.keyvalue.api.Cell, byte[]>===)"
+      justification: "KeyValueSnapshotReader is a relatively new API and is not widely\
+        \ used"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/snapshot/KeyValueSnapshotReader.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/snapshot/KeyValueSnapshotReader.java
@@ -16,7 +16,6 @@
 
 package com.palantir.atlasdb.transaction.api.snapshot;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
@@ -51,5 +50,5 @@ public interface KeyValueSnapshotReader {
             TableReference tableReference,
             Iterable<byte[]> rows,
             ColumnSelection columnSelection,
-            ImmutableMap.Builder<Cell, byte[]> resultCollector);
+            Map<Cell, byte[]> localWrites);
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -504,16 +504,11 @@ public class SnapshotTransaction extends AbstractTransaction
             return AbstractTransaction.EMPTY_SORTED_ROWS;
         }
         hasReads = true;
-        ImmutableSortedMap.Builder<Cell, byte[]> resultCollector = ImmutableSortedMap.naturalOrder();
         NavigableMap<Cell, byte[]> writes = localWriteBuffer.getLocalWrites().get(tableRef);
-        if (writes != null && !writes.isEmpty()) {
-            for (byte[] row : rows) {
-                extractLocalWritesForRow(resultCollector, writes, row, columnSelection);
-            }
-        }
+        Map<Cell, byte[]> writesForRows = extractLocalWritesForRows(writes, rows, columnSelection);
 
         NavigableMap<byte[], RowResult<byte[]>> results =
-                keyValueSnapshotReader.getRows(tableRef, rows, columnSelection, resultCollector);
+                keyValueSnapshotReader.getRows(tableRef, rows, columnSelection, writesForRows);
         long getRowsMillis = TimeUnit.NANOSECONDS.toMillis(timer.stop());
         if (perfLogger.isDebugEnabled()) {
             perfLogger.debug(
@@ -926,53 +921,55 @@ public class SnapshotTransaction extends AbstractTransaction
 
         // can't skip lock check as we don't know how many cells to expect for the column selection
         validatePreCommitRequirementsOnNonExhaustiveReadIfNecessary(tableRef, getStartTimestamp());
-        return filterRowResults(tableRef, rawResults, ImmutableMap.builderWithExpectedSize(rawResults.size()));
+
+        Map<Cell, byte[]> results = Maps.newHashMapWithExpectedSize(rawResults.size());
+        getWithPostFilteringSync(tableRef, rawResults, Value.GET_VALUE).forEach(e -> {
+            results.put(e.getKey(), e.getValue());
+        });
+
+        removeEmptyColumns(tableRef, results);
+
+        return RowResults.viewOfSortedMap(Cells.breakCellsUpByRow(results));
     }
 
-    private NavigableMap<byte[], RowResult<byte[]>> filterRowResults(
-            TableReference tableRef, Map<Cell, Value> rawResults, ImmutableMap.Builder<Cell, byte[]> resultCollector) {
-        ImmutableMap<Cell, byte[]> collected = resultCollector
-                .putAll(getWithPostFilteringSync(tableRef, rawResults, Value.GET_VALUE))
-                .buildOrThrow();
-        Map<Cell, byte[]> filterDeletedValues = removeEmptyColumns(collected, tableRef);
-        return RowResults.viewOfSortedMap(Cells.breakCellsUpByRow(filterDeletedValues));
-    }
+    private void removeEmptyColumns(TableReference tableReference, Map<Cell, byte[]> results) {
+        int unfilteredSize = results.size();
 
-    private Map<Cell, byte[]> removeEmptyColumns(Map<Cell, byte[]> unfiltered, TableReference tableReference) {
-        Map<Cell, byte[]> filtered = Maps.filterValues(unfiltered, Predicates.not(Value::isTombstone));
-        // compute filtered size without traversing lazily transformed map `size()` as that allocates entries
-        long filteredCount = unfiltered.values().stream()
-                .filter(Predicates.not(Value::isTombstone))
-                .count();
+        results.values().removeIf(Value::isTombstone);
 
-        long emptyValues = unfiltered.size() - filteredCount;
+        int emptyValues = unfilteredSize - results.size();
         snapshotEventRecorder.recordFilteredEmptyValues(tableReference, emptyValues);
         TraceStatistics.incEmptyValues(emptyValues);
-
-        return filtered;
     }
 
     /**
-     * This will add any local writes for this row to the result map.
+     * This will return any local writes for these rows.
      * <p>
      * If an empty value was written as a delete, this will also be included in the map.
      */
-    private void extractLocalWritesForRow(
-            @Output ImmutableMap.Builder<Cell, byte[]> result,
-            SortedMap<Cell, byte[]> writes,
-            byte[] row,
-            ColumnSelection columnSelection) {
-        Cell lowCell = Cells.createSmallestCellForRow(row);
-        for (Map.Entry<Cell, byte[]> entry : writes.tailMap(lowCell).entrySet()) {
-            Cell cell = entry.getKey();
-            if (!Arrays.equals(row, cell.getRowName())) {
-                break;
-            }
-            if (columnSelection.allColumnsSelected()
-                    || columnSelection.getSelectedColumns().contains(cell.getColumnName())) {
-                result.put(cell, entry.getValue());
+    private Map<Cell, byte[]> extractLocalWritesForRows(
+            SortedMap<Cell, byte[]> writes, Iterable<byte[]> rows, ColumnSelection columnSelection) {
+        if (writes == null || writes.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Cell, byte[]> results = new HashMap<>();
+
+        for (byte[] row : rows) {
+            Cell lowCell = Cells.createSmallestCellForRow(row);
+            for (Map.Entry<Cell, byte[]> entry : writes.tailMap(lowCell).entrySet()) {
+                Cell cell = entry.getKey();
+                if (!Arrays.equals(row, cell.getRowName())) {
+                    break;
+                }
+                if (columnSelection.allColumnsSelected()
+                        || columnSelection.getSelectedColumns().contains(cell.getColumnName())) {
+                    results.put(cell, entry.getValue());
+                }
             }
         }
+
+        return Collections.unmodifiableMap(results);
     }
 
     @Override
@@ -1019,14 +1016,14 @@ public class SnapshotTransaction extends AbstractTransaction
         }
         hasReads = true;
 
-        Map<Cell, byte[]> result = new HashMap<>();
+        Map<Cell, byte[]> results = new HashMap<>();
         Map<Cell, byte[]> writes = localWriteBuffer.getLocalWrites().get(tableRef);
         long numberOfNonDeleteLocalWrites = 0;
         if (writes != null && !writes.isEmpty()) {
             for (Cell cell : cells) {
                 byte[] value = writes.get(cell);
                 if (value != null) {
-                    result.put(cell, value);
+                    results.put(cell, value);
                     if (value != PtBytes.EMPTY_BYTE_ARRAY) {
                         numberOfNonDeleteLocalWrites++;
                     }
@@ -1036,12 +1033,12 @@ public class SnapshotTransaction extends AbstractTransaction
 
         // We don't need to read any cells that were written locally.
         long expectedNumberOfPresentCellsToFetch = numberOfExpectedPresentCells - numberOfNonDeleteLocalWrites;
-        Set<Cell> cellsToFetch = Sets.difference(cells, result.keySet());
+        Set<Cell> cellsToFetch = Sets.difference(cells, results.keySet());
         ListenableFuture<Map<Cell, byte[]>> initialResults = keyValueSnapshotReader.getAsync(tableRef, cellsToFetch);
         return Futures.transform(
                 initialResults,
                 fromKeyValueService -> {
-                    result.putAll(fromKeyValueService);
+                    results.putAll(fromKeyValueService);
 
                     long getMillis = TimeUnit.NANOSECONDS.toMillis(timer.stop());
                     if (perfLogger.isDebugEnabled()) {
@@ -1049,7 +1046,7 @@ public class SnapshotTransaction extends AbstractTransaction
                                 "Snapshot transaction get cells (some possibly deleted)",
                                 LoggingArgs.tableRef(tableRef),
                                 SafeArg.of("numberOfCells", cells.size()),
-                                SafeArg.of("numberOfCellsRetrieved", result.size()),
+                                SafeArg.of("numberOfCellsRetrieved", results.size()),
                                 SafeArg.of("getOperation", operationName),
                                 SafeArg.of("durationMillis", getMillis));
                     }
@@ -1060,7 +1057,9 @@ public class SnapshotTransaction extends AbstractTransaction
                             fromKeyValueService.size() == expectedNumberOfPresentCellsToFetch;
                     validatePreCommitRequirementsOnReadIfNecessary(
                             tableRef, getStartTimestamp(), allPossibleCellsReadAndPresent);
-                    return removeEmptyColumns(result, tableRef);
+                    removeEmptyColumns(tableRef, results);
+
+                    return Collections.unmodifiableMap(results);
                 },
                 MoreExecutors.directExecutor());
     }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractTransactionTest.java
@@ -1575,6 +1575,20 @@ public abstract class AbstractTransactionTest extends TransactionTestSetup {
     }
 
     @Test
+    public void getRowsWithDuplicateQueriesOfLocalWrites() {
+        Transaction tx = startTransaction();
+        byte[] row0 = row(0);
+        byte[] anotherRow0 = row(0);
+        byte[] col0 = column(0);
+        tx.put(TEST_TABLE, ImmutableMap.of(Cell.create(row0, col0), value(0)));
+
+        SortedMap<byte[], RowResult<byte[]>> readRows =
+                tx.getRows(TEST_TABLE, ImmutableList.of(row0, anotherRow0), ColumnSelection.all());
+        assertThat(readRows.firstKey()).containsExactly(row0);
+        assertThat(readRows).hasSize(1);
+    }
+
+    @Test
     public void getRowsAppliesColumnSelection() {
         Transaction tx = startTransaction();
         byte[] row0 = row(0);

--- a/changelog/@unreleased/pr-7293.v2.yml
+++ b/changelog/@unreleased/pr-7293.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix bug that causes queries with duplicate rows to fail when the duplicate
+    row has a local write.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7293


### PR DESCRIPTION
**Before this PR**:

When making a query with a duplicate row, if that row has a local write, then the query will throw an `IllegalArgumentException`. I've added a test case that reproduces the failure. Below is the exception that is thrown:

```
java.lang.IllegalArgumentException: Multiple entries with same key: Cell{rowName=726f7730, columnName=636f6c30}=[B@7d47dfed and Cell{rowName=726f7730, columnName=636f6c30}=[B@7d47dfed
	at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:382)
	at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:376)
	at com.google.common.collect.ImmutableSortedMap.fromEntries(ImmutableSortedMap.java:552)
	at com.google.common.collect.ImmutableSortedMap.access$100(ImmutableSortedMap.java:68)
	at com.google.common.collect.ImmutableSortedMap$Builder.buildOrThrow(ImmutableSortedMap.java:730)
	at com.google.common.collect.ImmutableSortedMap$Builder.buildOrThrow(ImmutableSortedMap.java:611)
	at com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReader.getRows(DefaultKeyValueSnapshotReader.java:125)
	at com.palantir.atlasdb.transaction.impl.SnapshotTransaction.getRowsInternal(SnapshotTransaction.java:516)
	at com.palantir.atlasdb.transaction.impl.SnapshotTransaction.getRows(SnapshotTransaction.java:487)
	at com.palantir.atlasdb.transaction.impl.SerializableTransaction.getRows(SerializableTransaction.java:211)
	at com.palantir.atlasdb.transaction.impl.ForwardingTransaction.getRows(ForwardingTransaction.java:59)
	at com.palantir.atlasdb.transaction.impl.AbstractTransactionTest.getRowsWithDuplicateQueriesOfLocalWrites(AbstractTransactionTest.java:1586)
```

AtlasDB claims to support this, and there is an existing `getRowsWithDuplicateQueries` that verifies this. But this test doesn't cover the case when the duplicate row is a local write.

**After this PR**:

Queries with duplicate rows of a local write succeed.

`ImmutableSortedMap.Builder` doesn't support `buildKeepingLast`, so this fix requires a slightly larger refactor.
