### PR TITLE
Improve index conflict handler validation

### DIFF
--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/table/description/Schema.java
@@ -292,10 +292,10 @@ public class Schema {
                         "In index, a component derived from column must reference an existing column");
             }
 
-            if (indexMetadata.getIndexType().equals(IndexType.CELL_REFERENCING)) {
+            if (!indexMetadata.getIndexType().equals(IndexType.ADDITIVE)) {
                 com.palantir.logsafe.Preconditions.checkArgument(
-                        ConflictHandler.RETRY_ON_WRITE_WRITE.equals(tableMetadata.getConflictHandler()),
-                        "Nonadditive indexes require write-write conflicts on their tables");
+                        tableMetadata.getConflictHandler().checkWriteWriteConflicts(),
+                        "Nonadditive indexes must check write-write conflicts");
             }
         }
     }


### PR DESCRIPTION
AtlasDB does not allow schemas with a cell-referencing index whose primary table uses a conflict handler that checks for write-write conflicts but is not specifically `RETRY_WRITE_WRITE` (for example, `SERIALIZABLE`).

We don't need to require `RETRY_WRITE_WRITE` specifically, we just want to make sure that write-write conflicts are checked.