### PR TITLE
[ASTS] fix: run all tests rather than stopping on first failure locally

### DIFF
--- a/changelog/@unreleased/pr-7298.v2.yml
+++ b/changelog/@unreleased/pr-7298.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Run all tests rather than stopping on first failure locally
+  links:
+  - https://github.com/palantir/atlasdb/pull/7298

--- a/gradle/shared.gradle
+++ b/gradle/shared.gradle
@@ -91,7 +91,7 @@ afterEvaluate {
 
 tasks.withType(Test) {
     enableAssertions = true
-    failFast = true
+    failFast = System.getenv().containsKey('CI')
 }
 
 ext.atlasdb_shaded = 'com.palantir.atlasdb.shaded.'


### PR DESCRIPTION
As someone who likes to write tests first for an entire class when scoping things out, having fail fast locally is rather irritating when I want to make sure that, for the methods I have implemented, tests are all passing (and can ignore the ones I haven't implemented).

Having fail fast locally means I have to manually disable tests. 

Fail fast was enabled for CI to reduce CI time, so I'm preserving this behaviour. 

This env var does exist in circle CI: https://circleci.com/docs/variables/