### PR TITLE
[ASTS] feat(bucket-assigner): Persisters for the various value types

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/TimestampRange.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/TimestampRange.java
@@ -16,9 +16,13 @@
 
 package com.palantir.atlasdb.sweep.asts;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@JsonSerialize(as = ImmutableTimestampRange.class)
+@JsonDeserialize(as = ImmutableTimestampRange.class)
 public interface TimestampRange {
     @Value.Parameter
     long startInclusive();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketStateAndIdentifier.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketStateAndIdentifier.java
@@ -16,8 +16,12 @@
 
 package com.palantir.atlasdb.sweep.asts.bucketingthings;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
+@JsonSerialize(as = ImmutableBucketStateAndIdentifier.class)
+@JsonDeserialize(as = ImmutableBucketStateAndIdentifier.class)
 @Value.Immutable
 public interface BucketStateAndIdentifier {
     @Value.Parameter

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/ObjectPersister.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/ObjectPersister.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import com.palantir.logsafe.exceptions.SafeUncheckedIoException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.io.IOException;
+
+// Without a type T, we can't safely implement tryDeserialize without an error of unsafe type cases.
+// Having T also helps give some type safety to prevent accidental screwups when using the many reader writers.
+final class ObjectPersister<T> {
+    private static final SafeLogger log = SafeLoggerFactory.get(ObjectPersister.class);
+    private final ObjectReader reader;
+    private final ObjectWriter writer;
+    private final Class<T> clazz; // Partly exists to "consume" T, but also so that our logs can be more specific.
+    private final LogSafety logSafety;
+
+    private ObjectPersister(ObjectReader reader, ObjectWriter writer, Class<T> clazz, LogSafety logSafety) {
+        this.reader = reader;
+        this.writer = writer;
+        this.clazz = clazz;
+        this.logSafety = logSafety;
+    }
+
+    static <T> ObjectPersister<T> of(ObjectMapper objectMapper, Class<T> clazz, LogSafety logSafetyOfValues) {
+        return new ObjectPersister<>(
+                objectMapper.readerFor(clazz), objectMapper.writerFor(clazz), clazz, logSafetyOfValues);
+    }
+
+    public T tryDeserialize(byte[] bytes) {
+        try {
+            return reader.readValue(bytes);
+        } catch (IOException e) {
+            throw new SafeUncheckedIoException(
+                    "Failed to deserialise {} into {}", e, toArg("bytes", bytes), SafeArg.of("class", clazz.getName()));
+        }
+    }
+
+    public byte[] trySerialize(T object) {
+        try {
+            return writer.writeValueAsBytes(object);
+        } catch (JsonProcessingException e) {
+            throw new SafeUncheckedIoException(
+                    "Failed to serialise {} from {}", e, toArg("object", object), SafeArg.of("class", clazz.getName()));
+        }
+    }
+
+    // Log safety determined at runtime, and so cannot just blanket mark the function as unsafe as it would expect.
+    @SuppressWarnings("SafeLoggingPropagation")
+    private <K> Arg<K> toArg(@CompileTimeConstant String name, K value) {
+        switch (logSafety) {
+            case SAFE:
+                return SafeArg.of(name, value);
+            case UNSAFE:
+                return UnsafeArg.of(name, value);
+            default:
+                log.error("Unexpected log safety level {}", SafeArg.of("logSafety", logSafety));
+                // We're explicitly going against the grain and not throwing. This does mean that we'll fail
+                // silently (other than a log message!), but it's better than causing an accidental outage for something
+                // inconsequential.
+                return UnsafeArg.of(name, value);
+        }
+    }
+
+    enum LogSafety {
+        SAFE,
+        UNSAFE, // No DO_NOT_LOG, as we shouldn't be persisting things you cannot keep on disk safely!
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketIdentifierPersisterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketIdentifierPersisterTest.java
@@ -1,0 +1,61 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.io.BaseEncoding;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.ObjectPersister.LogSafety;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public final class BucketIdentifierPersisterTest {
+    private static final ObjectPersister<Long> PERSISTER =
+            ObjectPersister.of(ObjectMappers.newServerSmileMapper(), Long.class, LogSafety.SAFE);
+
+    private static final long BUCKET_IDENTIFIER_ONE = 12321323918230981L;
+    private static final long BUCKET_IDENTIFIER_TWO = 1239019283092131L;
+
+    // Be very careful about changing these without a migration.
+    private static final byte[] SERIALIZED_BUCKET_IDENTIFIER_ONE =
+            BaseEncoding.base64().decode("OikKBSVXRhZxaXAuig==");
+
+    private static final byte[] SERIALIZED_BUCKET_IDENTIFIER_TWO =
+            BaseEncoding.base64().decode("OikKBSUIZnBqB1EVhg==");
+
+    @ParameterizedTest
+    @MethodSource("bucketIdentifiers")
+    public void deserializingBucketIdentifierIsInverseOfSerialization(long bucketIdentifier) {
+        byte[] serialized = PERSISTER.trySerialize(bucketIdentifier);
+        assertThat(PERSISTER.tryDeserialize(serialized)).isEqualTo(bucketIdentifier);
+    }
+
+    @ParameterizedTest
+    @MethodSource("bucketIdentifiers")
+    public void canDeserializeExistingVersionOfBucketIdentifier(long bucketIdentifier, byte[] serialized) {
+        assertThat(PERSISTER.tryDeserialize(serialized)).isEqualTo(bucketIdentifier);
+    }
+
+    private static Stream<Arguments> bucketIdentifiers() {
+        return Stream.of(
+                Arguments.of(BUCKET_IDENTIFIER_ONE, SERIALIZED_BUCKET_IDENTIFIER_ONE),
+                Arguments.of(BUCKET_IDENTIFIER_TWO, SERIALIZED_BUCKET_IDENTIFIER_TWO));
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketStateAndIdentifierPersisterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/BucketStateAndIdentifierPersisterTest.java
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import static com.palantir.logsafe.testing.Assertions.assertThat;
+
+import com.google.common.io.BaseEncoding;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.ObjectPersister.LogSafety;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public final class BucketStateAndIdentifierPersisterTest {
+    private static final ObjectPersister<BucketStateAndIdentifier> PERSISTER =
+            ObjectPersister.of(ObjectMappers.newServerSmileMapper(), BucketStateAndIdentifier.class, LogSafety.SAFE);
+
+    // We're not enumerating all states here as we test serde in BucketAssignerStateTest
+    private static final BucketStateAndIdentifier BUCKET_STATE_AND_IDENTIFIER_ONE =
+            ImmutableBucketStateAndIdentifier.builder()
+                    .bucketIdentifier(123L)
+                    .state(BucketAssignerState.start(1))
+                    .build();
+
+    private static final BucketStateAndIdentifier BUCKET_STATE_AND_IDENTIFIER_TWO =
+            ImmutableBucketStateAndIdentifier.builder()
+                    .bucketIdentifier(456L)
+                    .state(BucketAssignerState.immediatelyClosing(123, 541))
+                    .build();
+
+    // Be very careful about changing these without a migration.
+    private static final byte[] SERIALIZED_BUCKET_STATE_AND_IDENTIFIER_ONE = BaseEncoding.base64()
+            .decode("OikKBfqPYnVja2V0SWRlbnRpZmllciQDtoRzdGF0ZfqDdHlwZURzdGFydJZzdGFydFRpbWVzdGFtcEluY2x1c2l2ZcL7+w==");
+
+    private static final byte[] SERIALIZED_BUCKET_STATE_AND_IDENTIFIER_TWO = BaseEncoding.base64()
+            .decode(
+                    "OikKBfqPYnVja2V0SWRlbnRpZmllciQOkIRzdGF0ZfqDdHlwZVFpbW1lZGlhdGVseUNsb3NpbmeWc3RhcnRUaW1lc3RhbXBJbmNsdXNpdmUkA7aUZW5kVGltZXN0YW1wRXhjbHVzaXZlJBC6+/s=");
+
+    @ParameterizedTest
+    @MethodSource("bucketStateAndIdentifiers")
+    public void deserializingBucketStateAndIdentifierIsInverseOfSerialization(
+            BucketStateAndIdentifier bucketStateAndIdentifier) {
+        byte[] serialized = PERSISTER.trySerialize(bucketStateAndIdentifier);
+        assertThat(PERSISTER.tryDeserialize(serialized)).isEqualTo(bucketStateAndIdentifier);
+    }
+
+    @ParameterizedTest
+    @MethodSource("bucketStateAndIdentifiers")
+    public void canDeserializeExistingVersionOfBucketStateAndIdentifier(
+            BucketStateAndIdentifier bucketStateAndIdentifier, byte[] serialized) {
+        assertThat(PERSISTER.tryDeserialize(serialized)).isEqualTo(bucketStateAndIdentifier);
+    }
+
+    private static Stream<Arguments> bucketStateAndIdentifiers() {
+        return Stream.of(
+                Arguments.of(BUCKET_STATE_AND_IDENTIFIER_ONE, SERIALIZED_BUCKET_STATE_AND_IDENTIFIER_ONE),
+                Arguments.of(BUCKET_STATE_AND_IDENTIFIER_TWO, SERIALIZED_BUCKET_STATE_AND_IDENTIFIER_TWO));
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/ObjectPersisterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/ObjectPersisterTest.java
@@ -1,0 +1,121 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.ObjectPersister.LogSafety;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import java.io.IOException;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import org.immutables.value.Value;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public final class ObjectPersisterTest {
+    @ParameterizedTest
+    @MethodSource("safety")
+    public void failedSerializationWithLogSafetyThrowsExceptionWithCorrectArgSafety(SafetyAndFactory safetyAndFactory) {
+        ObjectPersister<ImpossibleToSerialize> persister = ObjectPersister.of(
+                ObjectMappers.newServerSmileMapper(), ImpossibleToSerialize.class, safetyAndFactory.safety());
+        ImpossibleToSerialize object = ImpossibleToSerialize.of();
+        assertThatLoggableExceptionThrownBy(() -> persister.trySerialize(object))
+                .hasLogMessage("Failed to serialise {} from {}")
+                .hasExactlyArgs(
+                        safetyAndFactory.createArg("object", object),
+                        SafeArg.of("class", ImpossibleToSerialize.class.getName()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("safety")
+    public void failedDeserializationWithLogSafetyThrowsExceptionWithCorrectArgSafety(
+            SafetyAndFactory safetyAndFactory) {
+        ObjectPersister<ImpossibleToSerialize> persister = ObjectPersister.of(
+                ObjectMappers.newServerSmileMapper(), ImpossibleToSerialize.class, safetyAndFactory.safety());
+        byte[] bytes = new byte[] {1, 2, 3};
+        assertThatLoggableExceptionThrownBy(() -> persister.tryDeserialize(bytes))
+                .hasLogMessage("Failed to deserialise {} into {}")
+                .hasExactlyArgs(
+                        safetyAndFactory.createArg("bytes", bytes),
+                        SafeArg.of("class", ImpossibleToSerialize.class.getName()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0, 1, Long.MAX_VALUE, Long.MIN_VALUE}) // arbitrary
+    public void deserialisationIsInverseOfSerialisation(long value) {
+        ObjectPersister<Long> persister =
+                ObjectPersister.of(ObjectMappers.newServerSmileMapper(), Long.class, LogSafety.SAFE);
+        assertThat(persister.tryDeserialize(persister.trySerialize(value))).isEqualTo(value);
+    }
+
+    private static Stream<SafetyAndFactory> safety() {
+        return Stream.of(
+                ImmutableSafetyAndFactory.of(LogSafety.SAFE, SafeArg::of),
+                ImmutableSafetyAndFactory.of(LogSafety.UNSAFE, UnsafeArg::of));
+    }
+
+    @Value.Immutable
+    @JsonSerialize(using = FailingSerializer.class)
+    //  Without any annotation, the object mapper will serialize as {}, rather than failing
+    interface ImpossibleToSerialize {
+        @Value.Parameter
+        long value();
+
+        static ImpossibleToSerialize of() {
+            return ImmutableImpossibleToSerialize.of(123);
+        }
+    }
+
+    static class FailingSerializer extends StdSerializer<ImpossibleToSerialize> {
+
+        protected FailingSerializer(Class<ImpossibleToSerialize> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(
+                ImpossibleToSerialize impossibleToSerialize,
+                JsonGenerator jsonGenerator,
+                SerializerProvider serializerProvider)
+                throws IOException {
+            throw new IOException("This is a failing serializer");
+        }
+    }
+
+    @Value.Immutable
+    interface SafetyAndFactory {
+        @Value.Parameter
+        LogSafety safety();
+
+        @Value.Parameter
+        BiFunction<String, Object, Arg<?>> argFactory();
+
+        default Arg<?> createArg(String name, Object value) {
+            return argFactory().apply(name, value);
+        }
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/TimestampRangePersisterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/TimestampRangePersisterTest.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.io.BaseEncoding;
+import com.palantir.atlasdb.sweep.asts.TimestampRange;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.ObjectPersister.LogSafety;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public final class TimestampRangePersisterTest {
+    private static final ObjectPersister<TimestampRange> PERSISTER =
+            ObjectPersister.of(ObjectMappers.newServerSmileMapper(), TimestampRange.class, LogSafety.SAFE);
+
+    private static final TimestampRange OPEN_RANGE = TimestampRange.openBucket(123L);
+    private static final TimestampRange CLOSED_RANGE = TimestampRange.of(123L, 456L);
+
+    // Be very careful about changing these without a migration.
+    private static final byte[] SERIALIZED_OPEN_RANGE =
+            BaseEncoding.base64().decode("OikKBfqNc3RhcnRJbmNsdXNpdmUkA7aLZW5kRXhjbHVzaXZlwfs");
+    private static final byte[] SERIALIZED_CLOSED_RANGE =
+            BaseEncoding.base64().decode("OikKBfqNc3RhcnRJbmNsdXNpdmUkA7aLZW5kRXhjbHVzaXZlJA6Q+w==");
+
+    @ParameterizedTest
+    @MethodSource("timestampRanges")
+    public void deserializingTimestampRangeIsInverseOfSerialization(TimestampRange range) {
+        byte[] serialized = PERSISTER.trySerialize(range);
+        assertThat(PERSISTER.tryDeserialize(serialized)).isEqualTo(range);
+    }
+
+    @ParameterizedTest
+    @MethodSource("timestampRanges")
+    public void canDeserializeExistingVersionOfTimestampRange(TimestampRange range, byte[] serialized) {
+        assertThat(PERSISTER.tryDeserialize(serialized)).isEqualTo(range);
+    }
+
+    private static Stream<Arguments> timestampRanges() {
+        return Stream.of(
+                Arguments.of(OPEN_RANGE, SERIALIZED_OPEN_RANGE), Arguments.of(CLOSED_RANGE, SERIALIZED_CLOSED_RANGE));
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
We don't have any way to serde TimestampRange and BucketStateAndIdentifier.

**After this PR**:
We now do.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
ObjectPersister too generic? I had a BucketAssignerStorePersisters that had all three that actually had this as an internal abstraction, but then figured it would be fine as a standalone class.

BucketIdentifierPersisterTest overkill?


**Is documentation needed?**:
N/A

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
N/A
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
Yes!
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
N/A
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
N/A
**Does this PR need a schema migration?**
N/A
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
No
**What was existing testing like? What have you done to improve it?**:
Added some to ensure that we can serde, and so that we don't break compat with existing serde in the future
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
N/A
**Has the safety of all log arguments been decided correctly?**:
Yes! Well - it's configurable
**Will this change significantly affect our spending on metrics or logs?**:
N/A, unless we screw up serde
**How would I tell that this PR does not work in production? (monitors, etc.)**:
big loud errors
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Not wired up
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
N/A
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
N/A
## Development Process
**Where should we start reviewing?**:
ObjectPersister
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
