### PR TITLE
rename TransactionKeyValueService to DataKeyValueService

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -277,6 +277,130 @@ acceptedBreaks:
         \ ===java.util.Map<com.palantir.atlasdb.keyvalue.api.Cell, byte[]>===)"
       justification: "KeyValueSnapshotReader is a relatively new API and is not widely\
         \ used"
+  "0.1157.0":
+    com.palantir.atlasdb:atlasdb-api:
+    - code: "java.class.removed"
+      old: "interface com.palantir.atlasdb.cell.api.AutoDelegate_TransactionKeyValueService"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.class.removed"
+      old: "interface com.palantir.atlasdb.cell.api.AutoDelegate_TransactionKeyValueServiceManager"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.class.removed"
+      old: "interface com.palantir.atlasdb.cell.api.TransactionKeyValueService"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.class.removed"
+      old: "interface com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.class.removed"
+      old: "interface com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.class.removed"
+      old: "interface com.palantir.atlasdb.spi.TransactionKeyValueServiceManagerFactory<T\
+        \ extends java.lang.Object>"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.class.removed"
+      old: "interface com.palantir.atlasdb.spi.TransactionKeyValueServiceRuntimeConfig"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager\
+        \ com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManagerFactory::createKeyValueSnapshotReaderManager(===com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager===,\
+        \ com.palantir.atlasdb.transaction.service.TransactionService, boolean, com.palantir.atlasdb.transaction.api.OrphanedSentinelDeleter,\
+        \ com.palantir.atlasdb.transaction.api.DeleteExecutor, com.palantir.atlasdb.util.MetricsManager)"
+      new: "parameter com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager\
+        \ com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManagerFactory::createKeyValueSnapshotReaderManager(===com.palantir.atlasdb.cell.api.DataKeyValueServiceManager===,\
+        \ com.palantir.atlasdb.transaction.service.TransactionService, boolean, com.palantir.atlasdb.transaction.api.OrphanedSentinelDeleter,\
+        \ com.palantir.atlasdb.transaction.api.DeleteExecutor, com.palantir.atlasdb.util.MetricsManager)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    com.palantir.atlasdb:atlasdb-config:
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter com.palantir.atlasdb.factory.TransactionManagersInitializer\
+        \ com.palantir.atlasdb.factory.TransactionManagersInitializer::createInitialTables(com.palantir.atlasdb.keyvalue.api.KeyValueService,\
+        \ ===com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager===, java.util.Set<com.palantir.atlasdb.table.description.Schema>,\
+        \ boolean, boolean)"
+      new: "parameter com.palantir.atlasdb.factory.TransactionManagersInitializer\
+        \ com.palantir.atlasdb.factory.TransactionManagersInitializer::createInitialTables(com.palantir.atlasdb.keyvalue.api.KeyValueService,\
+        \ ===com.palantir.atlasdb.cell.api.DataKeyValueServiceManager===, java.util.Set<com.palantir.atlasdb.table.description.Schema>,\
+        \ boolean, boolean)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManagerFactory\
+        \ com.palantir.atlasdb.factory.AtlasDbServiceDiscovery::createKeyValueSnapshotReaderManagerFactoryOfCorrectType(===com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig===)"
+      new: "parameter com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManagerFactory\
+        \ com.palantir.atlasdb.factory.AtlasDbServiceDiscovery::createKeyValueSnapshotReaderManagerFactoryOfCorrectType(===com.palantir.atlasdb.spi.DataKeyValueServiceConfig===)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.config.ImmutableAtlasDbConfig com.palantir.atlasdb.config.ImmutableAtlasDbConfig::withTransactionKeyValueService(com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.config.ImmutableAtlasDbConfig com.palantir.atlasdb.config.ImmutableAtlasDbConfig::withTransactionKeyValueService(java.util.Optional<?\
+        \ extends com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig>)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.config.ImmutableAtlasDbConfig.Builder com.palantir.atlasdb.config.ImmutableAtlasDbConfig.Builder::transactionKeyValueService(com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.config.ImmutableAtlasDbConfig.Builder com.palantir.atlasdb.config.ImmutableAtlasDbConfig.Builder::transactionKeyValueService(java.util.Optional<?\
+        \ extends com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig>)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig::withTransactionKeyValueService(com.palantir.atlasdb.spi.TransactionKeyValueServiceRuntimeConfig)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig::withTransactionKeyValueService(java.util.Optional<?\
+        \ extends com.palantir.atlasdb.spi.TransactionKeyValueServiceRuntimeConfig>)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig.Builder\
+        \ com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig.Builder::transactionKeyValueService(com.palantir.atlasdb.spi.TransactionKeyValueServiceRuntimeConfig)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig.Builder\
+        \ com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig.Builder::transactionKeyValueService(java.util.Optional<?\
+        \ extends com.palantir.atlasdb.spi.TransactionKeyValueServiceRuntimeConfig>)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method com.palantir.atlasdb.spi.TransactionKeyValueServiceManagerFactory<?>\
+        \ com.palantir.atlasdb.factory.AtlasDbServiceDiscovery::createTransactionKeyValueServiceManagerFactoryOfCorrectType(com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig)"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method java.util.Optional<com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig>\
+        \ com.palantir.atlasdb.config.AtlasDbConfig::transactionKeyValueService()"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method java.util.Optional<com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig>\
+        \ com.palantir.atlasdb.config.ImmutableAtlasDbConfig::transactionKeyValueService()"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method java.util.Optional<com.palantir.atlasdb.spi.TransactionKeyValueServiceRuntimeConfig>\
+        \ com.palantir.atlasdb.config.AtlasDbRuntimeConfig::transactionKeyValueService()"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
+    - code: "java.method.removed"
+      old: "method java.util.Optional<com.palantir.atlasdb.spi.TransactionKeyValueServiceRuntimeConfig>\
+        \ com.palantir.atlasdb.config.ImmutableAtlasDbRuntimeConfig::transactionKeyValueService()"
+      justification: "Renaming TransactionKeyValueService to DataKeyValueService is\
+        \ acceptable as it is marked @Beta and unused in production."
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/DataKeyValueService.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/DataKeyValueService.java
@@ -40,7 +40,7 @@ import java.util.Map;
  * to transactions.
  */
 @AutoDelegate
-public interface TransactionKeyValueService {
+public interface DataKeyValueService {
     Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> getFirstBatchForRanges(
             TableReference tableRef, Iterable<RangeRequest> rangeRequests, long timestamp);
 

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/DataKeyValueServiceManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/cell/api/DataKeyValueServiceManager.java
@@ -14,11 +14,23 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.spi;
+package com.palantir.atlasdb.cell.api;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.processors.AutoDelegate;
+import java.util.Optional;
+import java.util.function.LongSupplier;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type", visible = false)
-public interface TransactionKeyValueServiceRuntimeConfig {
-    String type();
+@AutoDelegate
+public interface DataKeyValueServiceManager extends AutoCloseable {
+    DataKeyValueService getDataKeyValueService(LongSupplier timestampSupplier);
+
+    Optional<KeyValueService> getKeyValueService();
+
+    DdlManager getDdlManager();
+
+    boolean isInitialized();
+
+    @Override
+    void close();
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/DataKeyValueServiceConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/DataKeyValueServiceConfig.java
@@ -14,23 +14,12 @@
  * limitations under the License.
  */
 
-package com.palantir.atlasdb.cell.api;
+package com.palantir.atlasdb.spi;
 
-import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.processors.AutoDelegate;
-import java.util.Optional;
-import java.util.function.LongSupplier;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 
-@AutoDelegate
-public interface TransactionKeyValueServiceManager extends AutoCloseable {
-    TransactionKeyValueService getTransactionKeyValueService(LongSupplier timestampSupplier);
-
-    Optional<KeyValueService> getKeyValueService();
-
-    DdlManager getDdlManager();
-
-    boolean isInitialized();
-
-    @Override
-    void close();
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = As.PROPERTY, property = "type", visible = false)
+public interface DataKeyValueServiceConfig {
+    String type();
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/DataKeyValueServiceManagerFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/DataKeyValueServiceManagerFactory.java
@@ -16,14 +16,14 @@
 
 package com.palantir.atlasdb.spi;
 
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.coordination.CoordinationService;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.dialogue.clients.DialogueClients;
 import com.palantir.refreshable.Refreshable;
 
 /**
- * Factory for creating {@link TransactionKeyValueServiceManager} instances.
+ * Factory for creating {@link DataKeyValueServiceManager} instances.
  *
  * Implementations have access to the coordination service to be able query their internal state at a particular
  * timestamp, as well as schedule changes to it at a future timestamp.
@@ -33,19 +33,19 @@ import com.palantir.refreshable.Refreshable;
  *
  * @param <T> type used for the coordination state. Should be a jackson-compatible POJO.
  */
-public interface TransactionKeyValueServiceManagerFactory<T> {
+public interface DataKeyValueServiceManagerFactory<T> {
 
     String getType();
 
     Class<T> coordinationValueClass();
 
-    TransactionKeyValueServiceManager create(
+    DataKeyValueServiceManager create(
             String namespace,
             DialogueClients.ReloadingFactory reloadingFactory,
             MetricsManager metricsManager,
             CoordinationService<T> coordinationService,
             KeyValueServiceManager keyValueServiceManager,
-            TransactionKeyValueServiceConfig install,
-            Refreshable<TransactionKeyValueServiceRuntimeConfig> runtime,
+            DataKeyValueServiceConfig install,
+            Refreshable<DataKeyValueServiceRuntimeConfig> runtime,
             boolean initializeAsync);
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/DataKeyValueServiceRuntimeConfig.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/spi/DataKeyValueServiceRuntimeConfig.java
@@ -17,9 +17,8 @@
 package com.palantir.atlasdb.spi;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = As.PROPERTY, property = "type", visible = false)
-public interface TransactionKeyValueServiceConfig {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type", visible = false)
+public interface DataKeyValueServiceRuntimeConfig {
     String type();
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/snapshot/KeyValueSnapshotReaderManagerFactory.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/snapshot/KeyValueSnapshotReaderManagerFactory.java
@@ -16,7 +16,7 @@
 
 package com.palantir.atlasdb.transaction.api.snapshot;
 
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.transaction.api.DeleteExecutor;
 import com.palantir.atlasdb.transaction.api.OrphanedSentinelDeleter;
 import com.palantir.atlasdb.transaction.service.TransactionService;
@@ -26,7 +26,7 @@ public interface KeyValueSnapshotReaderManagerFactory {
     String getType();
 
     KeyValueSnapshotReaderManager createKeyValueSnapshotReaderManager(
-            TransactionKeyValueServiceManager transactionKeyValueServiceManager,
+            DataKeyValueServiceManager dataKeyValueServiceManager,
             TransactionService transactionService,
             boolean allowHiddenTableAccess,
             OrphanedSentinelDeleter orphanedSentinelDeleter,

--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
@@ -37,7 +37,7 @@ import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TableSplittingKeyValueService;
 import com.palantir.atlasdb.schema.KeyValueServiceMigrator;
@@ -362,7 +362,7 @@ public class KeyValueServiceMigratorsTest {
         TargetedSweeper sweeper = TargetedSweeper.createUninitializedForTest(kvs, () -> 1);
         SerializableTransactionManager txManager = SerializableTransactionManager.createForTest(
                 metricsManager,
-                new DelegatingTransactionKeyValueServiceManager(kvs),
+                new DelegatingDataKeyValueServiceManager(kvs),
                 timeLock.getLegacyTimelockService(),
                 timestampService,
                 timeLock.getLockService(),

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/AtlasDbConstants.java
@@ -98,7 +98,7 @@ public final class AtlasDbConstants {
 
     public static final byte[] DEFAULT_METADATA_COORDINATION_KEY = PtBytes.toBytes("m");
 
-    public static final byte[] DEFAULT_TRANSACTION_KEY_VALUE_SERVICE_COORDINATION_KEY = PtBytes.toBytes("x");
+    public static final byte[] DEFAULT_DATA_KEY_VALUE_SERVICE_COORDINATION_KEY = PtBytes.toBytes("x");
 
     public static final long DEFAULT_TRANSACTION_LOCK_ACQUIRE_TIMEOUT_MS = 60_000;
     public static final int THRESHOLD_FOR_LOGGING_LARGE_NUMBER_OF_TRANSACTION_LOOKUPS = 10_000_000;

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DelegatingDataKeyValueService.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DelegatingDataKeyValueService.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.keyvalue.impl;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.MustBeClosed;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -34,11 +34,11 @@ import com.palantir.common.base.ClosableIterator;
 import com.palantir.util.paging.TokenBackedBasicResultsPage;
 import java.util.Map;
 
-public final class DelegatingTransactionKeyValueService implements TransactionKeyValueService {
+public final class DelegatingDataKeyValueService implements DataKeyValueService {
 
     private final KeyValueService delegate;
 
-    public DelegatingTransactionKeyValueService(KeyValueService delegate) {
+    public DelegatingDataKeyValueService(KeyValueService delegate) {
         this.delegate = delegate;
     }
 

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DelegatingDataKeyValueServiceManager.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/keyvalue/impl/DelegatingDataKeyValueServiceManager.java
@@ -16,28 +16,28 @@
 
 package com.palantir.atlasdb.keyvalue.impl;
 
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.cell.api.DdlManager;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import java.util.Optional;
 import java.util.function.LongSupplier;
 
-public final class DelegatingTransactionKeyValueServiceManager implements TransactionKeyValueServiceManager {
+public final class DelegatingDataKeyValueServiceManager implements DataKeyValueServiceManager {
 
     private final Optional<KeyValueService> delegate;
-    private final TransactionKeyValueService transactionKeyValueService;
+    private final DataKeyValueService dataKeyValueService;
     private final DdlManager ddlManager;
 
-    public DelegatingTransactionKeyValueServiceManager(KeyValueService delegate) {
+    public DelegatingDataKeyValueServiceManager(KeyValueService delegate) {
         this.delegate = Optional.of(delegate);
-        this.transactionKeyValueService = new DelegatingTransactionKeyValueService(delegate);
+        this.dataKeyValueService = new DelegatingDataKeyValueService(delegate);
         this.ddlManager = new DelegatingDdlManager(delegate);
     }
 
     @Override
-    public TransactionKeyValueService getTransactionKeyValueService(LongSupplier _timestampSupplier) {
-        return transactionKeyValueService;
+    public DataKeyValueService getDataKeyValueService(LongSupplier _timestampSupplier) {
+        return dataKeyValueService;
     }
 
     @Override

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbConfig.java
@@ -26,8 +26,8 @@ import com.palantir.atlasdb.internalschema.ImmutableInternalSchemaInstallConfig;
 import com.palantir.atlasdb.internalschema.InternalSchemaInstallConfig;
 import com.palantir.atlasdb.keyvalue.api.LockWatchCachingConfig;
 import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
+import com.palantir.atlasdb.spi.DataKeyValueServiceConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
-import com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig;
 import com.palantir.atlasdb.sweep.queue.config.TargetedSweepInstallConfig;
 import com.palantir.exception.NotInitializedException;
 import com.palantir.logsafe.DoNotLog;
@@ -51,7 +51,7 @@ public abstract class AtlasDbConfig {
     public abstract KeyValueServiceConfig keyValueService();
 
     @Beta
-    public abstract Optional<TransactionKeyValueServiceConfig> transactionKeyValueService();
+    public abstract Optional<DataKeyValueServiceConfig> dataKeyValueService();
 
     public abstract Optional<LeaderConfig> leader();
 

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/config/AtlasDbRuntimeConfig.java
@@ -22,8 +22,8 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.compact.CompactorConfig;
 import com.palantir.atlasdb.internalschema.ImmutableInternalSchemaRuntimeConfig;
 import com.palantir.atlasdb.internalschema.InternalSchemaRuntimeConfig;
+import com.palantir.atlasdb.spi.DataKeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceRuntimeConfig;
-import com.palantir.atlasdb.spi.TransactionKeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.stream.StreamStorePersistenceConfiguration;
 import com.palantir.atlasdb.stream.StreamStorePersistenceConfigurations;
 import com.palantir.atlasdb.sweep.queue.config.TargetedSweepRuntimeConfig;
@@ -94,7 +94,7 @@ public abstract class AtlasDbRuntimeConfig {
     public abstract Optional<KeyValueServiceRuntimeConfig> keyValueService();
 
     @Beta
-    public abstract Optional<TransactionKeyValueServiceRuntimeConfig> transactionKeyValueService();
+    public abstract Optional<DataKeyValueServiceRuntimeConfig> dataKeyValueService();
 
     /**
      * Runtime live-reloadable parameters for communicating with TimeLock.

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscovery.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/AtlasDbServiceDiscovery.java
@@ -18,9 +18,9 @@ package com.palantir.atlasdb.factory;
 
 import com.palantir.atlasdb.namespacedeleter.NamespaceDeleterFactory;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
+import com.palantir.atlasdb.spi.DataKeyValueServiceConfig;
+import com.palantir.atlasdb.spi.DataKeyValueServiceManagerFactory;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
-import com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig;
-import com.palantir.atlasdb.spi.TransactionKeyValueServiceManagerFactory;
 import com.palantir.atlasdb.timestamp.DbTimeLockFactory;
 import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManagerFactory;
 import com.palantir.logsafe.SafeArg;
@@ -37,17 +37,15 @@ public final class AtlasDbServiceDiscovery {
         return createAtlasDbServiceOfCorrectType(config, AtlasDbFactory::getType, AtlasDbFactory.class);
     }
 
-    public static TransactionKeyValueServiceManagerFactory<?>
-            createTransactionKeyValueServiceManagerFactoryOfCorrectType(TransactionKeyValueServiceConfig config) {
+    public static DataKeyValueServiceManagerFactory<?> createDataKeyValueServiceManagerFactoryOfCorrectType(
+            DataKeyValueServiceConfig config) {
         return createAtlasDbServiceOfCorrectType(
-                config.type(),
-                TransactionKeyValueServiceManagerFactory::getType,
-                TransactionKeyValueServiceManagerFactory.class);
+                config.type(), DataKeyValueServiceManagerFactory::getType, DataKeyValueServiceManagerFactory.class);
     }
 
-    // TODO (jkong): A little cheaty, currently coupling usage of TKVSMF and KVSRF to be special or non-special...
+    // TODO (jkong): A little cheaty, currently coupling usage of DKVSMF and KVSRF to be special or non-special...
     public static KeyValueSnapshotReaderManagerFactory createKeyValueSnapshotReaderManagerFactoryOfCorrectType(
-            TransactionKeyValueServiceConfig config) {
+            DataKeyValueServiceConfig config) {
         return createAtlasDbServiceOfCorrectType(
                 config.type(),
                 KeyValueSnapshotReaderManagerFactory::getType,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -27,7 +27,7 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.cache.DefaultTimestampCache;
 import com.palantir.atlasdb.cache.TimestampCache;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.cleaner.Follower;
@@ -58,7 +58,7 @@ import com.palantir.atlasdb.internalschema.persistence.CoordinationServices;
 import com.palantir.atlasdb.keyvalue.api.CheckAndSetCompatibility;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.keyvalue.impl.ProfilingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.SweepStatsKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TracingKeyValueService;
@@ -68,13 +68,13 @@ import com.palantir.atlasdb.memory.InMemoryAtlasDbConfig;
 import com.palantir.atlasdb.schema.TargetedSweepSchema;
 import com.palantir.atlasdb.schema.generated.SweepTableFactory;
 import com.palantir.atlasdb.schema.generated.TargetedSweepTableFactory;
+import com.palantir.atlasdb.spi.DataKeyValueServiceConfig;
+import com.palantir.atlasdb.spi.DataKeyValueServiceManagerFactory;
+import com.palantir.atlasdb.spi.DataKeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.spi.DerivedSnapshotConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceManager;
 import com.palantir.atlasdb.spi.SharedResourcesConfig;
-import com.palantir.atlasdb.spi.TransactionKeyValueServiceConfig;
-import com.palantir.atlasdb.spi.TransactionKeyValueServiceManagerFactory;
-import com.palantir.atlasdb.spi.TransactionKeyValueServiceRuntimeConfig;
 import com.palantir.atlasdb.sweep.AdjustableSweepBatchConfigSource;
 import com.palantir.atlasdb.sweep.BackgroundSweeperImpl;
 import com.palantir.atlasdb.sweep.BackgroundSweeperPerformanceLogger;
@@ -451,26 +451,26 @@ public abstract class TransactionManagers {
                 },
                 closeables);
 
-        TransactionKeyValueServiceManager transactionKeyValueServiceManager = initializeCloseable(
-                () -> config().transactionKeyValueService()
-                        .map(transactionKeyValueServiceConfig -> createTransactionKeyValueServiceManager(
-                                AtlasDbServiceDiscovery.createTransactionKeyValueServiceManagerFactoryOfCorrectType(
-                                        transactionKeyValueServiceConfig),
+        DataKeyValueServiceManager dataKeyValueServiceManager = initializeCloseable(
+                () -> config().dataKeyValueService()
+                        .map(dataKeyValueServiceConfig -> createDataKeyValueServiceManager(
+                                AtlasDbServiceDiscovery.createDataKeyValueServiceManagerFactoryOfCorrectType(
+                                        dataKeyValueServiceConfig),
                                 metricsManager,
                                 lockAndTimestampServices,
                                 internalKeyValueService,
                                 new DefaultKeyValueServiceManager(metricsManager, adapter),
-                                transactionKeyValueServiceConfig,
-                                runtime.map(config -> config.transactionKeyValueService()
+                                dataKeyValueServiceConfig,
+                                runtime.map(config -> config.dataKeyValueService()
                                         .orElseThrow(() -> new SafeIllegalArgumentException(
-                                                "TransactionKeyValueServiceRuntimeConfig must be provided"))),
+                                                "DataKeyValueServiceRuntimeConfig must be provided"))),
                                 config().initializeAsync()))
-                        .orElseGet(() -> new DelegatingTransactionKeyValueServiceManager(internalKeyValueService)),
+                        .orElseGet(() -> new DelegatingDataKeyValueServiceManager(internalKeyValueService)),
                 closeables);
 
         TransactionManagersInitializer initializer = TransactionManagersInitializer.createInitialTables(
                 internalKeyValueService,
-                transactionKeyValueServiceManager,
+                dataKeyValueServiceManager,
                 schemas(),
                 config().initializeAsync(),
                 allSafeForLogging());
@@ -541,12 +541,12 @@ public abstract class TransactionManagers {
                 createClearsTable(internalKeyValueService)));
 
         KeyValueSnapshotReaderManager keyValueSnapshotReaderManager = createKeyValueSnapshotReaderManager(
-                transactionKeyValueServiceManager, transactionService, sweepStrategyManager, metricsManager);
+                dataKeyValueServiceManager, transactionService, sweepStrategyManager, metricsManager);
 
         TransactionManager transactionManager = initializeCloseable(
                 () -> SerializableTransactionManager.createInstrumented(
                         metricsManager,
-                        transactionKeyValueServiceManager,
+                        dataKeyValueServiceManager,
                         lockAndTimestampServices.timelock(),
                         lockAndTimestampServices.lockWatcher(),
                         lockAndTimestampServices.managedTimestampService(),
@@ -610,52 +610,51 @@ public abstract class TransactionManagers {
     }
 
     private KeyValueSnapshotReaderManager createKeyValueSnapshotReaderManager(
-            TransactionKeyValueServiceManager transactionKeyValueServiceManager,
+            DataKeyValueServiceManager dataKeyValueServiceManager,
             TransactionService transactionService,
             SweepStrategyManager sweepStrategyManager,
             MetricsManager metricsManager) {
-        Optional<KeyValueSnapshotReaderManagerFactory> serviceDiscoveredFactory = config().transactionKeyValueService()
+        Optional<KeyValueSnapshotReaderManagerFactory> serviceDiscoveredFactory = config().dataKeyValueService()
                 .map(AtlasDbServiceDiscovery::createKeyValueSnapshotReaderManagerFactoryOfCorrectType);
         DeleteExecutor deleteExecutor = DefaultDeleteExecutor.createDefault(
-                transactionKeyValueServiceManager.getKeyValueService().orElseThrow());
+                dataKeyValueServiceManager.getKeyValueService().orElseThrow());
         OrphanedSentinelDeleter orphanedSentinelDeleter =
                 new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor);
         return serviceDiscoveredFactory
                 .map(factory -> factory.createKeyValueSnapshotReaderManager(
-                        transactionKeyValueServiceManager,
+                        dataKeyValueServiceManager,
                         transactionService,
                         allowHiddenTableAccess(),
                         orphanedSentinelDeleter,
                         deleteExecutor,
                         metricsManager))
                 .orElseGet(() -> new DefaultKeyValueSnapshotReaderManager(
-                        transactionKeyValueServiceManager,
+                        dataKeyValueServiceManager,
                         transactionService,
                         allowHiddenTableAccess(),
                         orphanedSentinelDeleter,
                         deleteExecutor));
     }
 
-    private <T> TransactionKeyValueServiceManager createTransactionKeyValueServiceManager(
-            TransactionKeyValueServiceManagerFactory<T> factory,
+    private <T> DataKeyValueServiceManager createDataKeyValueServiceManager(
+            DataKeyValueServiceManagerFactory<T> factory,
             MetricsManager metricsManager,
             LockAndTimestampServices lockAndTimestampServices,
             KeyValueService internalTablesKeyValueService,
             KeyValueServiceManager keyValueServiceManager,
-            TransactionKeyValueServiceConfig config,
-            Refreshable<TransactionKeyValueServiceRuntimeConfig> runtimeConfigRefreshable,
+            DataKeyValueServiceConfig config,
+            Refreshable<DataKeyValueServiceRuntimeConfig> runtimeConfigRefreshable,
             boolean initializeAsync) {
-        CoordinationService<T> coordinationService =
-                CoordinationServices.createTransactionKeyValueServiceManagerCoordinator(
-                        factory.coordinationValueClass(),
-                        internalTablesKeyValueService,
-                        lockAndTimestampServices.managedTimestampService(),
-                        metricsManager,
-                        config().initializeAsync());
+        CoordinationService<T> coordinationService = CoordinationServices.createDataKeyValueServiceManagerCoordinator(
+                factory.coordinationValueClass(),
+                internalTablesKeyValueService,
+                lockAndTimestampServices.managedTimestampService(),
+                metricsManager,
+                config().initializeAsync());
         return factory.create(
                 config().namespace()
                         .orElseThrow(() -> new SafeIllegalArgumentException(
-                                "Namespace must be set when using transactionKeyValueService")),
+                                "Namespace must be set when using dataKeyValueService")),
                 reloadingFactory()
                         .withUserAgent(userAgent().addAgent(AtlasDbRemotingConstants.ATLASDB_HTTP_CLIENT_AGENT)),
                 metricsManager,

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagersInitializer.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagersInitializer.java
@@ -17,7 +17,7 @@ package com.palantir.atlasdb.factory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.async.initializer.AsyncInitializer;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.logging.LoggingArgs;
 import com.palantir.atlasdb.table.description.Schema;
@@ -30,18 +30,18 @@ public final class TransactionManagersInitializer extends AsyncInitializer {
 
     private KeyValueService internalKeyValueService;
 
-    private TransactionKeyValueServiceManager transactionKeyValueServiceManager;
+    private DataKeyValueServiceManager dataKeyValueServiceManager;
     private Set<Schema> schemas;
     private final boolean allSafeForLogging;
 
     public static TransactionManagersInitializer createInitialTables(
             KeyValueService internalKeyValueService,
-            TransactionKeyValueServiceManager transactionKeyValueServiceManager,
+            DataKeyValueServiceManager dataKeyValueServiceManager,
             Set<Schema> schemas,
             boolean initializeAsync,
             boolean allSafeForLogging) {
         TransactionManagersInitializer initializer = new TransactionManagersInitializer(
-                internalKeyValueService, transactionKeyValueServiceManager, schemas, allSafeForLogging);
+                internalKeyValueService, dataKeyValueServiceManager, schemas, allSafeForLogging);
         initializer.initialize(initializeAsync);
         return initializer;
     }
@@ -49,11 +49,11 @@ public final class TransactionManagersInitializer extends AsyncInitializer {
     @VisibleForTesting
     TransactionManagersInitializer(
             KeyValueService internalKeyValueService,
-            TransactionKeyValueServiceManager transactionKeyValueServiceManager,
+            DataKeyValueServiceManager dataKeyValueServiceManager,
             Set<Schema> schemas,
             boolean allSafeForLogging) {
         this.internalKeyValueService = internalKeyValueService;
-        this.transactionKeyValueServiceManager = transactionKeyValueServiceManager;
+        this.dataKeyValueServiceManager = dataKeyValueServiceManager;
         this.schemas = schemas;
         this.allSafeForLogging = allSafeForLogging;
     }
@@ -69,7 +69,7 @@ public final class TransactionManagersInitializer extends AsyncInitializer {
 
     private void createTablesAndIndexes() {
         for (Schema schema : schemas) {
-            Schemas.createUserTablesAndIndexes(schema, transactionKeyValueServiceManager.getDdlManager());
+            Schemas.createUserTablesAndIndexes(schema, dataKeyValueServiceManager.getDdlManager());
         }
     }
 

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.services;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.cache.DefaultTimestampCache;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.cleaner.Follower;
@@ -29,7 +29,7 @@ import com.palantir.atlasdb.debug.ConflictTracer;
 import com.palantir.atlasdb.factory.AtlasDbServiceDiscovery;
 import com.palantir.atlasdb.factory.LockAndTimestampServices;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.DerivedSnapshotConfig;
 import com.palantir.atlasdb.spi.KeyValueServiceConfig;
@@ -122,8 +122,7 @@ public class TransactionManagerModule {
             Cleaner cleaner,
             @Internal DerivedSnapshotConfig derivedSnapshotConfig,
             TransactionKnowledgeComponents knowledge) {
-        TransactionKeyValueServiceManager transactionKeyValueServiceManager =
-                new DelegatingTransactionKeyValueServiceManager(kvs);
+        DataKeyValueServiceManager dataKeyValueServiceManager = new DelegatingDataKeyValueServiceManager(kvs);
         DefaultDeleteExecutor deleteExecutor = new DefaultDeleteExecutor(
                 kvs,
                 Executors.newSingleThreadExecutor(
@@ -131,7 +130,7 @@ public class TransactionManagerModule {
         // todo(gmaretic): should this be using a real sweep queue?
         return new SerializableTransactionManager(
                 metricsManager,
-                transactionKeyValueServiceManager,
+                dataKeyValueServiceManager,
                 lts.timelock(),
                 lts.lockWatcher(),
                 lts.managedTimestampService(),
@@ -155,7 +154,7 @@ public class TransactionManagerModule {
                 Optional.empty(),
                 knowledge,
                 new DefaultKeyValueSnapshotReaderManager(
-                        transactionKeyValueServiceManager,
+                        dataKeyValueServiceManager,
                         transactionService,
                         config.allowAccessToHiddenTables(),
                         new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor),

--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/test/TestTransactionManagerModule.java
@@ -18,7 +18,7 @@ package com.palantir.atlasdb.services.test;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.cache.DefaultTimestampCache;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.cleaner.Follower;
@@ -29,7 +29,7 @@ import com.palantir.atlasdb.debug.ConflictTracer;
 import com.palantir.atlasdb.factory.AtlasDbServiceDiscovery;
 import com.palantir.atlasdb.factory.LockAndTimestampServices;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.services.ServicesConfig;
 import com.palantir.atlasdb.spi.AtlasDbFactory;
 import com.palantir.atlasdb.spi.DerivedSnapshotConfig;
@@ -123,13 +123,12 @@ public class TestTransactionManagerModule {
             Cleaner cleaner,
             @Internal DerivedSnapshotConfig derivedSnapshotConfig,
             TransactionKnowledgeComponents knowledge) {
-        TransactionKeyValueServiceManager transactionKeyValueServiceManager =
-                new DelegatingTransactionKeyValueServiceManager(kvs);
+        DataKeyValueServiceManager dataKeyValueServiceManager = new DelegatingDataKeyValueServiceManager(kvs);
         DefaultDeleteExecutor deleteExecutor =
                 new DefaultDeleteExecutor(kvs, PTExecutors.newSingleThreadExecutor(true));
         return new SerializableTransactionManager(
                 metricsManager,
-                new DelegatingTransactionKeyValueServiceManager(kvs),
+                new DelegatingDataKeyValueServiceManager(kvs),
                 lts.timelock(),
                 lts.lockWatcher(),
                 lts.managedTimestampService(),
@@ -153,7 +152,7 @@ public class TestTransactionManagerModule {
                 Optional.empty(),
                 knowledge,
                 new DefaultKeyValueSnapshotReaderManager(
-                        transactionKeyValueServiceManager,
+                        dataKeyValueServiceManager,
                         transactionService,
                         config.allowAccessToHiddenTables(),
                         new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor),

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/CoordinationServices.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/internalschema/persistence/CoordinationServices.java
@@ -57,14 +57,14 @@ public final class CoordinationServices {
         return wrapHidingVersionSerialization(versionedService);
     }
 
-    public static <T> CoordinationService<T> createTransactionKeyValueServiceManagerCoordinator(
+    public static <T> CoordinationService<T> createDataKeyValueServiceManagerCoordinator(
             Class<T> valueClass,
             KeyValueService keyValueService,
             TimestampService timestampService,
             MetricsManager _metricsManager,
             boolean initializeAsync) {
         // TODO(jakubk): Add the versioning.
-        return new CoordinationServiceImpl<>(createTransactionKeyValueServiceManagerCoordinationStore(
+        return new CoordinationServiceImpl<>(createDataKeyValueServiceManagerCoordinationStore(
                 keyValueService, timestampService::getFreshTimestamp, valueClass, initializeAsync));
     }
 
@@ -80,12 +80,12 @@ public final class CoordinationServices {
                 initializeAsync);
     }
 
-    private static <T> CoordinationStore<T> createTransactionKeyValueServiceManagerCoordinationStore(
+    private static <T> CoordinationStore<T> createDataKeyValueServiceManagerCoordinationStore(
             KeyValueService keyValueService, LongSupplier timestampSupplier, Class<T> clazz, boolean initializeAsync) {
         return KeyValueServiceCoordinationStore.create(
                 ObjectMappers.newServerObjectMapper(),
                 keyValueService,
-                AtlasDbConstants.DEFAULT_TRANSACTION_KEY_VALUE_SERVICE_COORDINATION_KEY,
+                AtlasDbConstants.DEFAULT_DATA_KEY_VALUE_SERVICE_COORDINATION_KEY,
                 timestampSupplier,
                 Object::equals,
                 clazz,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ColumnRangeBatchProvider.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/ColumnRangeBatchProvider.java
@@ -17,7 +17,7 @@ package com.palantir.atlasdb.transaction.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
@@ -33,19 +33,19 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 public class ColumnRangeBatchProvider implements BatchProvider<Map.Entry<Cell, Value>> {
-    private final TransactionKeyValueService transactionKeyValueService;
+    private final DataKeyValueService dataKeyValueService;
     private final TableReference tableRef;
     private final byte[] row;
     private final BatchColumnRangeSelection columnRangeSelection;
     private final long timestamp;
 
     public ColumnRangeBatchProvider(
-            TransactionKeyValueService transactionKeyValueService,
+            DataKeyValueService dataKeyValueService,
             TableReference tableRef,
             byte[] row,
             BatchColumnRangeSelection columnRangeSelection,
             long timestamp) {
-        this.transactionKeyValueService = transactionKeyValueService;
+        this.dataKeyValueService = dataKeyValueService;
         this.tableRef = tableRef;
         this.row = row;
         this.columnRangeSelection = columnRangeSelection;
@@ -61,7 +61,7 @@ public class ColumnRangeBatchProvider implements BatchProvider<Map.Entry<Cell, V
         BatchColumnRangeSelection newRange =
                 BatchColumnRangeSelection.create(startCol, columnRangeSelection.getEndCol(), batchSize);
         Map<byte[], RowColumnRangeIterator> range =
-                transactionKeyValueService.getRowsColumnRange(tableRef, ImmutableList.of(row), newRange, timestamp);
+                dataKeyValueService.getRowsColumnRange(tableRef, ImmutableList.of(row), newRange, timestamp);
         if (range.isEmpty()) {
             return ClosableIterators.wrapWithEmptyClose(
                     ImmutableList.<Map.Entry<Cell, Value>>of().iterator());

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/RowRangeBatchProvider.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/RowRangeBatchProvider.java
@@ -16,7 +16,7 @@
 package com.palantir.atlasdb.transaction.impl;
 
 import com.google.errorprone.annotations.MustBeClosed;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
 import com.palantir.atlasdb.keyvalue.api.RangeRequest;
 import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
@@ -29,17 +29,14 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 public class RowRangeBatchProvider implements BatchProvider<RowResult<Value>> {
-    private final TransactionKeyValueService transactionKeyValueService;
+    private final DataKeyValueService dataKeyValueService;
     private final TableReference tableRef;
     private final RangeRequest range;
     private final long timestamp;
 
     public RowRangeBatchProvider(
-            TransactionKeyValueService transactionKeyValueService,
-            TableReference tableRef,
-            RangeRequest range,
-            long timestamp) {
-        this.transactionKeyValueService = transactionKeyValueService;
+            DataKeyValueService dataKeyValueService, TableReference tableRef, RangeRequest range, long timestamp) {
+        this.dataKeyValueService = dataKeyValueService;
         this.tableRef = tableRef;
         this.range = range;
         this.timestamp = timestamp;
@@ -53,7 +50,7 @@ public class RowRangeBatchProvider implements BatchProvider<RowResult<Value>> {
             newRange.startRowInclusive(RangeRequests.getNextStartRow(range.isReverse(), lastToken));
         }
         newRange.batchHint(batchSize);
-        return transactionKeyValueService.getRange(tableRef, newRange.build(), timestamp);
+        return dataKeyValueService.getRange(tableRef, newRange.build(), timestamp);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SerializableTransaction.java
@@ -37,7 +37,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.cache.TimestampCache;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
 import com.palantir.atlasdb.debug.ConflictTracer;
@@ -146,7 +146,7 @@ public class SerializableTransaction extends SnapshotTransaction {
 
     public SerializableTransaction(
             MetricsManager metricsManager,
-            TransactionKeyValueService keyValueService,
+            DataKeyValueService keyValueService,
             TimelockService timelockService,
             LockWatchManagerInternal lockWatchManager,
             TransactionService transactionService,
@@ -915,7 +915,7 @@ public class SerializableTransaction extends SnapshotTransaction {
     private Transaction getReadOnlyTransaction(final long commitTs) {
         return new SnapshotTransaction(
                 metricsManager,
-                transactionKeyValueService,
+                dataKeyValueService,
                 timelockService,
                 lockWatchManager,
                 defaultTransactionService,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -24,8 +24,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 import com.palantir.atlasdb.cache.TimestampCache;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.cell.api.DdlManager;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
 import com.palantir.atlasdb.debug.ConflictTracer;
@@ -89,7 +89,7 @@ import java.util.stream.Collectors;
     private static final int NUM_RETRIES = 10;
 
     final MetricsManager metricsManager;
-    final TransactionKeyValueServiceManager transactionKeyValueServiceManager;
+    final DataKeyValueServiceManager dataKeyValueServiceManager;
     final TransactionService transactionService;
     final TimelockService timelockService;
     final LockWatchManagerInternal lockWatchManager;
@@ -120,7 +120,7 @@ import java.util.stream.Collectors;
 
     protected SnapshotTransactionManager(
             MetricsManager metricsManager,
-            TransactionKeyValueServiceManager transactionKeyValueServiceManager,
+            DataKeyValueServiceManager dataKeyValueServiceManager,
             TimelockService timelockService,
             LockWatchManagerInternal lockWatchManager,
             TimestampManagementService timestampManagementService,
@@ -147,7 +147,7 @@ import java.util.stream.Collectors;
         this.lockWatchManager = lockWatchManager;
         TimestampTracker.instrumentTimestamps(metricsManager, timelockService, cleaner);
         this.metricsManager = metricsManager;
-        this.transactionKeyValueServiceManager = transactionKeyValueServiceManager;
+        this.dataKeyValueServiceManager = dataKeyValueServiceManager;
         this.timelockService = timelockService;
         this.timestampManagementService = timestampManagementService;
         this.lockService = lockService;
@@ -317,7 +317,7 @@ import java.util.stream.Collectors;
         Optional<LockToken> immutableTimestampLock = Optional.of(immutableTsLock);
         return new SnapshotTransaction(
                 metricsManager,
-                transactionKeyValueServiceManager.getTransactionKeyValueService(startTimestampSupplier),
+                dataKeyValueServiceManager.getDataKeyValueService(startTimestampSupplier),
                 timelockService,
                 lockWatchManager,
                 transactionService,
@@ -365,7 +365,7 @@ import java.util.stream.Collectors;
         Optional<LockToken> immutableTimestampLock = Optional.empty();
         SnapshotTransaction transaction = new SnapshotTransaction(
                 metricsManager,
-                transactionKeyValueServiceManager.getTransactionKeyValueService(startTimestampSupplier),
+                dataKeyValueServiceManager.getDataKeyValueService(startTimestampSupplier),
                 timelockService,
                 NoOpLockWatchManager.create(),
                 transactionService,
@@ -426,7 +426,7 @@ import java.util.stream.Collectors;
                 SafeShutdownRunner.createWithCachedThreadpool(Duration.ofSeconds(20))) {
             shutdownRunner.shutdownSafely(super::close);
             shutdownRunner.shutdownSafely(cleaner::close);
-            shutdownRunner.shutdownSafely(transactionKeyValueServiceManager::close);
+            shutdownRunner.shutdownSafely(dataKeyValueServiceManager::close);
             shutdownRunner.shutdownSafely(deleteExecutor::close);
             shutdownRunner.shutdownSafely(() -> shutdownExecutor(getRangesExecutor));
             shutdownRunner.shutdownSafely(this::closeLockServiceIfPossible);
@@ -528,14 +528,14 @@ import java.util.stream.Collectors;
 
     @Override
     public KeyValueService getKeyValueService() {
-        return transactionKeyValueServiceManager
+        return dataKeyValueServiceManager
                 .getKeyValueService()
                 .orElseThrow(() -> new SafeIllegalStateException("KeyValueService is not supported"));
     }
 
     @Override
     public DdlManager getDdlManager() {
-        return transactionKeyValueServiceManager.getDdlManager();
+        return dataKeyValueServiceManager.getDdlManager();
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingDataKeyValueService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingDataKeyValueService.java
@@ -17,11 +17,11 @@
 package com.palantir.atlasdb.transaction.impl.expectations;
 
 import com.google.common.collect.ImmutableMap;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.expectations.TransactionReadInfo;
 
-public interface TrackingTransactionKeyValueService extends TransactionKeyValueService {
+public interface TrackingDataKeyValueService extends DataKeyValueService {
     TransactionReadInfo getOverallReadInfo();
 
     ImmutableMap<TableReference, TransactionReadInfo> getReadInfoByTable();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingDataKeyValueServiceImpl.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingDataKeyValueServiceImpl.java
@@ -20,8 +20,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.palantir.atlasdb.cell.api.AutoDelegate_TransactionKeyValueService;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.AutoDelegate_DataKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -40,17 +40,17 @@ import java.util.Map;
 import java.util.function.ToLongFunction;
 import one.util.streamex.EntryStream;
 
-public final class TrackingTransactionKeyValueServiceImpl
-        implements AutoDelegate_TransactionKeyValueService, TrackingTransactionKeyValueService {
-    private final TransactionKeyValueService delegate;
+public final class TrackingDataKeyValueServiceImpl
+        implements AutoDelegate_DataKeyValueService, TrackingDataKeyValueService {
+    private final DataKeyValueService delegate;
     private final KeyValueServiceDataTracker tracker = new KeyValueServiceDataTracker();
 
-    public TrackingTransactionKeyValueServiceImpl(TransactionKeyValueService delegate) {
+    public TrackingDataKeyValueServiceImpl(DataKeyValueService delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public TransactionKeyValueService delegate() {
+    public DataKeyValueService delegate() {
         return delegate;
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/snapshot/DefaultKeyValueSnapshotReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/snapshot/DefaultKeyValueSnapshotReader.java
@@ -25,7 +25,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.AtlasDbConstants;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
 import com.palantir.atlasdb.futures.AtlasFutures;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
@@ -76,7 +76,7 @@ public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotRead
     // TODO (jkong): Move canonical value of constant here, once post-filtering is removed from SnapshotTransaction
     private static final int MAX_POST_FILTERING_ITERATIONS = SnapshotTransaction.MAX_POST_FILTERING_ITERATIONS;
 
-    private final TransactionKeyValueService transactionKeyValueService;
+    private final DataKeyValueService dataKeyValueService;
     private final TransactionService transactionService;
     private final CommitTimestampLoader commitTimestampLoader;
     private final boolean allowHiddenTableAccess;
@@ -87,7 +87,7 @@ public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotRead
     private final KeyValueSnapshotMetricRecorder metricRecorder;
 
     public DefaultKeyValueSnapshotReader(
-            TransactionKeyValueService transactionKeyValueService,
+            DataKeyValueService dataKeyValueService,
             TransactionService transactionService,
             CommitTimestampLoader commitTimestampLoader,
             boolean allowHiddenTableAccess,
@@ -96,7 +96,7 @@ public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotRead
             ReadSnapshotValidator readSnapshotValidator,
             DeleteExecutor deleteExecutor,
             KeyValueSnapshotMetricRecorder metricRecorder) {
-        this.transactionKeyValueService = transactionKeyValueService;
+        this.dataKeyValueService = dataKeyValueService;
         this.transactionService = transactionService;
         this.commitTimestampLoader = commitTimestampLoader;
         this.allowHiddenTableAccess = allowHiddenTableAccess;
@@ -118,7 +118,7 @@ public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotRead
             Iterable<byte[]> rows,
             ColumnSelection columnSelection,
             Map<Cell, byte[]> localWrites) {
-        Map<Cell, Value> rawResults = new HashMap<>(transactionKeyValueService.getRows(
+        Map<Cell, Value> rawResults = new HashMap<>(dataKeyValueService.getRows(
                 tableReference, rows, columnSelection, startTimestampSupplier.getAsLong()));
 
         // We don't need to do work postFiltering if we have a write locally.
@@ -138,7 +138,7 @@ public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotRead
     private ListenableFuture<Map<Cell, byte[]>> getInternal(TableReference tableReference, Set<Cell> cells) {
         Map<Cell, Long> timestampsByCell = Cells.constantValueMap(cells, startTimestampSupplier.getAsLong());
         ListenableFuture<Collection<Map.Entry<Cell, byte[]>>> postFilteredResults = Futures.transformAsync(
-                transactionKeyValueService.getAsync(tableReference, timestampsByCell),
+                dataKeyValueService.getAsync(tableReference, timestampsByCell),
                 rawResults -> getWithPostFilteringAsync(tableReference, rawResults, Value.GET_VALUE),
                 MoreExecutors.directExecutor());
 
@@ -293,7 +293,7 @@ public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotRead
         if (!keysToReload.isEmpty()) {
             // TODO (jkong): Consider removing when a decision on validating pre-commit requirements mid-read is made
             return Futures.transform(
-                    transactionKeyValueService.getAsync(tableRef, keysToReload),
+                    dataKeyValueService.getAsync(tableRef, keysToReload),
                     nextRawResults -> {
                         boolean allPossibleCellsReadAndPresent = nextRawResults.size() == keysToReload.size();
                         readSnapshotValidator.throwIfPreCommitRequirementsNotMetOnRead(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/snapshot/DefaultKeyValueSnapshotReader.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/snapshot/DefaultKeyValueSnapshotReader.java
@@ -118,8 +118,8 @@ public final class DefaultKeyValueSnapshotReader implements KeyValueSnapshotRead
             Iterable<byte[]> rows,
             ColumnSelection columnSelection,
             Map<Cell, byte[]> localWrites) {
-        Map<Cell, Value> rawResults = new HashMap<>(dataKeyValueService.getRows(
-                tableReference, rows, columnSelection, startTimestampSupplier.getAsLong()));
+        Map<Cell, Value> rawResults = new HashMap<>(
+                dataKeyValueService.getRows(tableReference, rows, columnSelection, startTimestampSupplier.getAsLong()));
 
         // We don't need to do work postFiltering if we have a write locally.
         rawResults.keySet().removeAll(localWrites.keySet());

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIteratorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIteratorTest.java
@@ -59,9 +59,9 @@ public class GetRowsColumnRangeIteratorTest {
     public static final BatchColumnRangeSelection COLUMN_RANGE_SELECTION =
             BatchColumnRangeSelection.create(null, null, BATCH_SIZE);
 
-    private final DataKeyValueService tkvs = new DelegatingDataKeyValueService(new InMemoryKeyValueService(true));
+    private final DataKeyValueService dkvs = new DelegatingDataKeyValueService(new InMemoryKeyValueService(true));
     private final ColumnRangeBatchProvider batchProvider =
-            new ColumnRangeBatchProvider(tkvs, TABLE_REFERENCE, ROW, COLUMN_RANGE_SELECTION, Long.MAX_VALUE);
+            new ColumnRangeBatchProvider(dkvs, TABLE_REFERENCE, ROW, COLUMN_RANGE_SELECTION, Long.MAX_VALUE);
 
     @Test
     public void ifBatchIsEmptyNoValidateCallsAreMade() {
@@ -132,13 +132,13 @@ public class GetRowsColumnRangeIteratorTest {
                 .mapToObj(i -> String.format("cell%02d", i).getBytes(StandardCharsets.UTF_8))
                 .map(column -> Cell.create(ROW, column))
                 .collect(ImmutableMap.toImmutableMap(Function.identity(), _unused -> value));
-        tkvs.multiPut(Map.of(TABLE_REFERENCE, puts), 1L);
+        dkvs.multiPut(Map.of(TABLE_REFERENCE, puts), 1L);
 
         return puts.keySet();
     }
 
     private RowColumnRangeIterator getInitialIterator() {
-        return tkvs.getRowsColumnRange(TABLE_REFERENCE, ImmutableList.of(ROW), COLUMN_RANGE_SELECTION, Long.MAX_VALUE)
+        return dkvs.getRowsColumnRange(TABLE_REFERENCE, ImmutableList.of(ROW), COLUMN_RANGE_SELECTION, Long.MAX_VALUE)
                 .get(ROW);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIteratorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIteratorTest.java
@@ -29,13 +29,13 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.RowColumnRangeIterator;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueService;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
@@ -59,8 +59,8 @@ public class GetRowsColumnRangeIteratorTest {
     public static final BatchColumnRangeSelection COLUMN_RANGE_SELECTION =
             BatchColumnRangeSelection.create(null, null, BATCH_SIZE);
 
-    private final TransactionKeyValueService tkvs =
-            new DelegatingTransactionKeyValueService(new InMemoryKeyValueService(true));
+    private final DataKeyValueService tkvs =
+            new DelegatingDataKeyValueService(new InMemoryKeyValueService(true));
     private final ColumnRangeBatchProvider batchProvider =
             new ColumnRangeBatchProvider(tkvs, TABLE_REFERENCE, ROW, COLUMN_RANGE_SELECTION, Long.MAX_VALUE);
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIteratorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/GetRowsColumnRangeIteratorTest.java
@@ -59,8 +59,7 @@ public class GetRowsColumnRangeIteratorTest {
     public static final BatchColumnRangeSelection COLUMN_RANGE_SELECTION =
             BatchColumnRangeSelection.create(null, null, BATCH_SIZE);
 
-    private final DataKeyValueService tkvs =
-            new DelegatingDataKeyValueService(new InMemoryKeyValueService(true));
+    private final DataKeyValueService tkvs = new DelegatingDataKeyValueService(new InMemoryKeyValueService(true));
     private final ColumnRangeBatchProvider batchProvider =
             new ColumnRangeBatchProvider(tkvs, TABLE_REFERENCE, ROW, COLUMN_RANGE_SELECTION, Long.MAX_VALUE);
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/ReadSentinelHandlerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/ReadSentinelHandlerTest.java
@@ -28,7 +28,7 @@ import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueService;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.transaction.api.OrphanedSentinelDeleter;
 import com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException;
@@ -66,7 +66,7 @@ public final class ReadSentinelHandlerTest {
     @BeforeEach
     public void setUp() {
         readSentinelHandler = new ReadSentinelHandler(
-                new DelegatingTransactionKeyValueService(keyValueService),
+                new DelegatingDataKeyValueService(keyValueService),
                 transactionService,
                 TransactionReadSentinelBehavior.THROW_EXCEPTION,
                 orphanedSentinelDeleter);
@@ -138,7 +138,7 @@ public final class ReadSentinelHandlerTest {
     @Test
     public void handleReadSentinelDoesNothingIfConfigured() {
         ReadSentinelHandler ignoringReadSentinelHandler = new ReadSentinelHandler(
-                new DelegatingTransactionKeyValueService(keyValueService),
+                new DelegatingDataKeyValueService(keyValueService),
                 transactionService,
                 TransactionReadSentinelBehavior.IGNORE,
                 orphanedSentinelDeleter);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingDataKeyValueServiceForwardingTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingDataKeyValueServiceForwardingTest.java
@@ -27,7 +27,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -54,16 +54,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * Broadly tests that {@link TrackingTransactionKeyValueServiceImpl} methods forward delegate results using: physical equality
+ * Broadly tests that {@link TrackingDataKeyValueServiceImpl} methods forward delegate results using: physical equality
  * when relevant, and element/component physical equality when the semantics are different (methods returning
  * iterators or collections of iterators).
  * Mocks are used whenever possible. Exceptions include: types which cannot be mocked (e.g. byte arrays),
  * interfaces/implementations annotated with {@link org.mockito.DoNotMock} or similar (e.g. {@link Multimap}), and
  * when the method semantics and resulting tests impose it (e.g. methods where an iterator is wrapped can only be tested
- * by equality/in-order testing of its components, {@link TrackingTransactionKeyValueServiceImpl#getCandidateCellsForSweeping}).
+ * by equality/in-order testing of its components, {@link TrackingDataKeyValueServiceImpl#getCandidateCellsForSweeping}).
  */
 @ExtendWith(MockitoExtension.class)
-public final class TrackingTransactionKeyValueServiceForwardingTest {
+public final class TrackingDataKeyValueServiceForwardingTest {
     private static final long TIMESTAMP = 12L;
     private static final byte[] BYTES_1 = new byte[1];
     private static final byte[] BYTES_2 = new byte[2];
@@ -88,13 +88,13 @@ public final class TrackingTransactionKeyValueServiceForwardingTest {
     private Map<Cell, Value> valueByCellMap;
 
     @Mock
-    private TransactionKeyValueService delegate;
+    private DataKeyValueService delegate;
 
-    private TrackingTransactionKeyValueService trackingKvs;
+    private TrackingDataKeyValueService trackingKvs;
 
     @BeforeEach
     public void setUp() {
-        trackingKvs = new TrackingTransactionKeyValueServiceImpl(delegate);
+        trackingKvs = new TrackingDataKeyValueServiceImpl(delegate);
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingDataKeyValueServiceReadInfoTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingDataKeyValueServiceReadInfoTest.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
 import com.palantir.atlasdb.keyvalue.api.BatchColumnRangeSelection;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.ColumnRangeSelection;
@@ -57,7 +57,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * Note that the range of possible sizes will be larger if we use different sizes for different tests.
  */
 @ExtendWith(MockitoExtension.class)
-public final class TrackingTransactionKeyValueServiceReadInfoTest {
+public final class TrackingDataKeyValueServiceReadInfoTest {
     private static final String PARAMETERIZED_TEST_NAME = "size = {0}";
 
     public static List<Integer> sizes() {
@@ -73,14 +73,14 @@ public final class TrackingTransactionKeyValueServiceReadInfoTest {
     private RangeRequest rangeRequest;
 
     @Mock
-    private TransactionKeyValueService tkvs;
+    private DataKeyValueService tkvs;
 
-    private TrackingTransactionKeyValueService trackingKvs;
+    private TrackingDataKeyValueService trackingKvs;
     private ImmutableMap<Cell, Value> valueByCellMapOfSize;
 
     @BeforeEach
     public void beforeEach() {
-        this.trackingKvs = new TrackingTransactionKeyValueServiceImpl(tkvs);
+        this.trackingKvs = new TrackingDataKeyValueServiceImpl(tkvs);
     }
 
     @Mock

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingDataKeyValueServiceReadInfoTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/expectations/TrackingDataKeyValueServiceReadInfoTest.java
@@ -73,14 +73,14 @@ public final class TrackingDataKeyValueServiceReadInfoTest {
     private RangeRequest rangeRequest;
 
     @Mock
-    private DataKeyValueService tkvs;
+    private DataKeyValueService dkvs;
 
     private TrackingDataKeyValueService trackingKvs;
     private ImmutableMap<Cell, Value> valueByCellMapOfSize;
 
     @BeforeEach
     public void beforeEach() {
-        this.trackingKvs = new TrackingDataKeyValueServiceImpl(tkvs);
+        this.trackingKvs = new TrackingDataKeyValueServiceImpl(dkvs);
     }
 
     @Mock
@@ -93,7 +93,7 @@ public final class TrackingDataKeyValueServiceReadInfoTest {
     @MethodSource("sizes")
     public void readInfoIsCorrectAfterGetAsyncCallAndFutureConsumption(int size) {
         setup(size);
-        when(tkvs.getAsync(tableReference, timestampByCellMap))
+        when(dkvs.getAsync(tableReference, timestampByCellMap))
                 .thenReturn(Futures.immediateFuture(valueByCellMapOfSize));
 
         trackingKvs.getAsync(tableReference, timestampByCellMap);
@@ -106,7 +106,7 @@ public final class TrackingDataKeyValueServiceReadInfoTest {
     public void getAsyncTracksNothingBeforeDelegateResultCompletionAndTracksReadsAfterCompletion(int size) {
         setup(size);
         SettableFuture<Map<Cell, Value>> delegateFuture = SettableFuture.create();
-        when(tkvs.getAsync(tableReference, timestampByCellMap)).thenReturn(delegateFuture);
+        when(dkvs.getAsync(tableReference, timestampByCellMap)).thenReturn(delegateFuture);
         trackingKvs.getAsync(tableReference, timestampByCellMap);
 
         // tracking nothing
@@ -127,7 +127,7 @@ public final class TrackingDataKeyValueServiceReadInfoTest {
     @MethodSource("sizes")
     public void throwingGetAsyncResultTracksNothing(int size) {
         setup(size);
-        when(tkvs.getAsync(tableReference, timestampByCellMap))
+        when(dkvs.getAsync(tableReference, timestampByCellMap))
                 .thenReturn(Futures.immediateFailedFuture(new RuntimeException()));
 
         // ignore exception
@@ -147,7 +147,7 @@ public final class TrackingDataKeyValueServiceReadInfoTest {
     public void readInfoIsCorrectAfterGetRowsCall(int size) {
         setup(size);
         ColumnSelection columnSelection = mock(ColumnSelection.class);
-        when(tkvs.getRows(tableReference, rows, columnSelection, TIMESTAMP)).thenReturn(valueByCellMapOfSize);
+        when(dkvs.getRows(tableReference, rows, columnSelection, TIMESTAMP)).thenReturn(valueByCellMapOfSize);
 
         trackingKvs.getRows(tableReference, rows, columnSelection, TIMESTAMP);
 
@@ -159,7 +159,7 @@ public final class TrackingDataKeyValueServiceReadInfoTest {
     public void readInfoIsCorrectAfterGetRowsBatchColumnRangeCallAndIteratorsConsumption(int size) {
         setup(size);
         BatchColumnRangeSelection batchColumnRangeSelection = mock(BatchColumnRangeSelection.class);
-        when(tkvs.getRowsColumnRange(tableReference, rows, batchColumnRangeSelection, TIMESTAMP))
+        when(dkvs.getRowsColumnRange(tableReference, rows, batchColumnRangeSelection, TIMESTAMP))
                 .thenReturn(TrackingKeyValueServiceTestUtils.createRowColumnRangeIteratorByByteArrayMutableMapWithSize(
                         size));
 
@@ -177,7 +177,7 @@ public final class TrackingDataKeyValueServiceReadInfoTest {
         setup(size);
         int cellBatchHint = 17;
         ColumnRangeSelection columnRangeSelection = mock(ColumnRangeSelection.class);
-        when(tkvs.getRowsColumnRange(tableReference, rows, columnRangeSelection, cellBatchHint, TIMESTAMP))
+        when(dkvs.getRowsColumnRange(tableReference, rows, columnRangeSelection, cellBatchHint, TIMESTAMP))
                 .thenReturn(new LocalRowColumnRangeIterator(
                         valueByCellMapOfSize.entrySet().iterator()));
 
@@ -193,7 +193,7 @@ public final class TrackingDataKeyValueServiceReadInfoTest {
     public void readInfoIsCorrectAfterGetLatestTimestampsCall(int size) {
         setup(size);
         Map<Cell, Long> timestampByCellMapOfSize = TrackingKeyValueServiceTestUtils.createLongByCellMapWithSize(size);
-        when(tkvs.getLatestTimestamps(tableReference, timestampByCellMap)).thenReturn(timestampByCellMapOfSize);
+        when(dkvs.getLatestTimestamps(tableReference, timestampByCellMap)).thenReturn(timestampByCellMapOfSize);
 
         trackingKvs.getLatestTimestamps(tableReference, timestampByCellMap);
 
@@ -208,7 +208,7 @@ public final class TrackingDataKeyValueServiceReadInfoTest {
         List<RowResult<Value>> backingValueRowResultListOfSize =
                 TrackingKeyValueServiceTestUtils.createValueRowResultListWithSize(size);
 
-        when(tkvs.getRange(tableReference, rangeRequest, TIMESTAMP))
+        when(dkvs.getRange(tableReference, rangeRequest, TIMESTAMP))
                 .thenReturn(ClosableIterators.wrapWithEmptyClose(backingValueRowResultListOfSize.iterator()));
 
         trackingKvs.getRange(tableReference, rangeRequest, TIMESTAMP).forEachRemaining(_unused -> {});
@@ -224,7 +224,7 @@ public final class TrackingDataKeyValueServiceReadInfoTest {
         Map<RangeRequest, TokenBackedBasicResultsPage<RowResult<Value>, byte[]>> pageByRangeRequestMapOfSize =
                 TrackingKeyValueServiceTestUtils.createPageByRangeRequestMapWithSize(size);
 
-        when(tkvs.getFirstBatchForRanges(tableReference, rangeRequests, TIMESTAMP))
+        when(dkvs.getFirstBatchForRanges(tableReference, rangeRequests, TIMESTAMP))
                 .thenReturn(pageByRangeRequestMapOfSize);
 
         trackingKvs.getFirstBatchForRanges(tableReference, rangeRequests, TIMESTAMP);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -19,7 +19,7 @@ import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.watch.NoOpLockWatchManager;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.schema.SweepSchema;
 import com.palantir.atlasdb.schema.TargetedSweepSchema;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
@@ -80,7 +80,7 @@ public final class SweepTestUtils {
                 TransactionKnowledgeComponents.createForTests(kvs, metricsManager.getTaggedRegistry());
         TransactionManager txManager = SerializableTransactionManager.createForTest(
                 metricsManager,
-                new DelegatingTransactionKeyValueServiceManager(kvs),
+                new DelegatingDataKeyValueServiceManager(kvs),
                 legacyTimelockService,
                 tsmService,
                 lockService,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/AbstractSerializableTransactionTest.java
@@ -54,7 +54,7 @@ import com.palantir.atlasdb.keyvalue.api.RangeRequests;
 import com.palantir.atlasdb.keyvalue.api.RowResult;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.watch.NoOpLockWatchManager;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.keyvalue.impl.KvsManager;
 import com.palantir.atlasdb.keyvalue.impl.TransactionManagerManager;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
@@ -121,7 +121,7 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
         MultiTableSweepQueueWriter sweepQueue = getSweepQueueWriterUninitialized();
         SerializableTransactionManager txManager = SerializableTransactionManager.createForTest(
                 MetricsManagers.createForTests(),
-                new DelegatingTransactionKeyValueServiceManager(keyValueService),
+                new DelegatingDataKeyValueServiceManager(keyValueService),
                 timelockService,
                 timestampManagementService,
                 lockService,
@@ -153,7 +153,7 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
         LongSupplier startTimestampSupplier = Suppliers.ofInstance(timestampService.getFreshTimestamp())::get;
         return new SerializableTransaction(
                 MetricsManagers.createForTests(),
-                transactionKeyValueServiceManager.getTransactionKeyValueService(startTimestampSupplier),
+                dataKeyValueServiceManager.getDataKeyValueService(startTimestampSupplier),
                 timelockService,
                 NoOpLockWatchManager.create(),
                 transactionService,
@@ -173,7 +173,7 @@ public abstract class AbstractSerializableTransactionTest extends AbstractTransa
                 AbstractTransactionTest.DEFAULT_GET_RANGES_CONCURRENCY,
                 getSweepQueueWriterInitialized(),
                 new DefaultDeleteExecutor(
-                        transactionKeyValueServiceManager.getKeyValueService().orElseThrow(),
+                        dataKeyValueServiceManager.getKeyValueService().orElseThrow(),
                         MoreExecutors.newDirectExecutorService()),
                 true,
                 transactionConfigSupplier,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TestTransactionManagerImpl.java
@@ -19,13 +19,13 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.palantir.atlasdb.cache.TimestampCache;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.debug.ConflictTracer;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.impl.AssertLockedKeyValueService;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.ImmutableTransactionConfig;
 import com.palantir.atlasdb.transaction.TransactionConfig;
@@ -117,7 +117,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
 
     private TestTransactionManagerImpl(
             MetricsManager metricsManager,
-            TransactionKeyValueServiceManager keyValueService,
+            DataKeyValueServiceManager keyValueService,
             AbstractInMemoryTimelockExtension services,
             LockService lockService,
             TransactionService transactionService,
@@ -162,8 +162,8 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
         return false;
     }
 
-    private static TransactionKeyValueServiceManager createAssertKeyValue(KeyValueService kv, LockService lock) {
-        return new DelegatingTransactionKeyValueServiceManager(new AssertLockedKeyValueService(kv, lock));
+    private static DataKeyValueServiceManager createAssertKeyValue(KeyValueService kv, LockService lock) {
+        return new DelegatingDataKeyValueServiceManager(new AssertLockedKeyValueService(kv, lock));
     }
 
     @Override
@@ -187,7 +187,7 @@ public class TestTransactionManagerImpl extends SerializableTransactionManager i
         return transactionWrapper.apply(
                 new SerializableTransaction(
                         metricsManager,
-                        transactionKeyValueServiceManager.getTransactionKeyValueService(startTimestampSupplier),
+                        dataKeyValueServiceManager.getDataKeyValueService(startTimestampSupplier),
                         timelockService,
                         lockWatchManager,
                         transactionService,

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/transaction/impl/TransactionTestSetup.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.ComparingTimestampCache;
 import com.palantir.atlasdb.cache.TimestampCache;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.coordination.CoordinationService;
 import com.palantir.atlasdb.encoding.PtBytes;
 import com.palantir.atlasdb.internalschema.ImmutableInternalSchemaInstallConfig;
@@ -36,7 +36,7 @@ import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.keyvalue.api.watch.LockWatchManagerInternal;
 import com.palantir.atlasdb.keyvalue.impl.Cells;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.keyvalue.impl.KvsManager;
 import com.palantir.atlasdb.keyvalue.impl.TransactionManagerManager;
 import com.palantir.atlasdb.persistent.api.PersistentStore;
@@ -120,7 +120,7 @@ public abstract class TransactionTestSetup {
 
     protected final MetricsManager metricsManager = MetricsManagers.createForTests();
     protected KeyValueService keyValueService;
-    protected TransactionKeyValueServiceManager transactionKeyValueServiceManager;
+    protected DataKeyValueServiceManager dataKeyValueServiceManager;
     protected TimestampService timestampService;
     protected TimestampManagementService timestampManagementService;
     protected TransactionSchemaManager transactionSchemaManager;
@@ -154,9 +154,9 @@ public abstract class TransactionTestSetup {
         lockClient = LockClient.of("test_client");
 
         keyValueService = getKeyValueService();
-        transactionKeyValueServiceManager = new DelegatingTransactionKeyValueServiceManager(keyValueService);
+        dataKeyValueServiceManager = new DelegatingDataKeyValueServiceManager(keyValueService);
         deleteExecutor = DefaultDeleteExecutor.createDefault(
-                transactionKeyValueServiceManager.getKeyValueService().orElseThrow());
+                dataKeyValueServiceManager.getKeyValueService().orElseThrow());
         keyValueService.createTables(ImmutableMap.of(
                 TEST_TABLE_THOROUGH,
                 TableMetadata.builder()
@@ -213,7 +213,7 @@ public abstract class TransactionTestSetup {
         conflictDetectionManager = ConflictDetectionManagers.createWithoutWarmingCache(keyValueService);
         sweepStrategyManager = SweepStrategyManagers.createDefault(keyValueService);
         keyValueSnapshotReaderManager = new DefaultKeyValueSnapshotReaderManager(
-                transactionKeyValueServiceManager,
+                dataKeyValueServiceManager,
                 transactionService,
                 false,
                 new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor),

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -19,10 +19,10 @@ import static org.mockito.Mockito.spy;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.cache.DefaultTimestampCache;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.StatsTrackingKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TracingKeyValueService;
@@ -67,7 +67,7 @@ public class AtlasDbTestCase {
     protected LockClient lockClient;
     protected LockService lockService;
     protected TrackingKeyValueService keyValueService;
-    protected TransactionKeyValueServiceManager txnKeyValueServiceManager;
+    protected DataKeyValueServiceManager txnKeyValueServiceManager;
     protected TimelockService timelockService;
     protected TimestampService timestampService;
     protected ConflictDetectionManager conflictDetectionManager;
@@ -95,7 +95,7 @@ public class AtlasDbTestCase {
         timelockService = inMemoryTimelockExtension.getLegacyTimelockService();
         timestampService = inMemoryTimelockExtension.getTimestampService();
         keyValueService = trackingKeyValueService(getBaseKeyValueService());
-        txnKeyValueServiceManager = new DelegatingTransactionKeyValueServiceManager(keyValueService);
+        txnKeyValueServiceManager = new DelegatingDataKeyValueServiceManager(keyValueService);
         TransactionTables.createTables(keyValueService);
         transactionService = spy(TransactionServices.createRaw(keyValueService, timestampService, false));
         conflictDetectionManager = ConflictDetectionManagers.createWithoutWarmingCache(keyValueService);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/keyvalue/impl/TableTasksTest.java
@@ -87,7 +87,7 @@ public class TableTasksTest {
         Cleaner cleaner = new NoOpCleaner();
         txManager = SerializableTransactionManager.createForTest(
                 metricsManager,
-                new DelegatingTransactionKeyValueServiceManager(kvs),
+                new DelegatingDataKeyValueServiceManager(kvs),
                 inMemoryTimelockExtension.getLegacyTimelockService(),
                 inMemoryTimelockExtension.getTimestampManagementService(),
                 lockService,

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AbstractSnapshotTransactionTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/AbstractSnapshotTransactionTest.java
@@ -236,10 +236,10 @@ public abstract class AbstractSnapshotTransactionTest extends AtlasDbTestCase {
     }
 
     private Expectations asyncGetExpectation(
-            DataKeyValueService tkvMock, Cell cell, long transactionTs, LockService lockMock) {
+            DataKeyValueService dkvMock, Cell cell, long transactionTs, LockService lockMock) {
         return new Expectations() {
             {
-                oneOf(tkvMock).getAsync(TABLE, ImmutableMap.of(cell, transactionTs));
+                oneOf(dkvMock).getAsync(TABLE, ImmutableMap.of(cell, transactionTs));
                 will(returnValue(Futures.immediateFailedFuture(new RuntimeException())));
             }
         };

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/FakeDataKeyValueServiceManager.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/FakeDataKeyValueServiceManager.java
@@ -16,23 +16,23 @@
 
 package com.palantir.atlasdb.transaction.impl;
 
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.cell.api.DdlManager;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.Optional;
 import java.util.function.LongSupplier;
 
-public final class FakeTransactionKeyValueServiceManager implements TransactionKeyValueServiceManager {
-    private final TransactionKeyValueService delegate;
+public final class FakeDataKeyValueServiceManager implements DataKeyValueServiceManager {
+    private final DataKeyValueService delegate;
 
-    public FakeTransactionKeyValueServiceManager(TransactionKeyValueService delegate) {
+    public FakeDataKeyValueServiceManager(DataKeyValueService delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public TransactionKeyValueService getTransactionKeyValueService(LongSupplier timestampSupplier) {
+    public DataKeyValueService getDataKeyValueService(LongSupplier timestampSupplier) {
         return delegate;
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/InvalidatableDataKeyValueService.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/InvalidatableDataKeyValueService.java
@@ -16,21 +16,21 @@
 
 package com.palantir.atlasdb.transaction.impl;
 
-import com.palantir.atlasdb.cell.api.AutoDelegate_TransactionKeyValueService;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueService;
+import com.palantir.atlasdb.cell.api.AutoDelegate_DataKeyValueService;
+import com.palantir.atlasdb.cell.api.DataKeyValueService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public final class InvalidatableTransactionKeyValueService implements AutoDelegate_TransactionKeyValueService {
-    private final TransactionKeyValueService delegate;
+public final class InvalidatableDataKeyValueService implements AutoDelegate_DataKeyValueService {
+    private final DataKeyValueService delegate;
     private final AtomicBoolean isStillValid;
 
-    public InvalidatableTransactionKeyValueService(TransactionKeyValueService delegate) {
+    public InvalidatableDataKeyValueService(DataKeyValueService delegate) {
         this.delegate = delegate;
         this.isStillValid = new AtomicBoolean(true);
     }
 
     @Override
-    public TransactionKeyValueService delegate() {
+    public DataKeyValueService delegate() {
         return delegate;
     }
 

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SerializableTransactionManagerTest.java
@@ -34,7 +34,7 @@ import com.palantir.atlasdb.debug.ConflictTracer;
 import com.palantir.atlasdb.keyvalue.api.ClusterAvailabilityStatus;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.watch.NoOpLockWatchManager;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.ImmutableTransactionConfig;
 import com.palantir.atlasdb.transaction.api.KeyValueServiceStatus;
@@ -277,7 +277,7 @@ public class SerializableTransactionManagerTest {
             boolean initializeAsync, Callback<TransactionManager> callBack, ScheduledExecutorService executor) {
         return SerializableTransactionManager.create(
                 metricsManager,
-                new DelegatingTransactionKeyValueServiceManager(mockKvs),
+                new DelegatingDataKeyValueServiceManager(mockKvs),
                 mockTimelockService,
                 NoOpLockWatchManager.create(),
                 mockTimestampManagementService,
@@ -303,7 +303,7 @@ public class SerializableTransactionManagerTest {
                 Optional.empty(),
                 knowledge,
                 new DefaultKeyValueSnapshotReaderManager(
-                        new DelegatingTransactionKeyValueServiceManager(mockKvs),
+                        new DelegatingDataKeyValueServiceManager(mockKvs),
                         mock(TransactionService.class),
                         false,
                         mock(DefaultOrphanedSentinelDeleter.class),

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -329,9 +329,6 @@ public class SnapshotTransactionManagerTest {
 
     private KeyValueSnapshotReaderManager getKeyValueSnapshotReaderManager(SweepStrategyManager sweepStrategyManager) {
         return TestKeyValueSnapshotReaderManagers.createForTests(
-                dataKeyValueServiceManager,
-                mock(TransactionService.class),
-                sweepStrategyManager,
-                deleteExecutor);
+                dataKeyValueServiceManager, mock(TransactionService.class), sweepStrategyManager, deleteExecutor);
     }
 }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -31,12 +31,12 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.cache.DefaultTimestampCache;
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
 import com.palantir.atlasdb.debug.ConflictTracer;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.watch.NoOpLockWatchManager;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
 import com.palantir.atlasdb.transaction.ImmutableTransactionConfig;
 import com.palantir.atlasdb.transaction.api.AtlasDbConstraintCheckingMode;
@@ -80,8 +80,8 @@ public class SnapshotTransactionManagerTest {
     private final Cleaner cleaner = mock(Cleaner.class);
     private final KeyValueService keyValueService = mock(KeyValueService.class);
 
-    private final TransactionKeyValueServiceManager transactionKeyValueServiceManager =
-            new DelegatingTransactionKeyValueServiceManager(keyValueService);
+    private final DataKeyValueServiceManager dataKeyValueServiceManager =
+            new DelegatingDataKeyValueServiceManager(keyValueService);
 
     private final MetricsManager metricsManager = MetricsManagers.createForTests();
 
@@ -102,7 +102,7 @@ public class SnapshotTransactionManagerTest {
         timestampService = inMemoryTimelockClassExtension.getManagedTimestampService();
         snapshotTransactionManager = new SnapshotTransactionManager(
                 metricsManager,
-                transactionKeyValueServiceManager,
+                dataKeyValueServiceManager,
                 inMemoryTimelockClassExtension.getLegacyTimelockService(),
                 NoOpLockWatchManager.create(),
                 timestampService,
@@ -160,7 +160,7 @@ public class SnapshotTransactionManagerTest {
     public void canCloseTransactionManagerWithNonCloseableLockService() {
         SnapshotTransactionManager newTransactionManager = new SnapshotTransactionManager(
                 metricsManager,
-                transactionKeyValueServiceManager,
+                dataKeyValueServiceManager,
                 inMemoryTimelockClassExtension.getLegacyTimelockService(),
                 NoOpLockWatchManager.create(),
                 inMemoryTimelockClassExtension.getManagedTimestampService(),
@@ -300,7 +300,7 @@ public class SnapshotTransactionManagerTest {
             TimelockService timelockService, boolean grabImmutableTsLockOnReads) {
         return new SnapshotTransactionManager(
                 metricsManager,
-                transactionKeyValueServiceManager,
+                dataKeyValueServiceManager,
                 timelockService,
                 NoOpLockWatchManager.create(),
                 timestampService,
@@ -329,7 +329,7 @@ public class SnapshotTransactionManagerTest {
 
     private KeyValueSnapshotReaderManager getKeyValueSnapshotReaderManager(SweepStrategyManager sweepStrategyManager) {
         return TestKeyValueSnapshotReaderManagers.createForTests(
-                transactionKeyValueServiceManager,
+                dataKeyValueServiceManager,
                 mock(TransactionService.class),
                 sweepStrategyManager,
                 deleteExecutor);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TestKeyValueSnapshotReaderManagers.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TestKeyValueSnapshotReaderManagers.java
@@ -16,9 +16,9 @@
 
 package com.palantir.atlasdb.transaction.impl;
 
-import com.palantir.atlasdb.cell.api.TransactionKeyValueServiceManager;
+import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.transaction.api.DeleteExecutor;
 import com.palantir.atlasdb.transaction.api.snapshot.KeyValueSnapshotReaderManager;
 import com.palantir.atlasdb.transaction.impl.snapshot.DefaultKeyValueSnapshotReaderManager;
@@ -32,7 +32,7 @@ public interface TestKeyValueSnapshotReaderManagers {
             SweepStrategyManager sweepStrategyManager,
             DeleteExecutor deleteExecutor) {
         return new DefaultKeyValueSnapshotReaderManager(
-                new DelegatingTransactionKeyValueServiceManager(keyValueService),
+                new DelegatingDataKeyValueServiceManager(keyValueService),
                 transactionService,
                 false,
                 new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor),
@@ -40,12 +40,12 @@ public interface TestKeyValueSnapshotReaderManagers {
     }
 
     static KeyValueSnapshotReaderManager createForTests(
-            TransactionKeyValueServiceManager transactionKeyValueServiceManager,
+            DataKeyValueServiceManager dataKeyValueServiceManager,
             TransactionService transactionService,
             SweepStrategyManager sweepStrategyManager,
             DeleteExecutor deleteExecutor) {
         return new DefaultKeyValueSnapshotReaderManager(
-                transactionKeyValueServiceManager,
+                dataKeyValueServiceManager,
                 transactionService,
                 false,
                 new DefaultOrphanedSentinelDeleter(sweepStrategyManager::get, deleteExecutor),

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/TransactionManagerTest.java
@@ -29,7 +29,7 @@ import com.palantir.atlasdb.cleaner.NoOpCleaner;
 import com.palantir.atlasdb.debug.ConflictTracer;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.watch.NoOpLockWatchManager;
-import com.palantir.atlasdb.keyvalue.impl.DelegatingTransactionKeyValueServiceManager;
+import com.palantir.atlasdb.keyvalue.impl.DelegatingDataKeyValueServiceManager;
 import com.palantir.atlasdb.keyvalue.impl.InMemoryKeyValueService;
 import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
@@ -123,7 +123,7 @@ public class TransactionManagerTest extends TransactionTestSetup {
         LockService mockLockService = mock(LockService.class);
         TransactionManager txnManagerWithMocks = SerializableTransactionManager.createForTest(
                 metricsManager,
-                new DelegatingTransactionKeyValueServiceManager(getKeyValueService()),
+                new DelegatingDataKeyValueServiceManager(getKeyValueService()),
                 mockTimeLockService,
                 mockTimestampManagementService,
                 mockLockService,
@@ -248,7 +248,7 @@ public class TransactionManagerTest extends TransactionTestSetup {
         LockService mockLockService = mock(LockService.class);
         TransactionManager txnManagerWithMocks = new SerializableTransactionManager(
                 metricsManager,
-                new DelegatingTransactionKeyValueServiceManager(keyValueService),
+                new DelegatingDataKeyValueServiceManager(keyValueService),
                 timelock,
                 NoOpLockWatchManager.create(),
                 timeManagement,

--- a/changelog/@unreleased/pr-7307.v2.yml
+++ b/changelog/@unreleased/pr-7307.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: rename TransactionKeyValueService to DataKeyValueService
+  links:
+  - https://github.com/palantir/atlasdb/pull/7307


### PR DESCRIPTION
## General
**Before this PR**:
The name "TransactionKeyValueService" was chosen represent the key value interface available within transactions. After some discussion, we determined that this name was confusing, as it is the interface used to operate on data tables, _not_ on the Transactions tables.

**After this PR**:
DataKeyValueService is a better name, because from the perspective of configuration, the data KVS is responsible for storing the data tables.

This API is currently marked as beta, and there are no production usages at this time, so this rename is safe to do.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
rename TransactionKeyValueService to DataKeyValueService
==COMMIT_MSG==

**Please tag any other people who should be aware of this PR**:
@jeremyk-91


