### PR TITLE
[ASTS] Sweep Bucket Records Table + Assigner usage

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketRecordsTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketRecordsTable.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.palantir.atlasdb.sweep.asts.TimestampRange;
+
+public interface SweepBucketRecordsTable {
+    /**
+     * Returns the {@link TimestampRange} for the given bucket identifier, throwing if one is not present.
+     */
+    TimestampRange getTimestampRangeRecord(long bucketIdentifier);
+
+    void putTimestampRangeRecord(long bucketIdentifier, TimestampRange timestampRange);
+
+    void deleteTimestampRangeRecord(long bucketIdentifier);
+}


### PR DESCRIPTION
## General
**Before this PR**:
We don't keep a record of the sweep timestamp for a given bucket that persists beyond a given bucket being deleted. This is necessary for the background task to know how far we can clean up relevant sweep metadata.

**After this PR**:
We do now!
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P2
**Concerns / possible downsides (what feedback would you like?)**:
I may have just shoved the assertion everywhere in the tests. The ones where we are supposed to write the record, I appended that to the name, but not for those that aren't supposed to write the record.

I could also write separate tests about when the record is and isn't supposed to be written but that seemed overkill.

Will self review tomorrow
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
None
**What was existing testing like? What have you done to improve it?**:
Added more tests
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Record is written
**Has the safety of all log arguments been decided correctly?**:
Yes
**Will this change significantly affect our spending on metrics or logs?**:
I don't imagine the failure between after writing the record and updating the state machine is that common.

**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
It's one extra CAS per bucket
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
If we changed to having a different timestamp range per shard.
## Development Process
**Where should we start reviewing?**:
DBA
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
