### PR TITLE
[ASTS] Concrete implementation of the Sweep Assigned Bucket Store

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
@@ -1,0 +1,319 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
+import com.palantir.atlasdb.keyvalue.api.ColumnSelection;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.TimestampRangeDelete;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.schema.generated.SweepAssignedBucketsTable.SweepAssignedBucketsRow;
+import com.palantir.atlasdb.schema.generated.TargetedSweepTableFactory;
+import com.palantir.atlasdb.sweep.asts.Bucket;
+import com.palantir.atlasdb.sweep.asts.SweepableBucket;
+import com.palantir.atlasdb.sweep.asts.TimestampRange;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.ObjectPersister.LogSafety;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+final class DefaultSweepAssignedBucketStore
+        implements SweepBucketsTable,
+                SweepBucketPointerTable,
+                SweepBucketAssignerStateMachineTable,
+                SweepBucketRecordsTable {
+    private static final SafeLogger log = SafeLoggerFactory.get(DefaultSweepAssignedBucketStore.class);
+    private static final int CAS_ATTEMPT_LIMIT = 5; // TODO: Remove this and share the logic somewhere.
+    private static final TimestampRangeDelete DELETE_ALL_TIMESTAMPS = new TimestampRangeDelete.Builder()
+            .deleteSentinels(true)
+            .timestamp(Long.MAX_VALUE)
+            .endInclusive(true)
+            .build();
+
+    @VisibleForTesting
+    static final TableReference TABLE_REF =
+            TargetedSweepTableFactory.of().getSweepAssignedBucketsTable(null).getTableRef();
+
+    private final KeyValueService keyValueService;
+    private final ObjectPersister<TimestampRange> timestampRangePersister;
+    private final ObjectPersister<BucketStateAndIdentifier> bucketStateAndIdentifierPersister;
+    private final ObjectPersister<Long> bucketIdentifierPersister;
+
+    private DefaultSweepAssignedBucketStore(
+            KeyValueService keyValueService,
+            ObjectPersister<TimestampRange> timestampRangePersister,
+            ObjectPersister<BucketStateAndIdentifier> bucketStateAndIdentifierPersister,
+            ObjectPersister<Long> bucketIdentifierPersister) {
+        this.keyValueService = keyValueService;
+        this.timestampRangePersister = timestampRangePersister;
+        this.bucketStateAndIdentifierPersister = bucketStateAndIdentifierPersister;
+        this.bucketIdentifierPersister = bucketIdentifierPersister;
+    }
+
+    static DefaultSweepAssignedBucketStore create(KeyValueService keyValueService) {
+        ObjectMapper smileMapper = ObjectMappers.newServerSmileMapper();
+        return new DefaultSweepAssignedBucketStore(
+                keyValueService,
+                ObjectPersister.of(smileMapper, TimestampRange.class, LogSafety.SAFE),
+                ObjectPersister.of(smileMapper, BucketStateAndIdentifier.class, LogSafety.SAFE),
+                ObjectPersister.of(smileMapper, Long.class, LogSafety.SAFE));
+    }
+
+    public void setInitialStateForBucketAssigner(long bucketIdentifier, long startTimestamp) {
+        BucketStateAndIdentifier initialState =
+                BucketStateAndIdentifier.of(bucketIdentifier, BucketAssignerState.start(startTimestamp));
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketAssignerStateMachineCell();
+        casCell(cell, Optional.empty(), bucketStateAndIdentifierPersister.trySerialize(initialState));
+    }
+
+    @Override
+    // TODO: What happens when there was no state originally?
+    //  Do we bootstrap it separately, or do we force the caller of getBucketStateAndIdentifier to handle that case.
+    public void updateStateMachineForBucketAssigner(
+            BucketStateAndIdentifier original, BucketStateAndIdentifier updated) {
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketAssignerStateMachineCell();
+        casCell(
+                cell,
+                Optional.of(bucketStateAndIdentifierPersister.trySerialize(original)),
+                bucketStateAndIdentifierPersister.trySerialize(updated));
+    }
+
+    @Override
+    public BucketStateAndIdentifier getBucketStateAndIdentifier() {
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketAssignerStateMachineCell();
+        Optional<BucketStateAndIdentifier> value = readCell(cell, bucketStateAndIdentifierPersister::tryDeserialize);
+        return value.orElseThrow(() -> new SafeIllegalStateException(
+                "No bucket state and identifier found. This should have been bootstrapped during "
+                        + " initialisation, and as such, is an invalid state."));
+    }
+
+    @Override
+    public Set<Bucket> getStartingBucketsForShards(Set<ShardAndStrategy> shardAndStrategies) {
+        List<Cell> cellsToLoad = shardAndStrategies.stream()
+                .map(SweepAssignedBucketStoreKeyPersister.INSTANCE::sweepBucketPointerCell)
+                .collect(Collectors.toList());
+        Map<Cell, Value> result = keyValueService.getRows(
+                TABLE_REF,
+                cellsToLoad.stream().map(Cell::getRowName).collect(Collectors.toList()),
+                // TODO: This is janky.
+
+                ColumnSelection.create(
+                        cellsToLoad.stream().map(Cell::getColumnName).collect(Collectors.toSet())),
+                Long.MAX_VALUE);
+
+        return shardAndStrategies.stream()
+                .map(shardAndStrategy -> {
+                    Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketPointerCell(shardAndStrategy);
+                    return Optional.ofNullable(result.get(cell))
+                            .map(Value::getContents)
+                            .map(bucketIdentifierPersister::tryDeserialize)
+                            .map(bucketIdentifier -> Bucket.of(shardAndStrategy, bucketIdentifier))
+                            .orElseGet(() -> {
+                                log.warn(
+                                        "No starting bucket found for shard and strategy {}",
+                                        SafeArg.of("shardAndStrategy", shardAndStrategy));
+                                return Bucket.of(shardAndStrategy, 0);
+                            });
+                })
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    // TODO: See if we should centralise the work that was done in Jeremy's PR
+    public void updateStartingBucketForShardAndStrategy(Bucket newStartingBucket) {
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketPointerCell(
+                newStartingBucket.shardAndStrategy());
+
+        byte[] serializedBucketProgress = bucketIdentifierPersister.trySerialize(newStartingBucket.bucketIdentifier());
+        for (int attempt = 0; attempt < CAS_ATTEMPT_LIMIT; attempt++) {
+            try {
+                Optional<Long> currentStartingBucket = readCell(cell, bucketIdentifierPersister::tryDeserialize);
+                if (currentStartingBucket.isEmpty()) {
+                    keyValueService.checkAndSet(CheckAndSetRequest.newCell(TABLE_REF, cell, serializedBucketProgress));
+                    if (log.isDebugEnabled()) {
+                        log.debug("Persisted new starting bucket", SafeArg.of("newStartingBucket", newStartingBucket));
+                    }
+                } else {
+                    if (newStartingBucket.bucketIdentifier() > currentStartingBucket.get()) {
+                        keyValueService.checkAndSet(CheckAndSetRequest.singleCell(
+                                TABLE_REF,
+                                cell,
+                                bucketIdentifierPersister.trySerialize(currentStartingBucket.get()),
+                                bucketIdentifierPersister.trySerialize(newStartingBucket.bucketIdentifier())));
+                        if (log.isDebugEnabled()) {
+                            log.debug(
+                                    "Updated sweep bucket progress",
+                                    SafeArg.of("previousStartingBucket", currentStartingBucket),
+                                    SafeArg.of("newStartingBucket", newStartingBucket));
+                        }
+                    } else {
+                        log.info(
+                                "Attempted to update starting bucket, but the existing starting bucket in the database"
+                                        + " was already ahead of us (possible timelock lost lock?)",
+                                SafeArg.of("previousStartingBucket", currentStartingBucket),
+                                SafeArg.of("newStartingBucket", newStartingBucket));
+                    }
+                }
+                return;
+            } catch (RuntimeException e) {
+                if (attempt == CAS_ATTEMPT_LIMIT - 1) {
+                    log.warn(
+                            "Repeatedly failed to update starting bucket as part of sweep; throwing, some work may"
+                                    + " need to be re-done.",
+                            SafeArg.of("attemptedNewStartingBucket", newStartingBucket),
+                            SafeArg.of("numAttempts", CAS_ATTEMPT_LIMIT),
+                            e);
+                    throw e;
+                } else {
+                    log.info(
+                            "Failed to read or update starting bucket as part of sweep. Retrying",
+                            SafeArg.of("newStartingBucket", newStartingBucket),
+                            SafeArg.of("attemptNumber", attempt + 1),
+                            e);
+                }
+            }
+        }
+    }
+
+    @Override
+    // TODO: This is also not simple - we need to keep loading rows until we load n live elements.
+    //  and also need to cap it at the latest bucket identifier.
+
+    // We assume here that each bucket is for a unique shard and strategy
+
+    // Do we actually need to do this? At the time we were going to load 50 buckets which were fine partitions, now
+    // they're 10 minutes long. 50 x 10 minutes is 500 minutes, so almost 10 hours worth of data each time. In a normal
+    // case where startbuckets is near the current bucket identifier, we would shortcircuit, but the algorithm for
+    // iteratively
+    // loading optimal is a little bit more complex. Is it sufficient to just load the row of the startBucket (and maybe
+    // the row after it)
+    // and return everything there? There may be no buckets (if startBucket hasn't updated yet), but this should be
+    // short lived (assuming the background task is running).
+    // This however does add a dependence on the background task actually running, however, whereas a model that keeps
+    // searching until we load n buckets or reach the end
+    // would work even if the background task does not run.
+
+    // TODO:
+    //  Do an iteration of all startMajorBucketIdentifierByShardAndStrategy
+    //  Add to set, and then decrement from maxRemainingBucketsToLoad.
+    //  If less than 0, then remove from startMajorBucketIdentifierByShardAndStrategy.
+    //  Cap the major identifier to the major equivalent of the maxBucketIdentifier.
+    //  Repeat until complete
+    public Set<SweepableBucket> getSweepableBuckets(Set<Bucket> startBuckets) {
+        List<SweepAssignedBucketsRow> rows = startBuckets.stream()
+                .flatMap(bucket -> Stream.of(
+                        SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketsRow(bucket),
+                        SweepAssignedBucketStoreKeyPersister.INSTANCE.nextSweepBucketsRow(bucket)))
+                .collect(Collectors.toList());
+
+        return readRows(rows);
+    }
+
+    @Override
+    public void putTimestampRangeForBucket(
+            Bucket bucket, Optional<TimestampRange> oldTimestampRange, TimestampRange newTimestampRange) {
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketsCell(bucket);
+        casCell(
+                cell,
+                oldTimestampRange.map(timestampRangePersister::trySerialize),
+                timestampRangePersister.trySerialize(newTimestampRange));
+    }
+
+    @Override
+    public void deleteBucketEntry(Bucket bucket) {
+        deleteCell(SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketsCell(bucket));
+    }
+
+    @Override
+    public TimestampRange getTimestampRangeRecord(long bucketIdentifier) {
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketRecordsCell(bucketIdentifier);
+        return readCell(cell, timestampRangePersister::tryDeserialize)
+                .orElseThrow(() -> new SafeIllegalStateException(
+                        "No timestamp range record found for bucket identifier",
+                        SafeArg.of("bucketIdentifier", bucketIdentifier)));
+    }
+
+    @Override
+    public void putTimestampRangeRecord(long bucketIdentifier, TimestampRange timestampRange) {
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketRecordsCell(bucketIdentifier);
+        casCell(cell, Optional.empty(), timestampRangePersister.trySerialize(timestampRange));
+    }
+
+    @Override
+    public void deleteTimestampRangeRecord(long bucketIdentifier) {
+        deleteCell(SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketRecordsCell(bucketIdentifier));
+    }
+
+    private void casCell(Cell cell, Optional<byte[]> existingValue, byte[] newValue) {
+        CheckAndSetRequest request = existingValue
+                .map(value -> CheckAndSetRequest.singleCell(TABLE_REF, cell, value, newValue))
+                .orElseGet(() -> CheckAndSetRequest.newCell(TABLE_REF, cell, newValue));
+        keyValueService.checkAndSet(request);
+    }
+
+    private <T> Optional<T> readCell(Cell cell, Function<byte[], T> deserializer) {
+        Map<Cell, Value> values = keyValueService.get(TABLE_REF, ImmutableMap.of(cell, Long.MAX_VALUE));
+        System.out.println(values);
+        Optional<byte[]> value = Optional.ofNullable(values.get(cell)).map(Value::getContents);
+        return value.map(deserializer);
+    }
+
+    private void deleteCell(Cell cell) {
+        // TODO(mdaudali): This is sneaky, in that we know (or believe, and tests will confirm), for now, that the
+        // timestamp written for the CAS is always 0, and so we can simply issue the delete to 0.
+        // If the CAS timestamp was to change, then this test would break.
+
+        // DO NOT CHANGE from 0L without understanding the implications. You likely need to move to a rangeDelete to
+        // delete all timestamps
+
+        // LATER change - I actually don't think we can do a point delete of TS 0, because the CAS will have a different
+        // CASSANDRA timestamp, and so by last write wins, the delete won't apply.
+
+        // Instead, I think we need to do a deleteAllTimestamps A LA sweep.
+
+        // We know that no one should ever write to a cell that was deleted, and so applying a giant range tombstone
+        // is still correct.
+        keyValueService.deleteAllTimestamps(TABLE_REF, ImmutableMap.of(cell, DELETE_ALL_TIMESTAMPS));
+    }
+
+    private Set<SweepableBucket> readRows(List<SweepAssignedBucketsRow> rows) {
+        Map<Cell, Value> reads = keyValueService.getRows(
+                TABLE_REF,
+                rows.stream().map(SweepAssignedBucketsRow::persistToBytes).collect(Collectors.toList()),
+                ColumnSelection.all(),
+                Long.MAX_VALUE);
+        return reads.entrySet().stream()
+                .map(entry -> SweepAssignedBucketStoreKeyPersister.INSTANCE.fromSweepBucketCellAndValue(
+                        entry.getKey(), entry.getValue(), timestampRangePersister))
+                .collect(Collectors.toSet());
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepAssignedBucketStoreKeyPersister.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepAssignedBucketStoreKeyPersister.java
@@ -1,0 +1,131 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.schema.generated.SweepAssignedBucketsTable.SweepAssignedBucketsColumn;
+import com.palantir.atlasdb.schema.generated.SweepAssignedBucketsTable.SweepAssignedBucketsRow;
+import com.palantir.atlasdb.sweep.asts.Bucket;
+import com.palantir.atlasdb.sweep.asts.SweepableBucket;
+import com.palantir.atlasdb.sweep.asts.TimestampRange;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.table.description.SweeperStrategy;
+
+/**
+ * The layout for this table is intended to be:
+ *
+ * +--------------------------+---------------+-----------------+-----------------+-----------------+
+ * |           Row            |    Col -1     |        0        |        1        |        X        |
+ * +--------------------------+---------------+-----------------+-----------------+-----------------+
+ * | (-1, -1, -1)             | STATE_MACHINE |                 |                 |                 |
+ * | (shard, -1, strategy)    | START_BUCKET  |                 |                 |                 |
+ * | (-1, major, -1)          | -             | TIMESTAMP_RANGE | TIMESTAMP_RANGE | TIMESTAMP_RANGE |
+ * | (shard, major, strategy) | -             | BUCKET          | BUCKET          | BUCKET          |
+ * +--------------------------+---------------+-----------------+-----------------+-----------------+
+ * Where shard, strategy, major are nonnegative.
+ *
+ * TODO(mdaudali): It is not required that we reserve -1 on the row side _xor_ -1 column. Should we remove one of those
+ *  dimensions. I kept the -1s around to highlight these are special cells, but it's not critical.
+ *
+ */
+enum SweepAssignedBucketStoreKeyPersister {
+    INSTANCE;
+
+    private static final long ROW_LENGTH = 100;
+    private static final byte RESERVED_IDENTIFIER = -1;
+
+    private static final byte[] RESERVED_STRATEGY = new byte[] {RESERVED_IDENTIFIER};
+    private static final byte[] RESERVED_COLUMN =
+            SweepAssignedBucketsColumn.of(RESERVED_IDENTIFIER).persistToBytes();
+    private static final Cell SWEEP_BUCKET_ASSIGNER_STATE_MACHINE_CELL = Cell.create(
+            SweepAssignedBucketsRow.of(RESERVED_IDENTIFIER, RESERVED_IDENTIFIER, RESERVED_STRATEGY)
+                    .persistToBytes(),
+            RESERVED_COLUMN);
+
+    Cell sweepBucketsCell(Bucket bucket) {
+        SweepAssignedBucketsRow row = sweepBucketsRow(bucket);
+        SweepAssignedBucketsColumn column =
+                SweepAssignedBucketsColumn.of(minorBucketIdentifier(bucket.bucketIdentifier()));
+        return Cell.create(row.persistToBytes(), column.persistToBytes());
+    }
+
+    SweepAssignedBucketsRow sweepBucketsRow(Bucket bucket) {
+        return SweepAssignedBucketsRow.of(
+                bucket.shardAndStrategy().shard(),
+                majorBucketIdentifier(bucket.bucketIdentifier()),
+                bucket.shardAndStrategy().strategy().persistToBytes());
+    }
+
+    SweepAssignedBucketsRow nextSweepBucketsRow(Bucket bucket) {
+        SweepAssignedBucketsRow currentRow = sweepBucketsRow(bucket);
+        return SweepAssignedBucketsRow.of(
+                currentRow.getShard(), currentRow.getMajorBucketIdentifier() + 1, currentRow.getStrategy());
+    }
+
+    SweepableBucket fromSweepBucketCellAndValue(
+            Cell cell, Value value, ObjectPersister<TimestampRange> timestampRangePersister) {
+        SweepAssignedBucketsRow row = SweepAssignedBucketsRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName());
+        SweepAssignedBucketsColumn column =
+                SweepAssignedBucketsColumn.BYTES_HYDRATOR.hydrateFromBytes(cell.getColumnName());
+        TimestampRange timestampRange = timestampRangePersister.tryDeserialize(value.getContents());
+        int shard = Math.toIntExact(row.getShard()); // throws if invalid shard
+        // TODO(mdaudali): Should we replace the DefaultBucketKeySerializer sweeper persister with
+        //  sweeperStrategy#persistToBytes
+        return SweepableBucket.of(
+                Bucket.of(
+                        ShardAndStrategy.of(shard, SweeperStrategy.BYTES_HYDRATOR.hydrateFromBytes(row.getStrategy())),
+                        bucketIdentifier(row.getMajorBucketIdentifier(), column.getMinorBucketIdentifier())),
+                timestampRange);
+    }
+
+    Cell sweepBucketAssignerStateMachineCell() {
+        return SWEEP_BUCKET_ASSIGNER_STATE_MACHINE_CELL;
+    }
+
+    Cell sweepBucketPointerCell(ShardAndStrategy shardAndStrategy) {
+        SweepAssignedBucketsRow row = SweepAssignedBucketsRow.of(
+                shardAndStrategy.shard(),
+                RESERVED_IDENTIFIER,
+                shardAndStrategy.strategy().persistToBytes());
+        return Cell.create(row.persistToBytes(), RESERVED_COLUMN);
+    }
+
+    // This is _not_ keyed on the shard and strategy, which does make clean up harder. We estimate this to be around
+    // 25MB of data per keyspace per year, which we believe is fine to abandon.
+    // If you do want to have the ability to retention the data, consider a one off task to clean up old data, or
+    // to _not_ delete the bucket in the foreground cleaner, but instead to mark it as deleted and actually delete it
+    // in the background task
+    Cell sweepBucketRecordsCell(long bucketIdentifier) {
+        SweepAssignedBucketsRow row = SweepAssignedBucketsRow.of(
+                RESERVED_IDENTIFIER, majorBucketIdentifier(bucketIdentifier), RESERVED_STRATEGY);
+        SweepAssignedBucketsColumn column = SweepAssignedBucketsColumn.of(minorBucketIdentifier(bucketIdentifier));
+        return Cell.create(row.persistToBytes(), column.persistToBytes());
+    }
+
+    private static long bucketIdentifier(long majorBucketIdentifier, long minorBucketIdentifier) {
+        return majorBucketIdentifier * ROW_LENGTH + minorBucketIdentifier;
+    }
+
+    private static long majorBucketIdentifier(long bucketIdentifier) {
+        return bucketIdentifier / ROW_LENGTH;
+    }
+
+    private static long minorBucketIdentifier(long bucketIdentifier) {
+        return bucketIdentifier % ROW_LENGTH;
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketRecordsTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketRecordsTable.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.palantir.atlasdb.sweep.asts.TimestampRange;
+
+public interface SweepBucketRecordsTable {
+    /**
+     * Returns the {@link TimestampRange} for the given bucket identifier, throwing if one is not present.
+     */
+    TimestampRange getTimestampRangeRecord(long bucketIdentifier);
+
+    void putTimestampRangeRecord(long bucketIdentifier, TimestampRange timestampRange);
+
+    void deleteTimestampRangeRecord(long bucketIdentifier);
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStoreTest.java
@@ -1,0 +1,286 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
+import com.palantir.atlasdb.schema.TargetedSweepSchema;
+import com.palantir.atlasdb.sweep.asts.Bucket;
+import com.palantir.atlasdb.sweep.asts.SweepableBucket;
+import com.palantir.atlasdb.sweep.asts.TimestampRange;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.table.description.Schemas;
+import com.palantir.atlasdb.table.description.SweeperStrategy;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+// TODO(mdaudali): make these tests abstract like the other tests for BucketProgress
+class DefaultSweepAssignedBucketStoreTest {
+    private final TestResourceManager testResourceManager = TestResourceManager.inMemory();
+    private final KeyValueService keyValueService = testResourceManager.getDefaultKvs();
+    private final DefaultSweepAssignedBucketStore store = DefaultSweepAssignedBucketStore.create(keyValueService);
+
+    @BeforeEach
+    public void before() {
+        Schemas.createTablesAndIndexes(TargetedSweepSchema.INSTANCE.getLatestSchema(), keyValueService);
+        keyValueService.truncateTable(DefaultSweepAssignedBucketStore.TABLE_REF);
+    }
+
+    @Test
+    public void getBucketStateAndIdentifierThrowsIfNoState() {
+        assertThatLoggableExceptionThrownBy(store::getBucketStateAndIdentifier)
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasLogMessage("No bucket state and identifier found. This should have been bootstrapped during "
+                        + " initialisation, and as such, is an invalid state.");
+    }
+
+    @Test
+    public void setInitialStateCreatesStartingState() {
+        long bucketIdentifier = 123;
+        long startTimestamp = 456;
+        store.setInitialStateForBucketAssigner(bucketIdentifier, startTimestamp);
+        BucketStateAndIdentifier initialState =
+                BucketStateAndIdentifier.of(bucketIdentifier, BucketAssignerState.start(startTimestamp));
+        assertThat(store.getBucketStateAndIdentifier()).isEqualTo(initialState);
+    }
+
+    @Test
+    public void cannotSetInitialStateWhenStateAlreadyExists() {
+        store.setInitialStateForBucketAssigner(123, 456);
+        assertThatThrownBy(() -> store.setInitialStateForBucketAssigner(789, 101112))
+                .isInstanceOf(CheckAndSetException.class);
+    }
+
+    @Test // TODO: test a present and different value, and a value that just does not exist.
+    public void updateStateMachineForBucketAssignerFailsIfInitialDoesNotMatchExisting() {
+        store.setInitialStateForBucketAssigner(123, 456);
+        BucketStateAndIdentifier incorrectInitialState =
+                BucketStateAndIdentifier.of(123, BucketAssignerState.start(789));
+        BucketStateAndIdentifier newState = BucketStateAndIdentifier.of(123, BucketAssignerState.start(101112));
+        assertThatThrownBy(() -> store.updateStateMachineForBucketAssigner(incorrectInitialState, newState))
+                .isInstanceOf(CheckAndSetException.class);
+    }
+
+    @Test
+    public void updateStateMachineForBucketAssignerModifiesStateToNewIfOriginalMatchesExisting() {
+        store.setInitialStateForBucketAssigner(123, 456);
+        BucketStateAndIdentifier initialState = BucketStateAndIdentifier.of(123, BucketAssignerState.start(456));
+        BucketStateAndIdentifier newState = BucketStateAndIdentifier.of(123, BucketAssignerState.start(101112));
+        store.updateStateMachineForBucketAssigner(initialState, newState);
+        assertThat(store.getBucketStateAndIdentifier()).isEqualTo(newState);
+    }
+
+    @Test
+    public void getStartingBucketsForShardReturnsStartingBucketWhenSet() {
+        List<Bucket> buckets = List.of(
+                Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 512),
+                Bucket.of(ShardAndStrategy.of(54, SweeperStrategy.CONSERVATIVE), 154389),
+                Bucket.of(ShardAndStrategy.of(25, SweeperStrategy.NON_SWEEPABLE), 97312907));
+
+        buckets.forEach(store::updateStartingBucketForShardAndStrategy);
+
+        assertThat(store.getStartingBucketsForShards(
+                        buckets.stream().map(Bucket::shardAndStrategy).collect(Collectors.toSet())))
+                .containsExactlyInAnyOrderElementsOf(buckets);
+    }
+
+    @Test
+    public void getStartingBucketsForShardReturnsZeroBucketIdentifierForUnsetShards() {
+        Bucket bucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 512);
+        Bucket unsetBucket = Bucket.of(ShardAndStrategy.of(54, SweeperStrategy.CONSERVATIVE), 0);
+
+        store.updateStartingBucketForShardAndStrategy(bucket);
+
+        assertThat(store.getStartingBucketsForShards(Set.of(bucket.shardAndStrategy(), unsetBucket.shardAndStrategy())))
+                .containsExactlyInAnyOrder(bucket, unsetBucket);
+    }
+
+    @Test
+    public void updateStartingBucketForShardDoesNotDecreaseExistingValue() {
+        Bucket existingBucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 512);
+        Bucket newBucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 256);
+
+        store.updateStartingBucketForShardAndStrategy(existingBucket);
+        store.updateStartingBucketForShardAndStrategy(newBucket);
+
+        assertThat(store.getStartingBucketsForShards(Set.of(existingBucket.shardAndStrategy())))
+                .containsExactly(existingBucket);
+    }
+
+    @Test
+    public void updateStartingBucketForShardSetsToAtLeastExistingValue() {
+        Bucket existingBucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 512);
+        Bucket newBucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 1024);
+
+        store.updateStartingBucketForShardAndStrategy(existingBucket);
+        store.updateStartingBucketForShardAndStrategy(newBucket);
+
+        assertThat(store.getStartingBucketsForShards(Set.of(existingBucket.shardAndStrategy())))
+                .containsExactly(newBucket);
+    }
+
+    @Test
+    public void getSweepableBucketsReturnsTimestampRangesforPresentBucketsForEachShardUpToTwoHundredBuckets() {
+        ShardAndStrategy shardAndStrategy = ShardAndStrategy.of(12, SweeperStrategy.THOROUGH);
+        List<SweepableBucket> buckets = IntStream.range(0, 400)
+                .mapToObj(i -> SweepableBucket.of(Bucket.of(shardAndStrategy, i), TimestampRange.of(i, i + 1)))
+                .collect(Collectors.toList());
+        buckets.forEach(
+                bucket -> store.putTimestampRangeForBucket(bucket.bucket(), Optional.empty(), bucket.timestampRange()));
+
+        assertThat(store.getSweepableBuckets(Set.of(Bucket.of(shardAndStrategy, 0))))
+                .containsExactlyInAnyOrderElementsOf(buckets.subList(0, 200));
+    }
+
+    @Test
+    public void getSweepableBucketsSkipsBucketsWithMajorIdentifierBeforeStartBucketProvided() {
+        ShardAndStrategy shardAndStrategy = ShardAndStrategy.of(12, SweeperStrategy.THOROUGH);
+        List<SweepableBucket> buckets = IntStream.range(0, 200)
+                .mapToObj(i -> SweepableBucket.of(Bucket.of(shardAndStrategy, i), TimestampRange.of(i, i + 1)))
+                .collect(Collectors.toList());
+
+        buckets.forEach(
+                bucket -> store.putTimestampRangeForBucket(bucket.bucket(), Optional.empty(), bucket.timestampRange()));
+
+        assertThat(store.getSweepableBuckets(Set.of(Bucket.of(shardAndStrategy, 100))))
+                .containsExactlyInAnyOrderElementsOf(buckets.subList(100, 200));
+    }
+
+    @Test
+    public void getSweepableBucketsReturnsLessThanMaxBucketLimitIfLessThanTwoHundredBucketsPresent() {
+        ShardAndStrategy shardAndStrategy = ShardAndStrategy.of(12, SweeperStrategy.THOROUGH);
+        List<SweepableBucket> buckets = IntStream.range(0, 10)
+                .mapToObj(i -> SweepableBucket.of(Bucket.of(shardAndStrategy, i), TimestampRange.of(i, i + 1)))
+                .collect(Collectors.toList());
+
+        buckets.forEach(
+                bucket -> store.putTimestampRangeForBucket(bucket.bucket(), Optional.empty(), bucket.timestampRange()));
+
+        assertThat(store.getSweepableBuckets(Set.of(Bucket.of(shardAndStrategy, 0))))
+                .containsExactlyInAnyOrderElementsOf(buckets);
+    }
+
+    @Test
+    public void getSweepableBucketsReturnsBucketsPerShardAndStrategy() {
+        List<Bucket> startBuckets = List.of(
+                Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 0),
+                Bucket.of(ShardAndStrategy.of(54, SweeperStrategy.CONSERVATIVE), 1000),
+                Bucket.of(ShardAndStrategy.of(25, SweeperStrategy.NON_SWEEPABLE), 5050));
+
+        List<SweepableBucket> buckets = IntStream.range(0, 112) // 112 chosen arbitrarily below 200
+                .mapToObj(i -> {
+                    TimestampRange range = TimestampRange.of(i, i + 1);
+                    return startBuckets.stream()
+                            .map(bucket -> SweepableBucket.of(
+                                    Bucket.of(bucket.shardAndStrategy(), bucket.bucketIdentifier() + i), range));
+                })
+                .flatMap(Function.identity())
+                .collect(Collectors.toList());
+
+        buckets.forEach(
+                bucket -> store.putTimestampRangeForBucket(bucket.bucket(), Optional.empty(), bucket.timestampRange()));
+
+        assertThat(store.getSweepableBuckets(new HashSet<>(startBuckets))).containsExactlyInAnyOrderElementsOf(buckets);
+    }
+
+    @Test
+    public void putTimestampRangeForBucketFailsIfOldTimestampRangeDoesNotMatchCurrent() {
+        Bucket bucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 512);
+        TimestampRange oldTimestampRange = TimestampRange.of(0, 1); // Not actually set
+        TimestampRange newTimestampRange = TimestampRange.of(1, 2);
+
+        assertThatThrownBy(() ->
+                        store.putTimestampRangeForBucket(bucket, Optional.of(oldTimestampRange), newTimestampRange))
+                .isInstanceOf(CheckAndSetException.class);
+    }
+
+    @Test
+    public void putTimestampRangeForBucketSucceedsIfOldTimestampRangeMatchesCurrent() {
+        Bucket bucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 512);
+        TimestampRange newTimestampRange = TimestampRange.of(1, 2);
+
+        store.putTimestampRangeForBucket(bucket, Optional.empty(), newTimestampRange);
+        Set<SweepableBucket> sweepableBuckets = store.getSweepableBuckets(Set.of(bucket));
+        assertThat(sweepableBuckets).containsExactly(SweepableBucket.of(bucket, newTimestampRange));
+    }
+
+    @Test
+    public void deleteBucketEntryDoesNotThrowIfBucketNotPresent() {
+        Bucket bucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 512);
+        assertThatCode(() -> store.deleteBucketEntry(bucket)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void deleteBucketEntryDeletesBucket() {
+        Bucket bucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 512);
+        TimestampRange timestampRange = TimestampRange.of(1, 2);
+        store.putTimestampRangeForBucket(bucket, Optional.empty(), timestampRange);
+        store.deleteBucketEntry(bucket);
+        assertThat(store.getSweepableBuckets(Set.of(bucket))).isEmpty();
+    }
+
+    @Test
+    public void getTimestampRangeRecordThrowsIfRecordNotPresent() {
+        assertThatLoggableExceptionThrownBy(() -> store.getTimestampRangeRecord(1))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasLogMessage("No timestamp range record found for bucket identifier")
+                .hasExactlyArgs(SafeArg.of("bucketIdentifier", 1L));
+    }
+
+    @Test
+    public void putTimestampRangeRecordPutsRecord() {
+        TimestampRange timestampRange = TimestampRange.of(1, 2);
+        store.putTimestampRangeRecord(1, timestampRange);
+        assertThat(store.getTimestampRangeRecord(1)).isEqualTo(timestampRange);
+    }
+
+    @Test
+    public void putTimestampRangeRecordFailsIfRecordAlreadyExists() {
+        TimestampRange timestampRange = TimestampRange.of(1, 2);
+        store.putTimestampRangeRecord(1, timestampRange);
+        assertThatThrownBy(() -> store.putTimestampRangeRecord(1, timestampRange))
+                .isInstanceOf(CheckAndSetException.class);
+    }
+
+    @Test
+    public void deleteTimestampRangeRecordDoesNotThrowIfRecordNotPresent() {
+        assertThatCode(() -> store.deleteTimestampRangeRecord(1)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void deleteTimestampRangeRecordDeletesRecord() {
+        TimestampRange timestampRange = TimestampRange.of(1, 2);
+        store.putTimestampRangeRecord(1, timestampRange);
+        store.deleteTimestampRangeRecord(1);
+        assertThatThrownBy(() -> store.getTimestampRangeRecord(1)).isInstanceOf(SafeIllegalStateException.class);
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepAssignedBucketStoreKeyPersisterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepAssignedBucketStoreKeyPersisterTest.java
@@ -1,0 +1,272 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.io.BaseEncoding;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.schema.generated.SweepAssignedBucketsTable.SweepAssignedBucketsRow;
+import com.palantir.atlasdb.sweep.asts.Bucket;
+import com.palantir.atlasdb.sweep.asts.SweepableBucket;
+import com.palantir.atlasdb.sweep.asts.TimestampRange;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.ObjectPersister.LogSafety;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.table.description.SweeperStrategy;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.eclipse.collections.impl.factory.Sets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public final class SweepAssignedBucketStoreKeyPersisterTest {
+    private static final ObjectPersister<TimestampRange> TIMESTAMP_RANGE_PERSISTER =
+            ObjectPersister.of(ObjectMappers.newServerSmileMapper(), TimestampRange.class, LogSafety.SAFE);
+
+    private static final Map<Bucket, Cell> GOLDEN_BUCKETS = Map.of(
+            Bucket.of(ShardAndStrategy.conservative(0), 0),
+            fromBase64("95dIh9y7UDyAgAE=", "gA=="),
+            Bucket.of(ShardAndStrategy.conservative(0), 1),
+            fromBase64("95dIh9y7UDyAgAE=", "gQ=="),
+            Bucket.of(ShardAndStrategy.conservative(1), 0),
+            fromBase64("HdZZiImVreeBgAE=", "gA=="),
+            Bucket.of(ShardAndStrategy.thorough(0), 10000000),
+            fromBase64("S75hl43DqVyA4YagAA==", "gA=="),
+            Bucket.of(ShardAndStrategy.thorough(0), 1),
+            fromBase64("uOHLXMd0L9KAgAA=", "gQ=="),
+            Bucket.of(ShardAndStrategy.thorough(1), 1245123123),
+            fromBase64("jAxmaZeQfpWB8L39nwA=", "lw=="),
+            Bucket.of(ShardAndStrategy.nonSweepable(), Long.MAX_VALUE),
+            fromBase64("PpljSwhiGMuA/4FHrhR64UeuAg==", "hw=="));
+
+    private static final Map<TimestampRange, Value> GOLDEN_TIMESTAMP_RANGES = Map.of(
+            TimestampRange.of(912301923, Long.MAX_VALUE),
+            Value.create(
+                    BaseEncoding.base64()
+                            .decode("OikKBfqNc3RhcnRJbmNsdXNpdmUkDUwJe4aLZW5kRXhjbHVzaXZlJQN/f39/f39/f777"),
+                    -1),
+            TimestampRange.openBucket(13123),
+            Value.create(BaseEncoding.base64().decode("OikKBfqNc3RhcnRJbmNsdXNpdmUkAxqGi2VuZEV4Y2x1c2l2ZcH7"), -1));
+
+    private static final Cell GOLDEN_SWEEP_BUCKET_ASSIGNER_STATE_MACHINE_CELL = Cell.create(
+            BaseEncoding.base64().decode("GTH5RX8BW6N/f/8="),
+            BaseEncoding.base64().decode("fw=="));
+
+    private static final Map<ShardAndStrategy, Cell> GOLDEN_SWEEP_BUCKET_POINTER_CELLS = Map.of(
+            ShardAndStrategy.conservative(0),
+            fromBase64("S0/IrI4nnp+AfwE=", "fw=="),
+            ShardAndStrategy.conservative(1),
+            fromBase64("s1rdA0gzO/CBfwE=", "fw=="),
+            ShardAndStrategy.thorough(0),
+            fromBase64("SovRDVViVQKAfwA=", "fw=="),
+            ShardAndStrategy.thorough(1),
+            fromBase64("uPBDJgpXMfeBfwA=", "fw=="),
+            ShardAndStrategy.nonSweepable(),
+            fromBase64("pWhFqaJi6q2AfwI=", "fw=="));
+
+    private static final Map<Long, Cell> GOLDEN_SWEEP_BUCKET_RECORDS_CELLS = Map.of(
+            0L,
+            fromBase64("odL6eJE/9Q9/gP8=", "gA=="),
+            1L,
+            fromBase64("odL6eJE/9Q9/gP8=", "gQ=="),
+            2L,
+            fromBase64("odL6eJE/9Q9/gP8=", "gg=="),
+            311421L,
+            fromBase64("6ty/CriS/L1/zCr/", "lQ=="),
+            Long.MAX_VALUE,
+            fromBase64("C4tS7h1RgGV//4FHrhR64Ueu/w==", "hw=="));
+
+    @Test
+    public void differentBucketsMapToDifferentSweepBucketsCells() {
+        List<Cell> cells = buckets().stream()
+                .map(SweepAssignedBucketStoreKeyPersister.INSTANCE::sweepBucketsCell)
+                .collect(Collectors.toList());
+
+        assertThat(cells).doesNotHaveDuplicates();
+    }
+
+    @ParameterizedTest
+    @MethodSource("goldenSweepBucketsCells")
+    public void bucketMapsToHistoricSweepBucketsCell(Bucket bucket, Cell expectedCell) {
+        Cell actualCell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketsCell(bucket);
+        assertThat(actualCell).isEqualTo(expectedCell);
+    }
+
+    // The tests for checking buckets map to historic rows are omitted as this is covered by the cell tests above.
+    @ParameterizedTest
+    @MethodSource("buckets")
+    public void nextSweepBucketsRowGetsNextRowByMajorBucketIdentifier(Bucket bucket) {
+        SweepAssignedBucketsRow currentRow = SweepAssignedBucketStoreKeyPersister.INSTANCE.nextSweepBucketsRow(bucket);
+        SweepAssignedBucketsRow nextRow = SweepAssignedBucketStoreKeyPersister.INSTANCE.nextSweepBucketsRow(bucket);
+
+        SweepAssignedBucketsRow expectedNextRow = SweepAssignedBucketsRow.of(
+                currentRow.getShard(), currentRow.getMajorBucketIdentifier(), currentRow.getStrategy());
+        assertThat(nextRow).isEqualTo(expectedNextRow);
+    }
+
+    @ParameterizedTest
+    @MethodSource("sweepableBuckets") // TODO: This has 150 test cases. That seems overkill...
+    public void canDeserializeCellsAndValuesBackToSweepableBucket(SweepableBucket sweepableBucket) {
+        Value value = Value.create(
+                TIMESTAMP_RANGE_PERSISTER.trySerialize(sweepableBucket.timestampRange()),
+                -1); // Timestamp does not matter
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketsCell(sweepableBucket.bucket());
+        SweepableBucket deserialisedSweepableBucket =
+                SweepAssignedBucketStoreKeyPersister.INSTANCE.fromSweepBucketCellAndValue(
+                        cell, value, TIMESTAMP_RANGE_PERSISTER);
+
+        assertThat(deserialisedSweepableBucket).isEqualTo(sweepableBucket);
+    }
+
+    @ParameterizedTest
+    @MethodSource("goldenSweepBucketCellsAndValues")
+    public void canDeserializeHistoricCellsAndValuesBackToSweepableBucket(
+            SweepableBucket sweepableBucket, Cell cell, Value value) {
+        SweepableBucket deserialisedSweepableBucket =
+                SweepAssignedBucketStoreKeyPersister.INSTANCE.fromSweepBucketCellAndValue(
+                        cell, value, TIMESTAMP_RANGE_PERSISTER);
+
+        assertThat(deserialisedSweepableBucket).isEqualTo(sweepableBucket);
+    }
+
+    @Test
+    public void sweepBucketAssignerStateMachineCellMatchesHistoricCell() {
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketAssignerStateMachineCell();
+        assertThat(cell).isEqualTo(GOLDEN_SWEEP_BUCKET_ASSIGNER_STATE_MACHINE_CELL);
+    }
+
+    @Test
+    public void differentShardsAndStrategiesMapToDifferentSweepBucketPointerCells() {
+        Stream<ShardAndStrategy> shardsAndStrategies = Stream.of(
+                ShardAndStrategy.conservative(0),
+                ShardAndStrategy.conservative(1),
+                ShardAndStrategy.conservative(255),
+                ShardAndStrategy.thorough(0),
+                ShardAndStrategy.thorough(1),
+                ShardAndStrategy.thorough(212),
+                ShardAndStrategy.nonSweepable());
+
+        List<Cell> cells = shardsAndStrategies
+                .map(SweepAssignedBucketStoreKeyPersister.INSTANCE::sweepBucketPointerCell)
+                .collect(Collectors.toList());
+
+        assertThat(cells).doesNotHaveDuplicates();
+    }
+
+    @ParameterizedTest
+    @MethodSource("goldenSweepBucketPointerCells")
+    public void shardsAndStrategiesMapToHistoricSweepBucketPointerCells(
+            ShardAndStrategy shardAndStrategy, Cell expectedCell) {
+        Cell actualCell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketPointerCell(shardAndStrategy);
+        assertThat(actualCell).isEqualTo(expectedCell);
+    }
+
+    @Test
+    public void differentBucketIdentifiersMapToDifferentSweepBucketRecordsCells() {
+        Set<Integer> bucketIdentifiers = Set.of(0, 1, 123123, Integer.MAX_VALUE);
+        List<Cell> cells = bucketIdentifiers.stream()
+                .map(SweepAssignedBucketStoreKeyPersister.INSTANCE::sweepBucketRecordsCell)
+                .collect(Collectors.toList());
+        assertThat(cells).doesNotHaveDuplicates();
+    }
+
+    @ParameterizedTest
+    @MethodSource("goldenSweepBucketRecordsCells")
+    public void bucketIdentifiersMapToHistoricSweepBucketRecordsCells(long bucketIdentifier, Cell expectedCell) {
+        Cell actualCell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketRecordsCell(bucketIdentifier);
+        assertThat(actualCell).isEqualTo(expectedCell);
+    }
+
+    // TODO(mdaudali): Should we add validation to ensure that bucket identifier for bucket and passed in above >= 0?
+
+    @Test
+    // A more rigorous test would likely involve some generator for the various inputs into each cell
+    // Perhaps an interesting place to leverage property-based testing
+    public void cellsDoNotOverlap() {
+        List<Cell> cells = Stream.concat(
+                        Stream.concat(
+                                Stream.of(
+                                        SweepAssignedBucketStoreKeyPersister.INSTANCE
+                                                .sweepBucketAssignerStateMachineCell(),
+                                        SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketRecordsCell(0)),
+                                buckets().stream()
+                                        .map(SweepAssignedBucketStoreKeyPersister.INSTANCE::sweepBucketsCell)),
+                        Stream.of(SweeperStrategy.values())
+                                .map(v -> SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketPointerCell(
+                                        ShardAndStrategy.of(0, v))))
+                .collect(Collectors.toList());
+        assertThat(cells).doesNotHaveDuplicates();
+    }
+
+    private static Set<Bucket> buckets() {
+        Set<Integer> shardsAndBucketIdentifiers = Set.of(0, 1, 123123, Integer.MAX_VALUE);
+        Set<SweeperStrategy> strategies = Set.of(SweeperStrategy.values());
+        Set<ShardAndStrategy> shardAndStrategies = Sets.cartesianProduct(shardsAndBucketIdentifiers, strategies)
+                .collect(pair -> ShardAndStrategy.of(pair.getOne(), pair.getTwo()))
+                .toSet();
+        return Sets.cartesianProduct(shardAndStrategies, shardsAndBucketIdentifiers)
+                .collect(pair -> Bucket.of(pair.getOne(), pair.getTwo()))
+                .toSet();
+    }
+
+    private static Set<SweepableBucket> sweepableBuckets() {
+        Set<TimestampRange> timestampRanges =
+                Set.of(TimestampRange.openBucket(13123), TimestampRange.of(901273, Long.MAX_VALUE));
+        return Sets.cartesianProduct(buckets(), timestampRanges)
+                .collect(pair -> SweepableBucket.of(pair.getOne(), pair.getTwo()))
+                .toSet();
+    }
+
+    private static Stream<Arguments> goldenSweepBucketsCells() {
+        return GOLDEN_BUCKETS.entrySet().stream().map(entry -> Arguments.of(entry.getKey(), entry.getValue()));
+    }
+
+    private static Stream<Arguments> goldenSweepBucketCellsAndValues() {
+        return GOLDEN_BUCKETS.entrySet().stream().flatMap(entry -> {
+            Bucket bucket = entry.getKey();
+            Cell cell = entry.getValue();
+            return GOLDEN_TIMESTAMP_RANGES.entrySet().stream()
+                    .map(timestampRangeEntry -> Arguments.of(
+                            SweepableBucket.of(bucket, timestampRangeEntry.getKey()),
+                            cell,
+                            timestampRangeEntry.getValue()));
+        });
+    }
+
+    private static Stream<Arguments> goldenSweepBucketPointerCells() {
+        return GOLDEN_SWEEP_BUCKET_POINTER_CELLS.entrySet().stream()
+                .map(entry -> Arguments.of(entry.getKey(), entry.getValue()));
+    }
+
+    // TODO(mdaudali): consider making a custom MapSource for parameterized tests
+    private static Stream<Arguments> goldenSweepBucketRecordsCells() {
+        return GOLDEN_SWEEP_BUCKET_RECORDS_CELLS.entrySet().stream()
+                .map(entry -> Arguments.of(entry.getKey(), entry.getValue()));
+    }
+
+    private static Cell fromBase64(String rowName, String columnName) {
+        return Cell.create(
+                BaseEncoding.base64().decode(rowName), BaseEncoding.base64().decode(columnName));
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
We had interfaces for interacting with some "store", but there was no concrete implementation for those interfaces
**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
We now do!
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
The delete method. I don't think we can use a point delete for the reasons I outlined in the comment, but please verify that I'm correct.

The PR is big, and I've not self reviewed it yet. It's likely to be split up to make reviewing easier.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A - deletion is the only assumption and I wrote a comment
**What was existing testing like? What have you done to improve it?**:
Added tests! A follow up PR will add tests for Cassandra and DBKvs in the same way as Bucket Progress
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
No exceptions except where we expect them :) It's not wired up.
**Has the safety of all log arguments been decided correctly?**:
Yes
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
N/A
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
I don't think so, I've generally erred on minimising calls.
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
Row reads, not scans, some CAS.
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
If we rearchitect sweep / decouple timestamp ranges from entire bucket identifiers
## Development Process
**Where should we start reviewing?**:
The store
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
See concerns - will likely split later.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
