### PR TITLE
[ASTS] Foreground Task Part IV: Decoupling Reader Timestamps

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTask.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTask.java
@@ -96,7 +96,7 @@ public class DefaultSingleBucketSweepTask implements SingleBucketSweepTask {
         SweepBatchWithPartitionInfo sweepBatchWithPartitionInfo = sweepQueueReader.getNextBatchToSweep(
                 sweepableBucket.bucket().shardAndStrategy(),
                 lastSweptTimestampInBucket,
-                getLastRelevantStartTimestampForSweep(sweepableBucket, sweepTimestampForIteration),
+                getBucketEndpoint(sweepableBucket),
                 sweepTimestampForIteration);
         SweepBatch sweepBatch = sweepBatchWithPartitionInfo.sweepBatch();
 
@@ -146,13 +146,12 @@ public class DefaultSingleBucketSweepTask implements SingleBucketSweepTask {
         }
     }
 
-    private static long getLastRelevantStartTimestampForSweep(
-            SweepableBucket sweepableBucket, long sweepTimestampForIteration) {
+    private static long getBucketEndpoint(
+            SweepableBucket sweepableBucket) {
         if (sweepableBucket.timestampRange().endExclusive() == -1) {
-            return sweepTimestampForIteration;
+            return Long.MAX_VALUE;
         }
-        return Math.min(
-                sweepTimestampForIteration, sweepableBucket.timestampRange().endExclusive());
+        return sweepableBucket.timestampRange().endExclusive();
     }
 
     private static boolean isCompletelySwept(long rangeEndExclusive, long lastSweptTimestampInBucket) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTask.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTask.java
@@ -96,7 +96,8 @@ public class DefaultSingleBucketSweepTask implements SingleBucketSweepTask {
         SweepBatchWithPartitionInfo sweepBatchWithPartitionInfo = sweepQueueReader.getNextBatchToSweep(
                 sweepableBucket.bucket().shardAndStrategy(),
                 lastSweptTimestampInBucket,
-                getEndOfSweepRange(sweepableBucket, sweepTimestampForIteration));
+                getLastRelevantStartTimestampForSweep(sweepableBucket, sweepTimestampForIteration),
+                sweepTimestampForIteration);
         SweepBatch sweepBatch = sweepBatchWithPartitionInfo.sweepBatch();
 
         ShardAndStrategy shardAndStrategy = sweepableBucket.bucket().shardAndStrategy();
@@ -145,7 +146,8 @@ public class DefaultSingleBucketSweepTask implements SingleBucketSweepTask {
         }
     }
 
-    private static long getEndOfSweepRange(SweepableBucket sweepableBucket, long sweepTimestampForIteration) {
+    private static long getLastRelevantStartTimestampForSweep(
+            SweepableBucket sweepableBucket, long sweepTimestampForIteration) {
         if (sweepableBucket.timestampRange().endExclusive() == -1) {
             return sweepTimestampForIteration;
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTask.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTask.java
@@ -96,7 +96,7 @@ public class DefaultSingleBucketSweepTask implements SingleBucketSweepTask {
         SweepBatchWithPartitionInfo sweepBatchWithPartitionInfo = sweepQueueReader.getNextBatchToSweep(
                 sweepableBucket.bucket().shardAndStrategy(),
                 lastSweptTimestampInBucket,
-                getBucketEndpoint(sweepableBucket),
+                getLastProcessableCellStartTimestamp(sweepableBucket, sweepTimestampForIteration),
                 sweepTimestampForIteration);
         SweepBatch sweepBatch = sweepBatchWithPartitionInfo.sweepBatch();
 
@@ -146,12 +146,11 @@ public class DefaultSingleBucketSweepTask implements SingleBucketSweepTask {
         }
     }
 
-    private static long getBucketEndpoint(
-            SweepableBucket sweepableBucket) {
+    private static long getLastProcessableCellStartTimestamp(SweepableBucket sweepableBucket, long sweepTimestamp) {
         if (sweepableBucket.timestampRange().endExclusive() == -1) {
-            return Long.MAX_VALUE;
+            return sweepTimestamp;
         }
-        return sweepableBucket.timestampRange().endExclusive();
+        return Math.min(sweepTimestamp, sweepableBucket.timestampRange().endExclusive());
     }
 
     private static boolean isCompletelySwept(long rangeEndExclusive, long lastSweptTimestampInBucket) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTask.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTask.java
@@ -96,7 +96,7 @@ public class DefaultSingleBucketSweepTask implements SingleBucketSweepTask {
         SweepBatchWithPartitionInfo sweepBatchWithPartitionInfo = sweepQueueReader.getNextBatchToSweep(
                 sweepableBucket.bucket().shardAndStrategy(),
                 lastSweptTimestampInBucket,
-                getLastProcessableCellStartTimestamp(sweepableBucket, sweepTimestampForIteration),
+                getMaxExclusiveProcessableStartTimestamp(sweepableBucket, sweepTimestampForIteration),
                 sweepTimestampForIteration);
         SweepBatch sweepBatch = sweepBatchWithPartitionInfo.sweepBatch();
 
@@ -146,7 +146,7 @@ public class DefaultSingleBucketSweepTask implements SingleBucketSweepTask {
         }
     }
 
-    private static long getLastProcessableCellStartTimestamp(SweepableBucket sweepableBucket, long sweepTimestamp) {
+    private static long getMaxExclusiveProcessableStartTimestamp(SweepableBucket sweepableBucket, long sweepTimestamp) {
         if (sweepableBucket.timestampRange().endExclusive() == -1) {
             return sweepTimestamp;
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulator.java
@@ -30,7 +30,7 @@ class SweepBatchAccumulator {
     private final Set<Long> abortedTimestamps = new HashSet<>();
     private final Set<Long> finePartitions = new HashSet<>();
     private final List<SweepableCellsTable.SweepableCellsRow> accumulatedDedicatedRows = new ArrayList<>();
-    private final long maxProcessableCellStartTimestamp;
+    private final long maxExclusiveProcessableCellStartTimestamp;
     private final int batchSizeThreshold;
 
     private long progressTimestamp;
@@ -39,22 +39,23 @@ class SweepBatchAccumulator {
     private boolean anyBatchesPresent = false;
     private boolean nextBatchAvailable = true;
 
-    SweepBatchAccumulator(long maxProcessableCellStartTimestamp, int batchSizeThreshold, long progressTimestamp) {
-        this.maxProcessableCellStartTimestamp = maxProcessableCellStartTimestamp;
+    SweepBatchAccumulator(
+            long maxExclusiveProcessableCellStartTimestamp, int batchSizeThreshold, long progressTimestamp) {
+        this.maxExclusiveProcessableCellStartTimestamp = maxExclusiveProcessableCellStartTimestamp;
         this.batchSizeThreshold = batchSizeThreshold;
         this.progressTimestamp = progressTimestamp;
     }
 
     void accumulateBatch(SweepBatch sweepBatch) {
         Preconditions.checkState(
-                sweepBatch.lastSweptTimestamp() < maxProcessableCellStartTimestamp,
-                "Tried to accumulate a batch %s at timestamp %s that went beyond the max processable timestamp %s!"
-                        + " This is unexpected, and suggests a bug in the way we read in targeted sweep."
-                        + " This by itself does not mean that AtlasDB service is compromised, but targeted sweep"
-                        + " may not be working.",
+                sweepBatch.lastSweptTimestamp() < maxExclusiveProcessableCellStartTimestamp,
+                "Tried to accumulate a batch %s at timestamp %s that went beyond the max exclusive processable"
+                    + " timestamp %s! This is unexpected, and suggests a bug in the way we read in targeted sweep."
+                    + " This by itself does not mean that AtlasDB service is compromised, but targeted sweep may not"
+                    + " be working.",
                 sweepBatch,
                 sweepBatch.lastSweptTimestamp(),
-                maxProcessableCellStartTimestamp);
+                maxExclusiveProcessableCellStartTimestamp);
 
         accumulatedWrites.addAll(sweepBatch.writes());
         abortedTimestamps.addAll(sweepBatch.abortedTimestamps());
@@ -86,7 +87,7 @@ class SweepBatchAccumulator {
     boolean shouldAcceptAdditionalBatch() {
         return accumulatedWrites.size() < batchSizeThreshold
                 && nextBatchAvailable
-                && progressTimestamp < (maxProcessableCellStartTimestamp - 1);
+                && progressTimestamp < (maxExclusiveProcessableCellStartTimestamp - 1);
     }
 
     private List<WriteInfo> getLatestWritesByCellReference() {
@@ -101,7 +102,7 @@ class SweepBatchAccumulator {
         if (anyBatchesPresent) {
             return progressTimestamp;
         }
-        return maxProcessableCellStartTimestamp - 1;
+        return maxExclusiveProcessableCellStartTimestamp - 1;
     }
 
     private void addRelevantFinePartitions(SweepBatch sweepBatch) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulator.java
@@ -30,7 +30,7 @@ class SweepBatchAccumulator {
     private final Set<Long> abortedTimestamps = new HashSet<>();
     private final Set<Long> finePartitions = new HashSet<>();
     private final List<SweepableCellsTable.SweepableCellsRow> accumulatedDedicatedRows = new ArrayList<>();
-    private final long lastProcessableCellStartTimestamp;
+    private final long maxProcessableCellStartTimestamp;
     private final int batchSizeThreshold;
 
     private long progressTimestamp;
@@ -39,22 +39,22 @@ class SweepBatchAccumulator {
     private boolean anyBatchesPresent = false;
     private boolean nextBatchAvailable = true;
 
-    SweepBatchAccumulator(long lastProcessableCellStartTimestamp, int batchSizeThreshold, long progressTimestamp) {
-        this.lastProcessableCellStartTimestamp = lastProcessableCellStartTimestamp;
+    SweepBatchAccumulator(long maxProcessableCellStartTimestamp, int batchSizeThreshold, long progressTimestamp) {
+        this.maxProcessableCellStartTimestamp = maxProcessableCellStartTimestamp;
         this.batchSizeThreshold = batchSizeThreshold;
         this.progressTimestamp = progressTimestamp;
     }
 
     void accumulateBatch(SweepBatch sweepBatch) {
         Preconditions.checkState(
-                sweepBatch.lastSweptTimestamp() < lastProcessableCellStartTimestamp,
-                "Tried to accumulate a batch %s at timestamp %s that went beyond the last processable timestamp %s!"
+                sweepBatch.lastSweptTimestamp() < maxProcessableCellStartTimestamp,
+                "Tried to accumulate a batch %s at timestamp %s that went beyond the max processable timestamp %s!"
                         + " This is unexpected, and suggests a bug in the way we read in targeted sweep."
                         + " This by itself does not mean that AtlasDB service is compromised, but targeted sweep"
                         + " may not be working.",
                 sweepBatch,
                 sweepBatch.lastSweptTimestamp(),
-                lastProcessableCellStartTimestamp);
+                maxProcessableCellStartTimestamp);
 
         accumulatedWrites.addAll(sweepBatch.writes());
         abortedTimestamps.addAll(sweepBatch.abortedTimestamps());
@@ -86,7 +86,7 @@ class SweepBatchAccumulator {
     boolean shouldAcceptAdditionalBatch() {
         return accumulatedWrites.size() < batchSizeThreshold
                 && nextBatchAvailable
-                && progressTimestamp < (lastProcessableCellStartTimestamp - 1);
+                && progressTimestamp < (maxProcessableCellStartTimestamp - 1);
     }
 
     private List<WriteInfo> getLatestWritesByCellReference() {
@@ -101,7 +101,7 @@ class SweepBatchAccumulator {
         if (anyBatchesPresent) {
             return progressTimestamp;
         }
-        return lastProcessableCellStartTimestamp - 1;
+        return maxProcessableCellStartTimestamp - 1;
     }
 
     private void addRelevantFinePartitions(SweepBatch sweepBatch) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulator.java
@@ -30,7 +30,7 @@ class SweepBatchAccumulator {
     private final Set<Long> abortedTimestamps = new HashSet<>();
     private final Set<Long> finePartitions = new HashSet<>();
     private final List<SweepableCellsTable.SweepableCellsRow> accumulatedDedicatedRows = new ArrayList<>();
-    private final long sweepTimestamp;
+    private final long lastProcessableCellStartTimestamp;
     private final int batchSizeThreshold;
 
     private long progressTimestamp;
@@ -39,22 +39,22 @@ class SweepBatchAccumulator {
     private boolean anyBatchesPresent = false;
     private boolean nextBatchAvailable = true;
 
-    SweepBatchAccumulator(long sweepTimestamp, int batchSizeThreshold, long progressTimestamp) {
-        this.sweepTimestamp = sweepTimestamp;
+    SweepBatchAccumulator(long lastProcessableCellStartTimestamp, int batchSizeThreshold, long progressTimestamp) {
+        this.lastProcessableCellStartTimestamp = lastProcessableCellStartTimestamp;
         this.batchSizeThreshold = batchSizeThreshold;
         this.progressTimestamp = progressTimestamp;
     }
 
     void accumulateBatch(SweepBatch sweepBatch) {
         Preconditions.checkState(
-                sweepBatch.lastSweptTimestamp() < sweepTimestamp,
+                sweepBatch.lastSweptTimestamp() < lastProcessableCellStartTimestamp,
                 "Tried to accumulate a batch %s at timestamp %s that went beyond the sweep timestamp %s!"
                         + " This is unexpected, and suggests a bug in the way we read in targeted sweep."
                         + " This by itself does not mean that AtlasDB service is compromised, but targeted sweep"
                         + " may not be working.",
                 sweepBatch,
                 sweepBatch.lastSweptTimestamp(),
-                sweepTimestamp);
+                lastProcessableCellStartTimestamp);
 
         accumulatedWrites.addAll(sweepBatch.writes());
         abortedTimestamps.addAll(sweepBatch.abortedTimestamps());
@@ -86,7 +86,7 @@ class SweepBatchAccumulator {
     boolean shouldAcceptAdditionalBatch() {
         return accumulatedWrites.size() < batchSizeThreshold
                 && nextBatchAvailable
-                && progressTimestamp < (sweepTimestamp - 1);
+                && progressTimestamp < (lastProcessableCellStartTimestamp - 1);
     }
 
     private List<WriteInfo> getLatestWritesByCellReference() {
@@ -101,7 +101,7 @@ class SweepBatchAccumulator {
         if (anyBatchesPresent) {
             return progressTimestamp;
         }
-        return sweepTimestamp - 1;
+        return lastProcessableCellStartTimestamp - 1;
     }
 
     private void addRelevantFinePartitions(SweepBatch sweepBatch) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulator.java
@@ -48,7 +48,7 @@ class SweepBatchAccumulator {
     void accumulateBatch(SweepBatch sweepBatch) {
         Preconditions.checkState(
                 sweepBatch.lastSweptTimestamp() < lastProcessableCellStartTimestamp,
-                "Tried to accumulate a batch %s at timestamp %s that went beyond the sweep timestamp %s!"
+                "Tried to accumulate a batch %s at timestamp %s that went beyond the last processable timestamp %s!"
                         + " This is unexpected, and suggests a bug in the way we read in targeted sweep."
                         + " This by itself does not mean that AtlasDB service is compromised, but targeted sweep"
                         + " may not be working.",

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableCells.java
@@ -169,7 +169,7 @@ public class SweepableCells extends SweepQueueTable {
     /**
      * Variant of {@link #getBatchForPartition(ShardAndStrategy, long, long, long)}, that considers both a maximum
      * start timestamp that we want to read from the table as well as the sweep timestamp separately. This is
-     * important for the sake of cells which started before maxStartTs but committed after that.
+     * important for the sake of cells which started before maxStartTsExclusive but committed after that.
      */
     SweepBatch getBatchForPartition(
             ShardAndStrategy shardStrategy,

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepableTimestamps.java
@@ -73,13 +73,13 @@ public class SweepableTimestamps extends SweepQueueTable {
      *
      * @param shardStrategy desired shard and strategy
      * @param lastSweptTs exclusive minimum timestamp to check for
-     * @param sweepTs exclusive maximum timestamp to check for
+     * @param maxTsExclusive exclusive maximum timestamp to check for
      * @return Optional containing the fine partition, or Optional.empty() if there are no more candidates before
      * sweepTs
      */
-    Optional<Long> nextTimestampPartition(ShardAndStrategy shardStrategy, long lastSweptTs, long sweepTs) {
+    Optional<Long> nextTimestampPartition(ShardAndStrategy shardStrategy, long lastSweptTs, long maxTsExclusive) {
         long minFineInclusive = SweepQueueUtils.tsPartitionFine(lastSweptTs + 1);
-        long maxFineInclusive = SweepQueueUtils.tsPartitionFine(sweepTs - 1);
+        long maxFineInclusive = SweepQueueUtils.tsPartitionFine(maxTsExclusive - 1);
         return nextSweepablePartition(shardStrategy, minFineInclusive, maxFineInclusive);
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTaskTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTaskTest.java
@@ -277,6 +277,7 @@ public class DefaultSingleBucketSweepTaskTest {
                         ImmutableSet.of(SweepQueueUtils.tsPartitionFine(context.startTimestampInclusive()))));
 
         defaultSingleBucketSweepTask.runOneIteration(context.sweepableBucket());
+
         verify(sweepQueueDeleter).sweep(ImmutableList.of(), Sweeper.of(context.shardAndStrategy()));
         verify(sweepQueueCleaner)
                 .clean(
@@ -311,6 +312,16 @@ public class DefaultSingleBucketSweepTaskTest {
                         ImmutableSet.of(SweepQueueUtils.tsPartitionFine(context.startTimestampInclusive()))));
 
         defaultSingleBucketSweepTask.runOneIteration(context.sweepableBucket());
+
+        // This is implied by strict mocking plus subsequent validations using information that was returned, but for
+        // this test it is essential that we fail if this call does not happen, hence explicitly stating this.
+        verify(sweepQueueReader)
+                .getNextBatchToSweep(
+                        context.shardAndStrategy(),
+                        context.startTimestampInclusive() - 1,
+                        context.endTimestampExclusive(),
+                        sweepTimestamp);
+
         verify(sweepQueueDeleter).sweep(ImmutableList.of(), Sweeper.of(context.shardAndStrategy()));
         verify(sweepQueueCleaner)
                 .clean(

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/SingleBucketSweepTaskIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/SingleBucketSweepTaskIntegrationTest.java
@@ -583,17 +583,17 @@ public class SingleBucketSweepTaskIntegrationTest {
 
         checkValueSwept(DEFAULT_CELL, END_OF_BUCKET_ONE - 1L, sweepStrategyTestContext);
         assertThat(getRangeFromTable(TargetedSweepTableFactory.of()
-                .getSweepableCellsTable(null)
-                .getTableRef()))
+                        .getSweepableCellsTable(null)
+                        .getTableRef()))
                 .as("sweepable cells should have been swept")
                 .isEmpty();
         assertThat(getRangeFromTable(TargetedSweepTableFactory.of()
-                .getSweepableTimestampsTable(null)
-                .getTableRef()))
+                        .getSweepableTimestampsTable(null)
+                        .getTableRef()))
                 .as("sweepable timestamps should have been swept")
                 .isEmpty();
         assertThat(bucketProgressStore.getBucketProgress(
-                sweepStrategyTestContext.bucketFactory().apply(1)))
+                        sweepStrategyTestContext.bucketFactory().apply(1)))
                 .as("bucket 1 is completely swept")
                 .hasValue(BucketProgress.createForTimestampProgress(END_OF_BUCKET_ONE - END_OF_BUCKET_ZERO - 1));
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/SingleBucketSweepTaskIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/SingleBucketSweepTaskIntegrationTest.java
@@ -569,7 +569,7 @@ public class SingleBucketSweepTaskIntegrationTest {
     //                     ^ Sweep Task
     @ParameterizedTest
     @MethodSource("testContexts")
-    public void successfullySweepsCellInMyBucketCommittingInTheNextBucket(
+    public void successfullySweepsCellInMyBucketCommittingInAFutureBucket(
             SweepStrategyTestContext sweepStrategyTestContext) {
         when(completelyClosedSweepBucketBoundRetriever.getStrictUpperBoundForCompletelyClosedBuckets())
                 .thenReturn(2L);
@@ -603,7 +603,7 @@ public class SingleBucketSweepTaskIntegrationTest {
     //                     ^ Sweep Task
     @ParameterizedTest
     @MethodSource("testContexts")
-    public void doesNotSweepCellInMyBucketCommittingInTheNextBucketIfSweepTimestampNotPastItsCommit(
+    public void doesNotSweepCellInMyBucketCommittingInAFutureBucketIfSweepTimestampNotPastItsCommit(
             SweepStrategyTestContext sweepStrategyTestContext) {
         when(completelyClosedSweepBucketBoundRetriever.getStrictUpperBoundForCompletelyClosedBuckets())
                 .thenReturn(2L);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/SingleBucketSweepTaskIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/SingleBucketSweepTaskIntegrationTest.java
@@ -616,17 +616,17 @@ public class SingleBucketSweepTaskIntegrationTest {
         assertThat(singleBucketSweepTask.runOneIteration(sweepableBucketOne)).isEqualTo(2L);
 
         assertThat(getRangeFromTable(TargetedSweepTableFactory.of()
-                .getSweepableCellsTable(null)
-                .getTableRef()))
+                        .getSweepableCellsTable(null)
+                        .getTableRef()))
                 .as("sweepable cells should not have been swept")
                 .isNotEmpty();
         assertThat(getRangeFromTable(TargetedSweepTableFactory.of()
-                .getSweepableTimestampsTable(null)
-                .getTableRef()))
+                        .getSweepableTimestampsTable(null)
+                        .getTableRef()))
                 .as("sweepable timestamps should not have been swept")
                 .isNotEmpty();
         assertThat(bucketProgressStore.getBucketProgress(
-                sweepStrategyTestContext.bucketFactory().apply(1)))
+                        sweepStrategyTestContext.bucketFactory().apply(1)))
                 .as("bucket 1 swept up to but not including its end")
                 .hasValue(BucketProgress.createForTimestampProgress(END_OF_BUCKET_ONE - END_OF_BUCKET_ZERO - 10 - 1));
     }

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/SingleBucketSweepTaskIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/SingleBucketSweepTaskIntegrationTest.java
@@ -91,13 +91,14 @@ public class SingleBucketSweepTaskIntegrationTest {
     private static final TableReference CONSERVATIVE_TABLE = TableReference.createFromFullyQualifiedName("terri.tory");
     private static final TableReference THOROUGH_TABLE = TableReference.createFromFullyQualifiedName("comp.lete");
 
-    private static final long END_OF_BUCKET_ZERO = SweepQueueUtils.minTsForCoarsePartition(73L);
-    private static final long END_OF_BUCKET_ONE = SweepQueueUtils.minTsForCoarsePartition(84L);
-    private static final TimestampRange BUCKET_ZERO_TIMESTAMP_RANGE = TimestampRange.of(0L, END_OF_BUCKET_ZERO);
+    private static final long END_OF_BUCKET_ZERO_EXCLUSIVE = SweepQueueUtils.minTsForCoarsePartition(73L);
+    private static final long END_OF_BUCKET_ONE_EXCLUSIVE = SweepQueueUtils.minTsForCoarsePartition(84L);
+    private static final TimestampRange BUCKET_ZERO_TIMESTAMP_RANGE =
+            TimestampRange.of(0L, END_OF_BUCKET_ZERO_EXCLUSIVE);
     private static final TimestampRange BUCKET_ONE_TIMESTAMP_RANGE =
-            TimestampRange.of(END_OF_BUCKET_ZERO, END_OF_BUCKET_ONE);
+            TimestampRange.of(END_OF_BUCKET_ZERO_EXCLUSIVE, END_OF_BUCKET_ONE_EXCLUSIVE);
     private static final TimestampRange BUCKET_TWO_TIMESTAMP_RANGE =
-            TimestampRange.of(END_OF_BUCKET_ONE, -1L); // open bucket
+            TimestampRange.of(END_OF_BUCKET_ONE_EXCLUSIVE, -1L); // open bucket
 
     private static final Cell DEFAULT_CELL = Cell.create(PtBytes.toBytes("row"), PtBytes.toBytes("column"));
     private static final byte[] DEFAULT_VALUE = PtBytes.toBytes("value");
@@ -251,7 +252,7 @@ public class SingleBucketSweepTaskIntegrationTest {
     @MethodSource("testContexts")
     public void doesNotSweepValuesInOtherBuckets(SweepStrategyTestContext sweepStrategyTestContext) {
         writeTwoCells(sweepStrategyTestContext.dataTable());
-        sweepTimestamp.set(END_OF_BUCKET_ZERO + 4500L);
+        sweepTimestamp.set(END_OF_BUCKET_ZERO_EXCLUSIVE + 4500L);
 
         assertThat(singleBucketSweepTask.runOneIteration(SweepableBucket.of(
                         sweepStrategyTestContext.bucketFactory().apply(1), BUCKET_ONE_TIMESTAMP_RANGE)))
@@ -288,7 +289,7 @@ public class SingleBucketSweepTaskIntegrationTest {
         when(completelyClosedSweepBucketBoundRetriever.getStrictUpperBoundForCompletelyClosedBuckets())
                 .thenReturn(1L); // All buckets at 0 are guaranteed closed
         writeTwoCells(sweepStrategyTestContext.dataTable());
-        sweepTimestamp.set(END_OF_BUCKET_ZERO + 5842L);
+        sweepTimestamp.set(END_OF_BUCKET_ZERO_EXCLUSIVE + 5842L);
 
         assertThat(singleBucketSweepTask.runOneIteration(SweepableBucket.of(
                         sweepStrategyTestContext.bucketFactory().apply(0), BUCKET_ZERO_TIMESTAMP_RANGE)))
@@ -321,7 +322,7 @@ public class SingleBucketSweepTaskIntegrationTest {
         assertThat(bucketProgressStore.getBucketProgress(
                         sweepStrategyTestContext.bucketFactory().apply(0)))
                 .as("bucket 0 is completely swept")
-                .hasValue(BucketProgress.createForTimestampProgress(END_OF_BUCKET_ZERO - 1));
+                .hasValue(BucketProgress.createForTimestampProgress(END_OF_BUCKET_ZERO_EXCLUSIVE - 1));
         verify(bucketCompletionListener, times(1))
                 .markBucketCompleteAndRemoveFromScheduling(
                         sweepStrategyTestContext.bucketFactory().apply(0));
@@ -337,7 +338,7 @@ public class SingleBucketSweepTaskIntegrationTest {
         when(completelyClosedSweepBucketBoundRetriever.getStrictUpperBoundForCompletelyClosedBuckets())
                 .thenReturn(0L); // This can happen if we have more shards
         writeTwoCells(sweepStrategyTestContext.dataTable());
-        sweepTimestamp.set(END_OF_BUCKET_ZERO + 4289L);
+        sweepTimestamp.set(END_OF_BUCKET_ZERO_EXCLUSIVE + 4289L);
 
         assertThat(singleBucketSweepTask.runOneIteration(SweepableBucket.of(
                         sweepStrategyTestContext.bucketFactory().apply(0), BUCKET_ZERO_TIMESTAMP_RANGE)))
@@ -355,7 +356,7 @@ public class SingleBucketSweepTaskIntegrationTest {
         assertThat(bucketProgressStore.getBucketProgress(
                         sweepStrategyTestContext.bucketFactory().apply(0)))
                 .as("bucket 0 is completely swept")
-                .hasValue(BucketProgress.createForTimestampProgress(END_OF_BUCKET_ZERO - 1));
+                .hasValue(BucketProgress.createForTimestampProgress(END_OF_BUCKET_ZERO_EXCLUSIVE - 1));
 
         // We don't delete the bucket in this case BECAUSE it might get rewritten by the state machine
         verify(bucketCompletionListener, never())
@@ -373,7 +374,7 @@ public class SingleBucketSweepTaskIntegrationTest {
         when(completelyClosedSweepBucketBoundRetriever.getStrictUpperBoundForCompletelyClosedBuckets())
                 .thenReturn(2L);
         writeTwoCells(sweepStrategyTestContext.dataTable());
-        sweepTimestamp.set(END_OF_BUCKET_ZERO);
+        sweepTimestamp.set(END_OF_BUCKET_ZERO_EXCLUSIVE);
         bucketProgressStore.updateBucketProgressToAtLeast(
                 sweepStrategyTestContext.bucketFactory().apply(0), BucketProgress.createForTimestampProgress(250L));
         assertThat(singleBucketSweepTask.runOneIteration(SweepableBucket.of(
@@ -398,7 +399,7 @@ public class SingleBucketSweepTaskIntegrationTest {
 
         bucketProgressStore.updateBucketProgressToAtLeast(
                 sweepStrategyTestContext.bucketFactory().apply(0),
-                BucketProgress.createForTimestampProgress(END_OF_BUCKET_ZERO - 1));
+                BucketProgress.createForTimestampProgress(END_OF_BUCKET_ZERO_EXCLUSIVE - 1));
         assertThat(singleBucketSweepTask.runOneIteration(SweepableBucket.of(
                         sweepStrategyTestContext.bucketFactory().apply(0), BUCKET_ZERO_TIMESTAMP_RANGE)))
                 .as("no entries should have been read from the sweep queue, because the bucket had already been"
@@ -424,7 +425,7 @@ public class SingleBucketSweepTaskIntegrationTest {
 
         bucketProgressStore.updateBucketProgressToAtLeast(
                 sweepStrategyTestContext.bucketFactory().apply(0),
-                BucketProgress.createForTimestampProgress(END_OF_BUCKET_ZERO - 1));
+                BucketProgress.createForTimestampProgress(END_OF_BUCKET_ZERO_EXCLUSIVE - 1));
         assertThat(singleBucketSweepTask.runOneIteration(SweepableBucket.of(
                         sweepStrategyTestContext.bucketFactory().apply(0), BUCKET_ZERO_TIMESTAMP_RANGE)))
                 .as("no entries should have been read from the sweep queue, because the bucket had already been"
@@ -444,7 +445,7 @@ public class SingleBucketSweepTaskIntegrationTest {
             SweepStrategyTestContext sweepStrategyTestContext) {
         writeCell(sweepStrategyTestContext.dataTable(), 5200L, DEFAULT_VALUE, 5900L);
         writeCell(sweepStrategyTestContext.dataTable(), 6400L, ANOTHER_VALUE, 7300L);
-        sweepTimestamp.set(END_OF_BUCKET_ZERO + 1);
+        sweepTimestamp.set(END_OF_BUCKET_ZERO_EXCLUSIVE + 1);
         assertThat(singleBucketSweepTask.runOneIteration(SweepableBucket.of(
                         sweepStrategyTestContext.bucketFactory().apply(2), BUCKET_TWO_TIMESTAMP_RANGE)))
                 .as("nothing should have been read from the queue, because sweep can't enter bucket 2")
@@ -462,17 +463,19 @@ public class SingleBucketSweepTaskIntegrationTest {
                 .thenReturn(2L);
         writeCell(
                 sweepStrategyTestContext.dataTable(),
-                END_OF_BUCKET_ONE + 200L,
+                END_OF_BUCKET_ONE_EXCLUSIVE + 200L,
                 DEFAULT_VALUE,
-                END_OF_BUCKET_ONE + 500L);
+                END_OF_BUCKET_ONE_EXCLUSIVE + 500L);
         writeCell(
                 sweepStrategyTestContext.dataTable(),
-                END_OF_BUCKET_ONE + 1200L,
+                END_OF_BUCKET_ONE_EXCLUSIVE + 1200L,
                 ANOTHER_VALUE,
-                END_OF_BUCKET_ONE + 1500L);
+                END_OF_BUCKET_ONE_EXCLUSIVE + 1500L);
         writeTransactionalDelete(
-                sweepStrategyTestContext.dataTable(), END_OF_BUCKET_ONE + 2200L, END_OF_BUCKET_ONE + 2500L);
-        sweepTimestamp.set(END_OF_BUCKET_ONE + 3000L);
+                sweepStrategyTestContext.dataTable(),
+                END_OF_BUCKET_ONE_EXCLUSIVE + 2200L,
+                END_OF_BUCKET_ONE_EXCLUSIVE + 2500L);
+        sweepTimestamp.set(END_OF_BUCKET_ONE_EXCLUSIVE + 3000L);
 
         assertThat(singleBucketSweepTask.runOneIteration(SweepableBucket.of(
                         sweepStrategyTestContext.bucketFactory().apply(2), BUCKET_TWO_TIMESTAMP_RANGE)))
@@ -482,7 +485,8 @@ public class SingleBucketSweepTaskIntegrationTest {
         assertThat(bucketProgressStore.getBucketProgress(
                         sweepStrategyTestContext.bucketFactory().apply(2)))
                 .as("bucket 2 makes progress up to the sweep timestamp")
-                .hasValue(BucketProgress.createForTimestampProgress(sweepTimestamp.get() - END_OF_BUCKET_ONE - 1));
+                .hasValue(BucketProgress.createForTimestampProgress(
+                        sweepTimestamp.get() - END_OF_BUCKET_ONE_EXCLUSIVE - 1));
 
         // We don't delete the bucket in this case because it is still open
         verify(bucketCompletionListener, never())
@@ -502,7 +506,7 @@ public class SingleBucketSweepTaskIntegrationTest {
         int numberOfCellsWritten = 2 * numberOfCellsSweptInOneIteration + 1;
         List<KnownTableWrite> knownTableWrites = LongStream.range(0, numberOfCellsWritten)
                 .mapToObj(index -> {
-                    long transactionTimestamp = END_OF_BUCKET_ONE + index;
+                    long transactionTimestamp = END_OF_BUCKET_ONE_EXCLUSIVE + index;
                     return KnownTableWrite.builder()
                             .startTimestamp(transactionTimestamp)
                             .commitTimestamp(transactionTimestamp)
@@ -515,7 +519,8 @@ public class SingleBucketSweepTaskIntegrationTest {
         writeCells(sweepStrategyTestContext.dataTable(), knownTableWrites);
 
         long partialProgressOnSecondBatch = 3333;
-        sweepTimestamp.set(END_OF_BUCKET_ONE + numberOfCellsSweptInOneIteration + partialProgressOnSecondBatch);
+        sweepTimestamp.set(
+                END_OF_BUCKET_ONE_EXCLUSIVE + numberOfCellsSweptInOneIteration + partialProgressOnSecondBatch);
 
         SweepableBucket sweepableBucketTwo =
                 SweepableBucket.of(sweepStrategyTestContext.bucketFactory().apply(2), BUCKET_TWO_TIMESTAMP_RANGE);
@@ -535,7 +540,7 @@ public class SingleBucketSweepTaskIntegrationTest {
                 .anyMatch(rowResult -> SweepableCellsRow.BYTES_HYDRATOR
                                 .hydrateFromBytes(rowResult.getRowName())
                                 .getTimestampPartition()
-                        == SweepQueueUtils.tsPartitionFine(END_OF_BUCKET_ONE));
+                        == SweepQueueUtils.tsPartitionFine(END_OF_BUCKET_ONE_EXCLUSIVE));
 
         assertThat(singleBucketSweepTask.runOneIteration(sweepableBucketTwo)).isEqualTo(partialProgressOnSecondBatch);
         assertThat(bucketProgressStore.getBucketProgress(
@@ -553,7 +558,7 @@ public class SingleBucketSweepTaskIntegrationTest {
                 .anyMatch(rowResult -> SweepableCellsRow.BYTES_HYDRATOR
                                 .hydrateFromBytes(rowResult.getRowName())
                                 .getTimestampPartition()
-                        == SweepQueueUtils.tsPartitionFine(END_OF_BUCKET_ONE));
+                        == SweepQueueUtils.tsPartitionFine(END_OF_BUCKET_ONE_EXCLUSIVE));
 
         assertThat(singleBucketSweepTask.runOneIteration(sweepableBucketTwo))
                 .as("no further progress is made past the sweep timestamp")
@@ -573,15 +578,23 @@ public class SingleBucketSweepTaskIntegrationTest {
             SweepStrategyTestContext sweepStrategyTestContext) {
         when(completelyClosedSweepBucketBoundRetriever.getStrictUpperBoundForCompletelyClosedBuckets())
                 .thenReturn(2L);
-        writeCell(sweepStrategyTestContext.dataTable(), END_OF_BUCKET_ONE - 3, DEFAULT_VALUE, END_OF_BUCKET_ONE - 2);
-        writeCell(sweepStrategyTestContext.dataTable(), END_OF_BUCKET_ONE - 1, ANOTHER_VALUE, END_OF_BUCKET_ONE);
+        writeCell(
+                sweepStrategyTestContext.dataTable(),
+                END_OF_BUCKET_ONE_EXCLUSIVE - 3,
+                DEFAULT_VALUE,
+                END_OF_BUCKET_ONE_EXCLUSIVE - 2);
+        writeCell(
+                sweepStrategyTestContext.dataTable(),
+                END_OF_BUCKET_ONE_EXCLUSIVE - 1,
+                ANOTHER_VALUE,
+                END_OF_BUCKET_ONE_EXCLUSIVE);
 
         sweepTimestamp.set(Long.MAX_VALUE);
         SweepableBucket sweepableBucketOne =
                 SweepableBucket.of(sweepStrategyTestContext.bucketFactory().apply(1), BUCKET_ONE_TIMESTAMP_RANGE);
         assertThat(singleBucketSweepTask.runOneIteration(sweepableBucketOne)).isEqualTo(2L);
 
-        checkValueSwept(DEFAULT_CELL, END_OF_BUCKET_ONE - 1, sweepStrategyTestContext);
+        checkValueSwept(DEFAULT_CELL, END_OF_BUCKET_ONE_EXCLUSIVE - 1, sweepStrategyTestContext);
         assertThat(getRangeFromTable(TargetedSweepTableFactory.of()
                         .getSweepableCellsTable(null)
                         .getTableRef()))
@@ -595,7 +608,8 @@ public class SingleBucketSweepTaskIntegrationTest {
         assertThat(bucketProgressStore.getBucketProgress(
                         sweepStrategyTestContext.bucketFactory().apply(1)))
                 .as("bucket 1 is completely swept")
-                .hasValue(BucketProgress.createForTimestampProgress(END_OF_BUCKET_ONE - END_OF_BUCKET_ZERO - 1));
+                .hasValue(BucketProgress.createForTimestampProgress(
+                        END_OF_BUCKET_ONE_EXCLUSIVE - END_OF_BUCKET_ZERO_EXCLUSIVE - 1));
     }
 
     // [          ][        S ][  C       )
@@ -607,10 +621,18 @@ public class SingleBucketSweepTaskIntegrationTest {
             SweepStrategyTestContext sweepStrategyTestContext) {
         when(completelyClosedSweepBucketBoundRetriever.getStrictUpperBoundForCompletelyClosedBuckets())
                 .thenReturn(2L);
-        writeCell(sweepStrategyTestContext.dataTable(), END_OF_BUCKET_ONE - 30, DEFAULT_VALUE, END_OF_BUCKET_ONE - 20);
-        writeCell(sweepStrategyTestContext.dataTable(), END_OF_BUCKET_ONE - 10, ANOTHER_VALUE, END_OF_BUCKET_ONE + 1);
+        writeCell(
+                sweepStrategyTestContext.dataTable(),
+                END_OF_BUCKET_ONE_EXCLUSIVE - 30,
+                DEFAULT_VALUE,
+                END_OF_BUCKET_ONE_EXCLUSIVE - 20);
+        writeCell(
+                sweepStrategyTestContext.dataTable(),
+                END_OF_BUCKET_ONE_EXCLUSIVE - 10,
+                ANOTHER_VALUE,
+                END_OF_BUCKET_ONE_EXCLUSIVE + 1);
 
-        sweepTimestamp.set(END_OF_BUCKET_ONE);
+        sweepTimestamp.set(END_OF_BUCKET_ONE_EXCLUSIVE);
         SweepableBucket sweepableBucketOne =
                 SweepableBucket.of(sweepStrategyTestContext.bucketFactory().apply(1), BUCKET_ONE_TIMESTAMP_RANGE);
         assertThat(singleBucketSweepTask.runOneIteration(sweepableBucketOne)).isEqualTo(2L);
@@ -628,7 +650,8 @@ public class SingleBucketSweepTaskIntegrationTest {
         assertThat(bucketProgressStore.getBucketProgress(
                         sweepStrategyTestContext.bucketFactory().apply(1)))
                 .as("bucket 1 swept up to the cell with a transaction crossing the bucket boundary")
-                .hasValue(BucketProgress.createForTimestampProgress(END_OF_BUCKET_ONE - END_OF_BUCKET_ZERO - 10 - 1));
+                .hasValue(BucketProgress.createForTimestampProgress(
+                        END_OF_BUCKET_ONE_EXCLUSIVE - END_OF_BUCKET_ZERO_EXCLUSIVE - 10 - 1));
     }
 
     // [          ][          ][vwxyz01   )
@@ -643,7 +666,7 @@ public class SingleBucketSweepTaskIntegrationTest {
         int numberOfCellsToWrite = 79;
         long timestampIncrement = SweepQueueUtils.TS_COARSE_GRANULARITY + SweepQueueUtils.TS_FINE_GRANULARITY;
 
-        long currentTimestamp = END_OF_BUCKET_ONE;
+        long currentTimestamp = END_OF_BUCKET_ONE_EXCLUSIVE;
         List<KnownTableWrite> knownTableWrites = new ArrayList<>();
         for (int i = 0; i < numberOfCellsToWrite; i++) {
             knownTableWrites.add(KnownTableWrite.builder()
@@ -702,7 +725,7 @@ public class SingleBucketSweepTaskIntegrationTest {
                         sweepStrategyTestContext.bucketFactory().apply(2)))
                 .hasValueSatisfying(progress -> assertThat(progress.timestampProgress())
                         .as("after the allowed number of iterations, sweep made progress within the same bucket")
-                        .isEqualTo(sweepTimestamp.get() - 1 - END_OF_BUCKET_ONE));
+                        .isEqualTo(sweepTimestamp.get() - 1 - END_OF_BUCKET_ONE_EXCLUSIVE));
     }
 
     @ParameterizedTest
@@ -711,7 +734,7 @@ public class SingleBucketSweepTaskIntegrationTest {
         when(completelyClosedSweepBucketBoundRetriever.getStrictUpperBoundForCompletelyClosedBuckets())
                 .thenReturn(2L);
         writeTwoCells(sweepStrategyTestContext.dataTable());
-        sweepTimestamp.set(END_OF_BUCKET_ONE);
+        sweepTimestamp.set(END_OF_BUCKET_ONE_EXCLUSIVE);
 
         assertThat(singleBucketSweepTask.runOneIteration(SweepableBucket.of(
                         Bucket.of(ShardAndStrategy.of(42, sweepStrategyTestContext.strategy()), 0),
@@ -733,7 +756,7 @@ public class SingleBucketSweepTaskIntegrationTest {
                 ? SweeperStrategy.THOROUGH
                 : SweeperStrategy.CONSERVATIVE;
         writeTwoCells(sweepStrategyTestContext.dataTable());
-        sweepTimestamp.set(END_OF_BUCKET_ONE);
+        sweepTimestamp.set(END_OF_BUCKET_ONE_EXCLUSIVE);
 
         assertThat(singleBucketSweepTask.runOneIteration(SweepableBucket.of(
                         Bucket.of(ShardAndStrategy.of(0, otherStrategy), 0), BUCKET_ZERO_TIMESTAMP_RANGE)))

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/SingleBucketSweepTaskIntegrationTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/SingleBucketSweepTaskIntegrationTest.java
@@ -627,7 +627,7 @@ public class SingleBucketSweepTaskIntegrationTest {
                 .isNotEmpty();
         assertThat(bucketProgressStore.getBucketProgress(
                         sweepStrategyTestContext.bucketFactory().apply(1)))
-                .as("bucket 1 swept up to but not including its end")
+                .as("bucket 1 swept up to the cell with a transaction crossing the bucket boundary")
                 .hasValue(BucketProgress.createForTimestampProgress(END_OF_BUCKET_ONE - END_OF_BUCKET_ZERO - 10 - 1));
     }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
@@ -187,7 +187,7 @@ public class SweepBatchAccumulatorTest {
                         SWEEP_TIMESTAMP)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Tried to accumulate a batch")
-                .hasMessageContaining("went beyond the sweep timestamp");
+                .hasMessageContaining("went beyond the max processable timestamp");
     }
 
     @Test
@@ -198,7 +198,7 @@ public class SweepBatchAccumulatorTest {
                         SWEEP_TIMESTAMP + 1)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Tried to accumulate a batch")
-                .hasMessageContaining("went beyond the sweep timestamp");
+                .hasMessageContaining("went beyond the max processable timestamp");
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepBatchAccumulatorTest.java
@@ -187,7 +187,7 @@ public class SweepBatchAccumulatorTest {
                         SWEEP_TIMESTAMP)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Tried to accumulate a batch")
-                .hasMessageContaining("went beyond the max processable timestamp");
+                .hasMessageContaining("went beyond the max exclusive processable timestamp");
     }
 
     @Test
@@ -198,7 +198,7 @@ public class SweepBatchAccumulatorTest {
                         SWEEP_TIMESTAMP + 1)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Tried to accumulate a batch")
-                .hasMessageContaining("went beyond the max processable timestamp");
+                .hasMessageContaining("went beyond the max exclusive processable timestamp");
     }
 
     @Test

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/SweepableCellsTest.java
@@ -21,6 +21,7 @@ import static com.palantir.atlasdb.sweep.queue.SweepQueueUtils.MAX_CELLS_DEDICAT
 import static com.palantir.atlasdb.sweep.queue.SweepQueueUtils.MAX_CELLS_GENERIC;
 import static com.palantir.atlasdb.sweep.queue.SweepQueueUtils.SWEEP_BATCH_SIZE;
 import static com.palantir.atlasdb.sweep.queue.SweepQueueUtils.tsPartitionFine;
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,6 +44,8 @@ import com.palantir.atlasdb.schema.generated.TargetedSweepTableFactory;
 import com.palantir.atlasdb.sweep.metrics.SweepMetricsAssert;
 import com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics;
 import com.palantir.lock.v2.TimelockService;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -171,14 +174,12 @@ public class SweepableCellsTest extends AbstractSweepQueueTest {
     }
 
     @Test
-    public void lastSweptTimestampIsMinimumOfMaximumProcessableAndEndOfFinePartitionWhenThereAreMatches() {
-        SweepBatch conservativeBatch = readConservativeWithMaximumStart(
-                shardCons, TS_FINE_PARTITION, TS - 1, SMALL_SWEEP_TS, SMALL_SWEEP_TS - 1);
-        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(SMALL_SWEEP_TS - 2);
-
-        conservativeBatch =
-                readConservativeWithMaximumStart(shardCons, TS_FINE_PARTITION, TS - 1, Long.MAX_VALUE, Long.MAX_VALUE);
-        assertThat(conservativeBatch.lastSweptTimestamp()).isEqualTo(endOfFinePartitionForTs(TS));
+    public void throwsOnReadIfMaximumStartTimestampIsGreaterThanSweepTimestamp() {
+        assertThatLoggableExceptionThrownBy(() -> readConservativeWithMaximumStart(
+                        shardCons, TS_FINE_PARTITION, TS - 1, SMALL_SWEEP_TS, SMALL_SWEEP_TS - 1))
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasExactlyArgs(
+                        SafeArg.of("maxStartTsExclusive", SMALL_SWEEP_TS), SafeArg.of("sweepTs", SMALL_SWEEP_TS - 1));
     }
 
     @Test


### PR DESCRIPTION
## General
**Before this PR**:
There's an issue with #7270 where a cell written by a transaction that started in bucket A and committed in bucket B would not be considered for sweeping. (See https://github.com/palantir/atlasdb/pull/7288/files#r1785120409.) This is because
- in the current implementation of `DefaultSingleBucketSweepTask`, we set the sweep timestamp to the minimum of the actual sweep timestamp and the end of the bucket when calling the `SweepQueueReader`, and
- in `SweepQueueReader`, we use the sweep timestamp both for the purposes of 
  - 1️⃣ controlling our reads to `SweepableTimestamps` and `SweepableCells`, **and** 
  - 2️⃣ filtering out writes corresponding to transactions that started before the sweep timestamp but committed after, because values behind these writes might still be readable to live transactions.

Normally this is okay, because the sweep timestamp increases over time - while using the sweep timestamp for 1️⃣ will mean that we end up reading some values that haven't committed yet, we'll come back and retry later. However, if we clamp the sweep timestamp to the end of the bucket range, then for a cell written across a sweep boundary we will never succeed the 2️⃣ check (though it's important that we don't actually sweep it until the 2️⃣ check would pass).

**After this PR**:
We thus explicitly treat the bounding concepts for 1️⃣ and 2️⃣ separately in `SweepQueueReader`: the _exclusive max processable cell start timestamp_ (which is used for the purposes of 1️⃣), and the _sweep timestamp_ (which is used for the purposes of 2️⃣). Standard targeted sweep uses the sweep timestamp for both of these; ASTS uses the minimum of the bucket end range and the sweep timestamp for 1️⃣, and just the sweep timestamp for 2️⃣.

It's worth considering the two newly added integration tests, as these capture the semantics I was looking for here.

**Priority**: P1

**Concerns / possible downsides (what feedback would you like?)**:
- Please check that the splitting of the original usage of sweep timestamp into the individual 1️⃣ and 2️⃣ scenarios has been performed correctly.
- There were multiple points at which decisions could be made about calculating the minimum of the range end and sweep timestamp, as well as whether to throw if the timestamp for 1️⃣ was greater than that of 2️⃣. I went with the idea that the core Sweep classes (`SweepableCells`, `SweepQueueReader`) can make assumptions about how they're being used / can expect to only be used by classes directly manipulating Sweep persistence, and so they should validate the 1️⃣ <= 2️⃣ invariant, while the ASTS task is itself responsible for bounding things correctly. Does this make sense?
  - There's also a version of this where the `Reader` which is how one interfaces with the queues is responsible for doing the min with the sweep timestamp, though I didn't have a strong preference for either way.

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**: No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**: No

**Does this PR need a schema migration?** No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: Nothing in particular I think.

**What was existing testing like? What have you done to improve it?**: Added one new unit test plus two new integration tests that fail on the previous bad behaviour (plus generally added some unit tests at places in the code that were changed).

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**: I don't think this applies.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**: N/A

## Execution
Does not change production.

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**: No

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**: No

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**: Not aware of anything obvious

## Development Process
**Where should we start reviewing?**: SingleBucketSweepTaskIntegrationTest

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: It's not.

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
