### PR TITLE
[ASTS] Implementation of SweepBucketAssignerStateMachineTable

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
@@ -1,0 +1,92 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetRequest;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.keyvalue.api.Value;
+import com.palantir.atlasdb.schema.generated.TargetedSweepTableFactory;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.ObjectPersister.LogSafety;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+final class DefaultSweepAssignedBucketStore implements SweepBucketAssignerStateMachineTable {
+    @VisibleForTesting
+    static final TableReference TABLE_REF =
+            TargetedSweepTableFactory.of().getSweepAssignedBucketsTable(null).getTableRef();
+
+    private final KeyValueService keyValueService;
+    private final ObjectPersister<BucketStateAndIdentifier> bucketStateAndIdentifierPersister;
+
+    private DefaultSweepAssignedBucketStore(
+            KeyValueService keyValueService,
+            ObjectPersister<BucketStateAndIdentifier> bucketStateAndIdentifierPersister) {
+        this.keyValueService = keyValueService;
+        this.bucketStateAndIdentifierPersister = bucketStateAndIdentifierPersister;
+    }
+
+    static DefaultSweepAssignedBucketStore create(KeyValueService keyValueService) {
+        return new DefaultSweepAssignedBucketStore(
+                keyValueService, ObjectPersister.of(BucketStateAndIdentifier.class, LogSafety.SAFE));
+    }
+
+    @Override
+    public void setInitialStateForBucketAssigner(long bucketIdentifier, long startTimestamp) {
+        BucketStateAndIdentifier initialState =
+                BucketStateAndIdentifier.of(bucketIdentifier, BucketAssignerState.start(startTimestamp));
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketAssignerStateMachineCell();
+        casCell(cell, Optional.empty(), bucketStateAndIdentifierPersister.trySerialize(initialState));
+    }
+
+    @Override
+    public void updateStateMachineForBucketAssigner(
+            BucketStateAndIdentifier original, BucketStateAndIdentifier updated) {
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketAssignerStateMachineCell();
+        casCell(
+                cell,
+                Optional.of(bucketStateAndIdentifierPersister.trySerialize(original)),
+                bucketStateAndIdentifierPersister.trySerialize(updated));
+    }
+
+    @Override
+    public BucketStateAndIdentifier getBucketStateAndIdentifier() {
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketAssignerStateMachineCell();
+        Optional<BucketStateAndIdentifier> value = readCell(cell, bucketStateAndIdentifierPersister::tryDeserialize);
+        return value.orElseThrow(() -> new SafeIllegalStateException(
+                "No bucket state and identifier found. This should have been bootstrapped during"
+                        + " initialisation, and as such, is an invalid state."));
+    }
+
+    private void casCell(Cell cell, Optional<byte[]> existingValue, byte[] newValue) {
+        CheckAndSetRequest request = existingValue
+                .map(value -> CheckAndSetRequest.singleCell(TABLE_REF, cell, value, newValue))
+                .orElseGet(() -> CheckAndSetRequest.newCell(TABLE_REF, cell, newValue));
+        keyValueService.checkAndSet(request);
+    }
+
+    private <T> Optional<T> readCell(Cell cell, Function<byte[], T> deserializer) {
+        Map<Cell, Value> values = keyValueService.get(TABLE_REF, ImmutableMap.of(cell, Long.MAX_VALUE));
+        Optional<byte[]> value = Optional.ofNullable(values.get(cell)).map(Value::getContents);
+        return value.map(deserializer);
+    }
+}

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketAssignerStateMachineTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketAssignerStateMachineTable.java
@@ -17,6 +17,11 @@
 package com.palantir.atlasdb.sweep.asts.bucketingthings;
 
 public interface SweepBucketAssignerStateMachineTable {
+    /**
+     * This should only be used to bootstrap the initial state. Subsequent calls to this method will throw an exception.
+     */
+    void setInitialStateForBucketAssigner(long bucketIdentifier, long startTimestamp);
+
     void updateStateMachineForBucketAssigner(BucketStateAndIdentifier original, BucketStateAndIdentifier updated);
 
     BucketStateAndIdentifier getBucketStateAndIdentifier();

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketAssignerTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketAssignerTest.java
@@ -364,6 +364,11 @@ public final class DefaultBucketAssignerTest {
         }
 
         @Override
+        public void setInitialStateForBucketAssigner(long bucketIdentifier, long startTimestamp) {
+            throw new UnsupportedOperationException("This should not be called");
+        }
+
+        @Override
         public void updateStateMachineForBucketAssigner(
                 BucketStateAndIdentifier original, BucketStateAndIdentifier updated) {
             assertThat(stateTransitions).last().isEqualTo(original);

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStoreTest.java
@@ -1,0 +1,95 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.atlasdb.keyvalue.api.CheckAndSetException;
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
+import com.palantir.atlasdb.schema.TargetedSweepSchema;
+import com.palantir.atlasdb.table.description.Schemas;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+// TODO(mdaudali): make these tests abstract like the other tests for BucketProgress
+public final class DefaultSweepAssignedBucketStoreTest {
+    private final TestResourceManager testResourceManager = TestResourceManager.inMemory();
+    private final KeyValueService keyValueService = testResourceManager.getDefaultKvs();
+    private final DefaultSweepAssignedBucketStore store = DefaultSweepAssignedBucketStore.create(keyValueService);
+
+    @BeforeEach
+    public void before() {
+        Schemas.createTablesAndIndexes(TargetedSweepSchema.INSTANCE.getLatestSchema(), keyValueService);
+        keyValueService.truncateTable(DefaultSweepAssignedBucketStore.TABLE_REF);
+    }
+
+    @Test
+    public void getBucketStateAndIdentifierThrowsIfNoState() {
+        assertThatLoggableExceptionThrownBy(store::getBucketStateAndIdentifier)
+                .isInstanceOf(SafeIllegalStateException.class)
+                .hasLogMessage("No bucket state and identifier found. This should have been bootstrapped during"
+                        + " initialisation, and as such, is an invalid state.");
+    }
+
+    @Test
+    public void setInitialStateCreatesStartingState() {
+        long bucketIdentifier = 123;
+        long startTimestamp = 456;
+        store.setInitialStateForBucketAssigner(bucketIdentifier, startTimestamp);
+        BucketStateAndIdentifier initialState =
+                BucketStateAndIdentifier.of(bucketIdentifier, BucketAssignerState.start(startTimestamp));
+        assertThat(store.getBucketStateAndIdentifier()).isEqualTo(initialState);
+    }
+
+    @Test
+    public void cannotSetInitialStateWhenStateAlreadyExists() {
+        store.setInitialStateForBucketAssigner(123, 456);
+        assertThatThrownBy(() -> store.setInitialStateForBucketAssigner(789, 101112))
+                .isInstanceOf(CheckAndSetException.class);
+    }
+
+    @Test
+    public void updateStateMachineForBucketAssignerFailsIfInitialDoesNotMatchExisting() {
+        store.setInitialStateForBucketAssigner(123, 456);
+        BucketStateAndIdentifier incorrectInitialState =
+                BucketStateAndIdentifier.of(123, BucketAssignerState.start(789));
+        BucketStateAndIdentifier newState = BucketStateAndIdentifier.of(123, BucketAssignerState.start(101112));
+        assertThatThrownBy(() -> store.updateStateMachineForBucketAssigner(incorrectInitialState, newState))
+                .isInstanceOf(CheckAndSetException.class);
+    }
+
+    @Test
+    public void updateStateMachineForBucketAssignerFailsIfNoExistingValuePresent() {
+        BucketStateAndIdentifier unsetInitialState = BucketStateAndIdentifier.of(123, BucketAssignerState.start(456));
+        BucketStateAndIdentifier newState = BucketStateAndIdentifier.of(123, BucketAssignerState.start(101112));
+        assertThatThrownBy(() -> store.updateStateMachineForBucketAssigner(unsetInitialState, newState))
+                .isInstanceOf(CheckAndSetException.class);
+    }
+
+    @Test
+    public void updateStateMachineForBucketAssignerModifiesStateToNewIfOriginalMatchesExisting() {
+        store.setInitialStateForBucketAssigner(123, 456);
+        BucketStateAndIdentifier initialState = BucketStateAndIdentifier.of(123, BucketAssignerState.start(456));
+        BucketStateAndIdentifier newState = BucketStateAndIdentifier.of(123, BucketAssignerState.start(101112));
+        store.updateStateMachineForBucketAssigner(initialState, newState);
+        assertThat(store.getBucketStateAndIdentifier()).isEqualTo(newState);
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
Breaking up https://github.com/palantir/atlasdb/pull/7313 into individual PRs representing each table. They will all be in the same class.

We have various interfaces representing logical tables necessary for tracking bucket state, but no concrete implementation.
**After this PR**:
Start of an initial implementation.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
Check the setInitialStateForBucketAssigner, which is new.

Also, I've done a drive by to the client smile mapper, from the server mapper. The server mappers enable FAIL_ON_UNKNOWN_PROPERTIES, which will prevent us from adding optional fields in the future. Do check this.
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
Added tests
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A

## Execution
Not wired up.

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Not this one
## Development Process
**Where should we start reviewing?**:
DBA
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
