### PR TITLE
[Named min timestamp leases] Client API

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
@@ -143,8 +143,8 @@ public final class InstrumentedTimelockService implements TimelockService {
 
     @ReviewedRestrictedApiUsage
     @Override
-    public long getMinLeasedNamedTimestamp(String timestampName) {
-        return executeWithRecord(() -> timelockService.getMinLeasedNamedTimestamp(timestampName));
+    public long getMinLeasedTimestampForName(String timestampName) {
+        return executeWithRecord(() -> timelockService.getMinLeasedTimestampForName(timestampName));
     }
 
     private <T> T executeWithRecord(Supplier<T> method) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.transaction.impl;
 import com.codahale.metrics.Meter;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.lock.annotations.ReviewedRestrictedApiUsage;
 import com.palantir.lock.v2.AcquireNamedMinTimestampLeaseResult;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -132,6 +133,7 @@ public final class InstrumentedTimelockService implements TimelockService {
         return executeWithRecord(timelockService::currentTimeMillis);
     }
 
+    @ReviewedRestrictedApiUsage
     @Override
     public AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(
             String timestampName, int numFreshTimestamps) {
@@ -139,6 +141,7 @@ public final class InstrumentedTimelockService implements TimelockService {
                 () -> timelockService.acquireNamedMinTimestampLease(timestampName, numFreshTimestamps));
     }
 
+    @ReviewedRestrictedApiUsage
     @Override
     public long getMinLeasedNamedTimestamp(String timestampName) {
         return executeWithRecord(() -> timelockService.getMinLeasedNamedTimestamp(timestampName));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/InstrumentedTimelockService.java
@@ -18,6 +18,7 @@ package com.palantir.atlasdb.transaction.impl;
 import com.codahale.metrics.Meter;
 import com.palantir.atlasdb.AtlasDbMetricNames;
 import com.palantir.atlasdb.util.MetricsManager;
+import com.palantir.lock.v2.AcquireNamedMinTimestampLeaseResult;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
@@ -129,6 +130,18 @@ public final class InstrumentedTimelockService implements TimelockService {
     @Override
     public long currentTimeMillis() {
         return executeWithRecord(timelockService::currentTimeMillis);
+    }
+
+    @Override
+    public AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(
+            String timestampName, int numFreshTimestamps) {
+        return executeWithRecord(
+                () -> timelockService.acquireNamedMinTimestampLease(timestampName, numFreshTimestamps));
+    }
+
+    @Override
+    public long getMinLeasedNamedTimestamp(String timestampName) {
+        return executeWithRecord(() -> timelockService.getMinLeasedNamedTimestamp(timestampName));
     }
 
     private <T> T executeWithRecord(Supplier<T> method) {

--- a/lock-api-objects/src/main/java/com/palantir/lock/annotations/ReviewedRestrictedApiUsage.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/annotations/ReviewedRestrictedApiUsage.java
@@ -1,0 +1,23 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.annotations;
+
+/**
+ * Annotation to be used to indicate that usage of a restricted method is intentional and all the nuances about it
+ * are understood.
+ */
+public @interface ReviewedRestrictedApiUsage {}

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/AcquireNamedMinTimestampLeaseResult.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/AcquireNamedMinTimestampLeaseResult.java
@@ -22,11 +22,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 public interface AcquireNamedMinTimestampLeaseResult {
     @Value.Parameter
-    long getMinLeased();
+    long minLeasedTimestamp();
 
     @Value.Parameter
-    LockToken getLock();
+    LockToken lock();
 
     @Value.Parameter
-    List<Long> getFreshTimestamps();
+    List<Long> freshTimestamps();
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/AcquireNamedMinTimestampLeaseResult.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/AcquireNamedMinTimestampLeaseResult.java
@@ -16,7 +16,7 @@
 
 package com.palantir.lock.v2;
 
-import com.palantir.timestamp.TimestampRange;
+import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -28,5 +28,5 @@ public interface AcquireNamedMinTimestampLeaseResult {
     LockToken getLock();
 
     @Value.Parameter
-    TimestampRange getFreshTimestamps();
+    List<Long> getFreshTimestamps();
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/AcquireNamedMinTimestampLeaseResult.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/AcquireNamedMinTimestampLeaseResult.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.v2;
+
+import com.palantir.timestamp.TimestampRange;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface AcquireNamedMinTimestampLeaseResult {
+    @Value.Parameter
+    long getMinLeased();
+
+    @Value.Parameter
+    LockToken getLock();
+
+    @Value.Parameter
+    TimestampRange getFreshTimestamps();
+}

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -110,4 +110,9 @@ public interface TimelockService {
     void tryUnlock(Set<LockToken> tokens);
 
     long currentTimeMillis();
+
+    // scary java docs!
+    AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(String timestampName, int numFreshTimestamps);
+
+    long getMinLeasedNamedTimestamp(String timestampName);
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -15,6 +15,8 @@
  */
 package com.palantir.lock.v2;
 
+import com.google.errorprone.annotations.RestrictedApi;
+import com.palantir.lock.annotations.ReviewedRestrictedApiUsage;
 import com.palantir.logsafe.Safe;
 import com.palantir.processors.AutoDelegate;
 import com.palantir.processors.DoNotDelegate;
@@ -111,8 +113,27 @@ public interface TimelockService {
 
     long currentTimeMillis();
 
-    // scary java docs!
+    /**
+     * Acquires a lease on a named timestamp. The lease is taken out with a new fresh timestamp.
+     * The returned timestamps are fresh timestamps obtained strictly after the lease is taken out.
+     */
+    @RestrictedApi(
+            explanation =
+                    "This method is for internal Atlas and internal library use only. Clients MUST NOT use it unless"
+                        + " given explicit approval. Mis-use can result in SEVERE DATA CORRUPTION and the API contract"
+                        + " is subject to change at any time.",
+            allowlistAnnotations = ReviewedRestrictedApiUsage.class)
     AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(String timestampName, int numFreshTimestamps);
 
+    /**
+     * Returns the smallest named timestamp for which there was an active lease at the time of the call.
+     * If there are no active leases, a fresh timestamp is obtained and returned.
+     */
+    @RestrictedApi(
+            explanation =
+                    "This method is for internal Atlas and internal library use only. Clients MUST NOT use it unless"
+                        + " given explicit approval. Mis-use can result in SEVERE DATA CORRUPTION and the API contract"
+                        + " is subject to change at any time.",
+            allowlistAnnotations = ReviewedRestrictedApiUsage.class)
     long getMinLeasedNamedTimestamp(String timestampName);
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -120,8 +120,8 @@ public interface TimelockService {
     @RestrictedApi(
             explanation =
                     "This method is for internal Atlas and internal library use only. Clients MUST NOT use it unless"
-                            + " given explicit approval. Mis-use can result in SEVERE DATA CORRUPTION and the API contract"
-                            + " is subject to change at any time.",
+                        + " given explicit approval. Mis-use can result in SEVERE DATA CORRUPTION and the API contract"
+                        + " is subject to change at any time.",
             allowlistAnnotations = ReviewedRestrictedApiUsage.class)
     AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(String timestampName, int numFreshTimestamps);
 
@@ -132,8 +132,8 @@ public interface TimelockService {
     @RestrictedApi(
             explanation =
                     "This method is for internal Atlas and internal library use only. Clients MUST NOT use it unless"
-                            + " given explicit approval. Mis-use can result in SEVERE DATA CORRUPTION and the API contract"
-                            + " is subject to change at any time.",
+                        + " given explicit approval. Mis-use can result in SEVERE DATA CORRUPTION and the API contract"
+                        + " is subject to change at any time.",
             allowlistAnnotations = ReviewedRestrictedApiUsage.class)
     long getMinLeasedTimestampForName(String timestampName);
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/TimelockService.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/TimelockService.java
@@ -120,20 +120,20 @@ public interface TimelockService {
     @RestrictedApi(
             explanation =
                     "This method is for internal Atlas and internal library use only. Clients MUST NOT use it unless"
-                        + " given explicit approval. Mis-use can result in SEVERE DATA CORRUPTION and the API contract"
-                        + " is subject to change at any time.",
+                            + " given explicit approval. Mis-use can result in SEVERE DATA CORRUPTION and the API contract"
+                            + " is subject to change at any time.",
             allowlistAnnotations = ReviewedRestrictedApiUsage.class)
     AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(String timestampName, int numFreshTimestamps);
 
     /**
-     * Returns the smallest named timestamp for which there was an active lease at the time of the call.
+     * Returns the smallest leased timestamp in the associated named collection at the time of the call.
      * If there are no active leases, a fresh timestamp is obtained and returned.
      */
     @RestrictedApi(
             explanation =
                     "This method is for internal Atlas and internal library use only. Clients MUST NOT use it unless"
-                        + " given explicit approval. Mis-use can result in SEVERE DATA CORRUPTION and the API contract"
-                        + " is subject to change at any time.",
+                            + " given explicit approval. Mis-use can result in SEVERE DATA CORRUPTION and the API contract"
+                            + " is subject to change at any time.",
             allowlistAnnotations = ReviewedRestrictedApiUsage.class)
-    long getMinLeasedNamedTimestamp(String timestampName);
+    long getMinLeasedTimestampForName(String timestampName);
 }

--- a/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.common.base.Throwables;
+import com.palantir.lock.annotations.ReviewedRestrictedApiUsage;
 import com.palantir.lock.v2.AcquireNamedMinTimestampLeaseResult;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -170,6 +171,7 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
         return runTaskTimed("currentTimeMillis", delegate::currentTimeMillis);
     }
 
+    @ReviewedRestrictedApiUsage
     @Override
     public AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(
             String timestampName, int numFreshTimestamps) {
@@ -178,6 +180,7 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
                 () -> delegate.acquireNamedMinTimestampLease(timestampName, numFreshTimestamps));
     }
 
+    @ReviewedRestrictedApiUsage
     @Override
     public long getMinLeasedNamedTimestamp(String timestampName) {
         return runTaskTimed("getMinLeasedNamedTimestamp", () -> delegate.getMinLeasedNamedTimestamp(timestampName));

--- a/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.RateLimiter;
 import com.palantir.common.base.Throwables;
+import com.palantir.lock.v2.AcquireNamedMinTimestampLeaseResult;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
@@ -167,6 +168,19 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
     @Override
     public long currentTimeMillis() {
         return runTaskTimed("currentTimeMillis", delegate::currentTimeMillis);
+    }
+
+    @Override
+    public AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(
+            String timestampName, int numFreshTimestamps) {
+        return runTaskTimed(
+                "acquireNamedMinTimestampLease",
+                () -> delegate.acquireNamedMinTimestampLease(timestampName, numFreshTimestamps));
+    }
+
+    @Override
+    public long getMinLeasedNamedTimestamp(String timestampName) {
+        return runTaskTimed("getMinLeasedNamedTimestamp", () -> delegate.getMinLeasedNamedTimestamp(timestampName));
     }
 
     private <T> T runTaskTimed(String actionName, Supplier<T> action) {

--- a/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/ProfilingTimelockService.java
@@ -182,8 +182,8 @@ public class ProfilingTimelockService implements AutoCloseable, TimelockService 
 
     @ReviewedRestrictedApiUsage
     @Override
-    public long getMinLeasedNamedTimestamp(String timestampName) {
-        return runTaskTimed("getMinLeasedNamedTimestamp", () -> delegate.getMinLeasedNamedTimestamp(timestampName));
+    public long getMinLeasedTimestampForName(String timestampName) {
+        return runTaskTimed("getMinLeasedNamedTimestamp", () -> delegate.getMinLeasedTimestampForName(timestampName));
     }
 
     private <T> T runTaskTimed(String actionName, Supplier<T> action) {

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -20,6 +20,7 @@ import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequestV2;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureTimestampRange;
 import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.lock.v2.AcquireNamedMinTimestampLeaseResult;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
@@ -166,6 +167,19 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
     @Override
     public long currentTimeMillis() {
         return rpcClient.currentTimeMillis();
+    }
+
+    @Override
+    public AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(
+            String timestampName, int numFreshTimestamps) {
+        // TODO(aalouane): implement!
+        throw new UnsupportedOperationException("Not implemented yet!");
+    }
+
+    @Override
+    public long getMinLeasedNamedTimestamp(String timestampName) {
+        // TODO(aalouane): implement!
+        throw new UnsupportedOperationException("Not implemented yet!");
     }
 
     @Override

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -20,6 +20,7 @@ import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsRequestV2;
 import com.palantir.atlasdb.timelock.api.ConjureGetFreshTimestampsResponseV2;
 import com.palantir.atlasdb.timelock.api.ConjureTimestampRange;
 import com.palantir.atlasdb.timelock.api.Namespace;
+import com.palantir.lock.annotations.ReviewedRestrictedApiUsage;
 import com.palantir.lock.v2.AcquireNamedMinTimestampLeaseResult;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -169,6 +170,7 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
         return rpcClient.currentTimeMillis();
     }
 
+    @ReviewedRestrictedApiUsage
     @Override
     public AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(
             String timestampName, int numFreshTimestamps) {
@@ -176,6 +178,7 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
         throw new UnsupportedOperationException("Not implemented yet!");
     }
 
+    @ReviewedRestrictedApiUsage
     @Override
     public long getMinLeasedNamedTimestamp(String timestampName) {
         // TODO(aalouane): implement!

--- a/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/RemoteTimelockServiceAdapter.java
@@ -180,7 +180,7 @@ public final class RemoteTimelockServiceAdapter implements TimelockService, Auto
 
     @ReviewedRestrictedApiUsage
     @Override
-    public long getMinLeasedNamedTimestamp(String timestampName) {
+    public long getMinLeasedTimestampForName(String timestampName) {
         // TODO(aalouane): implement!
         throw new UnsupportedOperationException("Not implemented yet!");
     }

--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
@@ -21,6 +21,7 @@ import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.leader.NotCurrentLeaderException;
+import com.palantir.lock.annotations.ReviewedRestrictedApiUsage;
 import com.palantir.lock.v2.AcquireNamedMinTimestampLeaseResult;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -181,12 +182,14 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
         return executeOnTimeLock(delegate::currentTimeMillis);
     }
 
+    @ReviewedRestrictedApiUsage
     @Override
     public AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(
             String timestampName, int numFreshTimestamps) {
         return delegate.acquireNamedMinTimestampLease(timestampName, numFreshTimestamps);
     }
 
+    @ReviewedRestrictedApiUsage
     @Override
     public long getMinLeasedNamedTimestamp(String timestampName) {
         return delegate.getMinLeasedNamedTimestamp(timestampName);

--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
@@ -21,6 +21,7 @@ import com.palantir.common.base.Throwables;
 import com.palantir.common.concurrent.NamedThreadFactory;
 import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.leader.NotCurrentLeaderException;
+import com.palantir.lock.v2.AcquireNamedMinTimestampLeaseResult;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockLeaseRefresher;
@@ -178,6 +179,17 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
     @Override
     public long currentTimeMillis() {
         return executeOnTimeLock(delegate::currentTimeMillis);
+    }
+
+    @Override
+    public AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(
+            String timestampName, int numFreshTimestamps) {
+        return delegate.acquireNamedMinTimestampLease(timestampName, numFreshTimestamps);
+    }
+
+    @Override
+    public long getMinLeasedNamedTimestamp(String timestampName) {
+        return delegate.getMinLeasedNamedTimestamp(timestampName);
     }
 
     private static <T> T executeOnTimeLock(Callable<T> callable) {

--- a/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/TimeLockClient.java
@@ -191,8 +191,8 @@ public class TimeLockClient implements AutoCloseable, TimelockService {
 
     @ReviewedRestrictedApiUsage
     @Override
-    public long getMinLeasedNamedTimestamp(String timestampName) {
-        return delegate.getMinLeasedNamedTimestamp(timestampName);
+    public long getMinLeasedTimestampForName(String timestampName) {
+        return delegate.getMinLeasedTimestampForName(timestampName);
     }
 
     private static <T> T executeOnTimeLock(Callable<T> callable) {

--- a/lock-api/src/main/java/com/palantir/lock/client/UnreliableTimeLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/UnreliableTimeLockService.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.buggify.api.BuggifyFactory;
 import com.palantir.atlasdb.buggify.impl.DefaultBuggifyFactory;
+import com.palantir.lock.annotations.ReviewedRestrictedApiUsage;
 import com.palantir.lock.v2.AcquireNamedMinTimestampLeaseResult;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
@@ -156,12 +157,14 @@ public final class UnreliableTimeLockService implements TimelockService {
         return delegate.currentTimeMillis();
     }
 
+    @ReviewedRestrictedApiUsage
     @Override
     public AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(
             String timestampName, int numFreshTimestamps) {
         return delegate.acquireNamedMinTimestampLease(timestampName, numFreshTimestamps);
     }
 
+    @ReviewedRestrictedApiUsage
     @Override
     public long getMinLeasedNamedTimestamp(String timestampName) {
         return delegate.getMinLeasedNamedTimestamp(timestampName);

--- a/lock-api/src/main/java/com/palantir/lock/client/UnreliableTimeLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/UnreliableTimeLockService.java
@@ -166,8 +166,8 @@ public final class UnreliableTimeLockService implements TimelockService {
 
     @ReviewedRestrictedApiUsage
     @Override
-    public long getMinLeasedNamedTimestamp(String timestampName) {
-        return delegate.getMinLeasedNamedTimestamp(timestampName);
+    public long getMinLeasedTimestampForName(String timestampName) {
+        return delegate.getMinLeasedTimestampForName(timestampName);
     }
 
     private void maybeRandomlyIncreaseTimestamp() {

--- a/lock-api/src/main/java/com/palantir/lock/client/UnreliableTimeLockService.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/UnreliableTimeLockService.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import com.palantir.atlasdb.buggify.api.BuggifyFactory;
 import com.palantir.atlasdb.buggify.impl.DefaultBuggifyFactory;
+import com.palantir.lock.v2.AcquireNamedMinTimestampLeaseResult;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
@@ -153,6 +154,17 @@ public final class UnreliableTimeLockService implements TimelockService {
     @Override
     public long currentTimeMillis() {
         return delegate.currentTimeMillis();
+    }
+
+    @Override
+    public AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(
+            String timestampName, int numFreshTimestamps) {
+        return delegate.acquireNamedMinTimestampLease(timestampName, numFreshTimestamps);
+    }
+
+    @Override
+    public long getMinLeasedNamedTimestamp(String timestampName) {
+        return delegate.getMinLeasedNamedTimestamp(timestampName);
     }
 
     private void maybeRandomlyIncreaseTimestamp() {

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
@@ -24,6 +24,7 @@ import com.palantir.lock.LockMode;
 import com.palantir.lock.LockRefreshToken;
 import com.palantir.lock.LockService;
 import com.palantir.lock.SimpleTimeDuration;
+import com.palantir.lock.v2.AcquireNamedMinTimestampLeaseResult;
 import com.palantir.lock.v2.ClientLockingOptions;
 import com.palantir.lock.v2.LockImmutableTimestampResponse;
 import com.palantir.lock.v2.LockRequest;
@@ -179,6 +180,19 @@ public class LegacyTimelockService implements TimelockService {
     @Override
     public long currentTimeMillis() {
         return lockService.currentTimeMillis();
+    }
+
+    @Override
+    public AcquireNamedMinTimestampLeaseResult acquireNamedMinTimestampLease(
+            String timestampName, int numFreshTimestamps) {
+        // TODO(aalouane): implement!
+        throw new UnsupportedOperationException("Not implemented yet!");
+    }
+
+    @Override
+    public long getMinLeasedNamedTimestamp(String timestampName) {
+        // TODO(aalouane): implement!
+        throw new UnsupportedOperationException("Not implemented yet!");
     }
 
     private long getImmutableTimestampInternal(long ts) {

--- a/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
+++ b/lock-impl/src/main/java/com/palantir/lock/impl/LegacyTimelockService.java
@@ -190,7 +190,7 @@ public class LegacyTimelockService implements TimelockService {
     }
 
     @Override
-    public long getMinLeasedNamedTimestamp(String timestampName) {
+    public long getMinLeasedTimestampForName(String timestampName) {
         // TODO(aalouane): implement!
         throw new UnsupportedOperationException("Not implemented yet!");
     }


### PR DESCRIPTION
## General
**Before this PR**:
No way to grab leases à la immutable timestamp lock on timestamps which are not the immutable timestamp lock.
**After this PR**:
Define a client-side API that allows querying the least leased timestamp and to lease said timestamp for any arbitrary timestamp name.
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P1
**Concerns / possible downsides (what feedback would you like?)**:
- The API is general. I am happy adding a specific one but I opted to leave this for the user.
- The API is public. This functionality needs to fit all configurations of our lock/timestamp setup and the only common denominator is the public `TimelockService`. It is possible to create some internal thing, or do weird casting. But, I preferred what we did in the past: adding it where we need it and use annotations to guard against unintended usage.
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
N/A
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
No-op PR
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
No-op PR
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:
`TimelockService`
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
