### PR TITLE
[ASTS] DefaultSweepAssignedBucketStore - Integration tests against a concrete KVS

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraDefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraDefaultSweepAssignedBucketStoreTest.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.cassandra;
+
+import com.palantir.atlasdb.containers.CassandraResource;
+import com.palantir.atlasdb.sweep.asts.progress.AbstractDefaultBucketProgressStoreTest;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class CassandraDefaultSweepAssignedBucketStoreTest extends AbstractDefaultBucketProgressStoreTest {
+    @RegisterExtension
+    public static final CassandraResource CASSANDRA = new CassandraResource();
+
+    public CassandraDefaultSweepAssignedBucketStoreTest() {
+        super(CASSANDRA);
+    }
+}

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/DbKvsOracleDefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/oracle/DbKvsOracleDefaultSweepAssignedBucketStoreTest.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.impl.oracle;
+
+import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.AbstractDefaultSweepAssignedBucketStoreTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@ExtendWith(DbKvsOracleExtension.class)
+public class DbKvsOracleDefaultSweepAssignedBucketStoreTest extends AbstractDefaultSweepAssignedBucketStoreTest {
+    @RegisterExtension
+    public static final TestResourceManager TRM = new TestResourceManager(DbKvsOracleExtension::createKvs);
+
+    public DbKvsOracleDefaultSweepAssignedBucketStoreTest() {
+        super(TRM);
+    }
+}

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresDefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresDefaultSweepAssignedBucketStoreTest.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
+
+import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
+import com.palantir.atlasdb.sweep.asts.progress.AbstractDefaultBucketProgressStoreTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@ExtendWith(DbKvsPostgresExtension.class)
+public class DbKvsPostgresDefaultSweepAssignedBucketStoreTest extends AbstractDefaultBucketProgressStoreTest {
+    @RegisterExtension
+    public static final TestResourceManager TRM = new TestResourceManager(DbKvsPostgresExtension::createKvs);
+
+    public DbKvsPostgresDefaultSweepAssignedBucketStoreTest() {
+        super(TRM);
+    }
+}

--- a/atlasdb-tests-shared/build.gradle
+++ b/atlasdb-tests-shared/build.gradle
@@ -30,6 +30,8 @@ dependencies {
   implementation 'org.assertj:assertj-guava'
   implementation 'org.jboss.xnio:xnio-api'
   implementation 'org.rocksdb:rocksdbjni'
+  implementation 'com.palantir.safe-logging:preconditions-assertj'
+
 
   implementation project(':atlasdb-api')
   implementation project(':atlasdb-client')
@@ -89,4 +91,3 @@ schemas = [
     'com.palantir.atlasdb.schema.indexing.IndexTestSchema',
     'com.palantir.atlasdb.schema.stream.StreamTestSchema'
 ]
-

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/InMemoryDefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/InMemoryDefaultSweepAssignedBucketStoreTest.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts.bucketingthings;
+
+import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
+
+public final class InMemoryDefaultSweepAssignedBucketStoreTest extends AbstractDefaultSweepAssignedBucketStoreTest {
+    private InMemoryDefaultSweepAssignedBucketStoreTest() {
+        super(TestResourceManager.inMemory());
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**: 
We only had tests for DefaultSweepAssignedBucketStore with the in memory KVS

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
Integration tests for implementations of DefaultSweepAssignedBucketStore for Cassandra, Oracle, Postgres + InMemory
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**: 
Check that the tests are actually executed!

**Is documentation needed?**: No.

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
 No

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**: 
No

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**: 
Yes

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
 No

**Does this PR need a schema migration?** 
No

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**: 
N/A

**What was existing testing like? What have you done to improve it?**: 
Added tests

## Development Process
**Where should we start reviewing?**: Your choice

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**: N/A

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
