### PR TITLE
[Named min timestamp leases] Move `ImmutableTimestampTracker` usage to `LockCollection`

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockManager.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockManager.java
@@ -16,12 +16,22 @@
 package com.palantir.atlasdb.timelock.lock;
 
 import com.palantir.lock.LockDescriptor;
+import java.util.Optional;
 import java.util.Set;
 
-final class LockCollection {
+final class LockManager {
     private final ExclusiveLockCollection exclusiveLocks = new ExclusiveLockCollection();
+    private final ImmutableTimestampTracker immutableTimestampTracker = new ImmutableTimestampTracker();
 
     OrderedLocks getAllExclusiveLocks(Set<LockDescriptor> descriptors) {
         return exclusiveLocks.getAll(descriptors);
+    }
+
+    Optional<Long> getImmutableTimestamp() {
+        return immutableTimestampTracker.getImmutableTimestamp();
+    }
+
+    AsyncLock getImmutableTimestampLock(long timestamp) {
+        return immutableTimestampTracker.getLockFor(timestamp);
     }
 }

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceEteTest.java
@@ -67,8 +67,7 @@ public class AsyncLockServiceEteTest {
             clock.id(),
             BufferMetrics.of(MetricsManagers.createForTests().getTaggedRegistry()));
     private final AsyncLockService service = new AsyncLockService(
-            new LockCollection(),
-            new ImmutableTimestampTracker(),
+            new LockManager(),
             new LockAcquirer(
                     new LockLog(new MetricRegistry(), () -> 2L),
                     Executors.newSingleThreadScheduledExecutor(),

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/AsyncLockServiceTest.java
@@ -54,14 +54,12 @@ public class AsyncLockServiceTest {
 
     private final LeaderClock leaderClock = LeaderClock.create();
     private final LockAcquirer acquirer = mock(LockAcquirer.class);
-    private final LockCollection locks = mock(LockCollection.class);
+    private final LockManager lockManager = mock(LockManager.class);
     private final HeldLocksCollection heldLocks = spy(HeldLocksCollection.create(leaderClock));
     private final AwaitedLocksCollection awaitedLocks = spy(new AwaitedLocksCollection());
-    private final ImmutableTimestampTracker immutableTimestampTracker = mock(ImmutableTimestampTracker.class);
     private final DeterministicScheduler reaperExecutor = new DeterministicScheduler();
     private final AsyncLockService lockService = new AsyncLockService(
-            locks,
-            immutableTimestampTracker,
+            lockManager,
             acquirer,
             heldLocks,
             awaitedLocks,
@@ -75,16 +73,16 @@ public class AsyncLockServiceTest {
         when(acquirer.acquireLocks(any(), any(), any())).thenReturn(new AsyncResult<>());
         when(acquirer.acquireLocks(any(), any(), any(), any())).thenReturn(new AsyncResult<>());
         when(acquirer.waitForLocks(any(), any(), any())).thenReturn(new AsyncResult<>());
-        when(locks.getAllExclusiveLocks(any())).thenReturn(OrderedLocks.fromSingleLock(newLock()));
-        when(immutableTimestampTracker.getImmutableTimestamp()).thenReturn(Optional.empty());
-        when(immutableTimestampTracker.getLockFor(anyLong())).thenReturn(newLock());
+        when(lockManager.getAllExclusiveLocks(any())).thenReturn(OrderedLocks.fromSingleLock(newLock()));
+        when(lockManager.getImmutableTimestamp()).thenReturn(Optional.empty());
+        when(lockManager.getImmutableTimestampLock(anyLong())).thenReturn(newLock());
     }
 
     @Test
     public void passesOrderedLocksToAcquirer() {
         OrderedLocks expected = orderedLocks(newLock(), newLock());
         Set<LockDescriptor> descriptors = descriptors(LOCK_A, LOCK_B);
-        when(locks.getAllExclusiveLocks(descriptors)).thenReturn(expected);
+        when(lockManager.getAllExclusiveLocks(descriptors)).thenReturn(expected);
 
         lockService.lock(REQUEST_ID, descriptors, DEADLINE);
 
@@ -95,7 +93,7 @@ public class AsyncLockServiceTest {
     public void passesOrderedLocksToAcquirerWhenWaitingForLocks() {
         OrderedLocks expected = orderedLocks(newLock(), newLock());
         Set<LockDescriptor> descriptors = descriptors(LOCK_A, LOCK_B);
-        when(locks.getAllExclusiveLocks(descriptors)).thenReturn(expected);
+        when(lockManager.getAllExclusiveLocks(descriptors)).thenReturn(expected);
 
         lockService.waitForLocks(REQUEST_ID, descriptors, DEADLINE);
 
@@ -127,7 +125,7 @@ public class AsyncLockServiceTest {
         UUID requestId = UUID.randomUUID();
         long timestamp = 123L;
         AsyncLock immutableTsLock = spy(newLock());
-        when(immutableTimestampTracker.getLockFor(timestamp)).thenReturn(immutableTsLock);
+        when(lockManager.getImmutableTimestampLock(timestamp)).thenReturn(immutableTsLock);
 
         lockService.lockImmutableTimestamp(requestId, timestamp);
 

--- a/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/LockCollectionTest.java
+++ b/timelock-server/src/test/java/com/palantir/atlasdb/timelock/lock/LockCollectionTest.java
@@ -30,13 +30,13 @@ import org.junit.jupiter.api.Test;
 
 public class LockCollectionTest {
 
-    private final LockCollection lockCollection = new LockCollection();
+    private final LockManager lockManager = new LockManager();
 
     @Test
     public void createsLocksOnDemand() {
         Set<LockDescriptor> descriptors = descriptors("foo", "bar");
 
-        List<AsyncLock> locks = lockCollection.getAllExclusiveLocks(descriptors).get();
+        List<AsyncLock> locks = lockManager.getAllExclusiveLocks(descriptors).get();
 
         assertThat(locks).hasSize(2);
         assertThat(ImmutableSet.copyOf(locks)).hasSize(2);
@@ -46,10 +46,8 @@ public class LockCollectionTest {
     public void returnsSameLockForMultipleRequests() {
         Set<LockDescriptor> descriptors = descriptors("foo", "bar");
 
-        List<AsyncLock> locks1 =
-                lockCollection.getAllExclusiveLocks(descriptors).get();
-        List<AsyncLock> locks2 =
-                lockCollection.getAllExclusiveLocks(descriptors).get();
+        List<AsyncLock> locks1 = lockManager.getAllExclusiveLocks(descriptors).get();
+        List<AsyncLock> locks2 = lockManager.getAllExclusiveLocks(descriptors).get();
 
         assertThat(locks1).containsExactlyElementsOf(locks2);
     }
@@ -62,11 +60,11 @@ public class LockCollectionTest {
                 .sorted()
                 .collect(Collectors.toList());
         List<AsyncLock> expectedOrder = orderedDescriptors.stream()
-                .map(descriptor -> lockCollection.getAllExclusiveLocks(ImmutableSet.of(descriptor)))
+                .map(descriptor -> lockManager.getAllExclusiveLocks(ImmutableSet.of(descriptor)))
                 .map(orderedLocks -> orderedLocks.get().get(0))
                 .collect(Collectors.toList());
 
-        List<AsyncLock> actualOrder = lockCollection
+        List<AsyncLock> actualOrder = lockManager
                 .getAllExclusiveLocks(ImmutableSet.copyOf(orderedDescriptors))
                 .get();
 


### PR DESCRIPTION
This is a re-factor PR, just moving things around. I am moving usages of `ImmutableTimestampTracker` to `LockCollection`. This is in preparation of making `LockCollection` expose the APIs for locks kept by `AsyncLockService`. I will be changing things inside this class next and the diffs should be better with this.

See for https://github.com/palantir/atlasdb/compare/aa-nmtl-trackers?expand=1 for the full picture.