### PR TITLE
[Named min timestamp leases] Add to server async lock service

### DIFF
--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockManager.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/LockManager.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.atlasdb.timelock.lock;
 
+import com.palantir.atlasdb.timelock.api.TimestampLeaseName;
 import com.palantir.lock.LockDescriptor;
 import java.util.Optional;
 import java.util.Set;
@@ -26,6 +27,14 @@ final class LockManager {
 
     OrderedLocks getAllExclusiveLocks(Set<LockDescriptor> descriptors) {
         return exclusiveLocks.getAll(descriptors);
+    }
+
+    Optional<Long> getNamedMinTimestamp(TimestampLeaseName timestampName) {
+        return namedMinTimestampLockCollection.getNamedMinTimestamp(timestampName);
+    }
+
+    AsyncLock getNamedTimestampLock(TimestampLeaseName timestampName, long timestamp) {
+        return namedMinTimestampLockCollection.getNamedTimestampLock(timestampName, timestamp);
     }
 
     Optional<Long> getImmutableTimestamp() {

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/NamedMinTimestampLockCollection.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/lock/NamedMinTimestampLockCollection.java
@@ -26,14 +26,22 @@ final class NamedMinTimestampLockCollection {
             Caffeine.newBuilder().build(NamedMinTimestampTrackerImpl::new);
 
     AsyncLock getImmutableTimestampLock(long timestamp) {
-        return getNamedMinTimestampLockInternal(TimestampLeaseName.RESERVED_NAME_FOR_IMMUTABLE_TIMESTAMP, timestamp);
+        return getNamedTimestampLockInternal(TimestampLeaseName.RESERVED_NAME_FOR_IMMUTABLE_TIMESTAMP, timestamp);
     }
 
     Optional<Long> getImmutableTimestamp() {
         return getNamedMinTimestampInternal(TimestampLeaseName.RESERVED_NAME_FOR_IMMUTABLE_TIMESTAMP);
     }
 
-    private AsyncLock getNamedMinTimestampLockInternal(String name, long timestamp) {
+    AsyncLock getNamedTimestampLock(TimestampLeaseName timestampName, long timestamp) {
+        return getNamedTimestampLockInternal(timestampName.name(), timestamp);
+    }
+
+    Optional<Long> getNamedMinTimestamp(TimestampLeaseName timestampName) {
+        return getNamedMinTimestampInternal(timestampName.name());
+    }
+
+    private AsyncLock getNamedTimestampLockInternal(String name, long timestamp) {
         return NamedMinTimestampLock.create(getNamedMinTimestampTracker(name), timestamp);
     }
 

--- a/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/NamedMinTimestampLockCollectionTest.java
+++ b/timelock-impl/src/test/java/com/palantir/atlasdb/timelock/lock/NamedMinTimestampLockCollectionTest.java
@@ -18,20 +18,72 @@ package com.palantir.atlasdb.timelock.lock;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import com.palantir.atlasdb.timelock.api.TimestampLeaseName;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public final class NamedMinTimestampLockCollectionTest {
+    private static final UUID REQUEST_ID_1 = UUID.randomUUID();
+    private static final UUID REQUEST_ID_2 = UUID.randomUUID();
+    private static final UUID REQUEST_ID_3 = UUID.randomUUID();
+
     private final NamedMinTimestampLockCollection locks = new NamedMinTimestampLockCollection();
 
+    @MethodSource("getTimestampLeaseNames")
+    @ParameterizedTest
+    public void namedMinTimestampLockDescriptorMatchesFormat(TimestampLeaseName timestampName) {
+        assertThat(getNamedTimestampLock(timestampName, 1).getDescriptor().getBytes())
+                .isEqualTo((timestampName.name() + ":1").getBytes(StandardCharsets.UTF_8));
+
+        assertThat(getNamedTimestampLock(timestampName, 91).getDescriptor().getBytes())
+                .isEqualTo((timestampName.name() + ":91").getBytes(StandardCharsets.UTF_8));
+    }
+
+    @MethodSource("getTimestampLeaseNames")
+    @ParameterizedTest
+    public void namedMinTimestampIsEmptyWhenNoLocksAreActive(TimestampLeaseName timestampName) {
+        assertThat(getNamedMinTimestamp(timestampName)).isEmpty();
+
+        AsyncLock lock = getNamedTimestampLock(timestampName, 1);
+        lock.lock(REQUEST_ID_1);
+        lock.unlock(REQUEST_ID_1);
+
+        assertThat(getNamedMinTimestamp(timestampName)).isEmpty();
+    }
+
+    @MethodSource("getTimestampLeaseNames")
+    @ParameterizedTest
+    public void getNamedMinTimestampReturnsMinimumLockedValueAllThroughout(TimestampLeaseName timestampName) {
+        AsyncLock lock1 = getNamedTimestampLock(timestampName, 100);
+        lock1.lock(REQUEST_ID_1);
+        assertThat(getNamedMinTimestamp(timestampName)).hasValue(100L);
+
+        AsyncLock lock2 = getNamedTimestampLock(timestampName, 50);
+        lock2.lock(REQUEST_ID_2);
+        assertThat(getNamedMinTimestamp(timestampName)).hasValue(50L);
+
+        AsyncLock lock3 = getImmutableTimestampLock(75);
+        lock3.lock(REQUEST_ID_3);
+        assertThat(getNamedMinTimestamp(timestampName)).hasValue(50L);
+
+        lock3.unlock(REQUEST_ID_3);
+        assertThat(getNamedMinTimestamp(timestampName)).hasValue(50L);
+
+        lock2.unlock(REQUEST_ID_2);
+        assertThat(getNamedMinTimestamp(timestampName)).hasValue(100L);
+    }
+
     @Test
-    public void immutableTimestampGetLockDescriptorMatchesFormat() {
-        assertThat(getLock(1).getDescriptor().getBytes())
+    public void immutableTimestampLockDescriptorMatchesFormat() {
+        assertThat(getImmutableTimestampLock(1).getDescriptor().getBytes())
                 .isEqualTo("ImmutableTimestamp:1".getBytes(StandardCharsets.UTF_8));
 
-        assertThat(getLock(91).getDescriptor().getBytes())
+        assertThat(getImmutableTimestampLock(91).getDescriptor().getBytes())
                 .isEqualTo("ImmutableTimestamp:91".getBytes(StandardCharsets.UTF_8));
     }
 
@@ -39,7 +91,7 @@ public final class NamedMinTimestampLockCollectionTest {
     public void immutableTimestampIsEmptyWhenNoLocksAreActive() {
         assertThat(getImmutableTimestamp()).isEmpty();
 
-        AsyncLock lock = getLock(1);
+        AsyncLock lock = getImmutableTimestampLock(1);
         UUID requestId = UUID.randomUUID();
         lock.lock(requestId);
         lock.unlock(requestId);
@@ -49,17 +101,17 @@ public final class NamedMinTimestampLockCollectionTest {
 
     @Test
     public void immutableTimestampReturnsMinimumLockedValueAllThroughout() {
-        AsyncLock lock1 = getLock(100);
+        AsyncLock lock1 = getImmutableTimestampLock(100);
         UUID requestId1 = UUID.randomUUID();
         lock1.lock(requestId1);
         assertThat(getImmutableTimestamp()).hasValue(100L);
 
-        AsyncLock lock2 = getLock(50);
+        AsyncLock lock2 = getImmutableTimestampLock(50);
         UUID requestId2 = UUID.randomUUID();
         lock2.lock(requestId2);
         assertThat(getImmutableTimestamp()).hasValue(50L);
 
-        AsyncLock lock3 = getLock(75);
+        AsyncLock lock3 = getImmutableTimestampLock(75);
         UUID requestId3 = UUID.randomUUID();
         lock3.lock(requestId3);
         assertThat(getImmutableTimestamp()).hasValue(50L);
@@ -71,11 +123,72 @@ public final class NamedMinTimestampLockCollectionTest {
         assertThat(getImmutableTimestamp()).hasValue(100L);
     }
 
+    @Test
+    public void concurrentLockingAndUnlockOfDifferentTimestampsDoNotInterfereWithOneAnother() {
+        TimestampLeaseName timestampName1 = TimestampLeaseName.of("CommitImmutableTimestamp");
+        TimestampLeaseName timestampName2 = TimestampLeaseName.of("ToyTimestamp");
+
+        AsyncLock immutableTimestampLock1 = getImmutableTimestampLock(100);
+        immutableTimestampLock1.lock(REQUEST_ID_1);
+        AsyncLock namedMinTimestampLock1 = getNamedTimestampLock(timestampName1, 80);
+        namedMinTimestampLock1.lock(REQUEST_ID_2);
+        assertThat(getImmutableTimestamp()).hasValue(100L);
+        assertThat(getNamedMinTimestamp(timestampName1)).hasValue(80L);
+        assertThat(getNamedMinTimestamp(timestampName2)).isEmpty();
+
+        // Intentionally re-using the request ids
+        AsyncLock immutableTimestampLock2 = getImmutableTimestampLock(90);
+        immutableTimestampLock2.lock(REQUEST_ID_2);
+        AsyncLock namedMinTimestampLock2 = getNamedTimestampLock(timestampName1, 90);
+        namedMinTimestampLock2.lock(REQUEST_ID_1);
+        AsyncLock namedMinTimestampLock3 = getNamedTimestampLock(timestampName2, 70);
+        namedMinTimestampLock3.lock(REQUEST_ID_2);
+        assertThat(getImmutableTimestamp()).hasValue(90L);
+        assertThat(getNamedMinTimestamp(timestampName1)).hasValue(80L);
+        assertThat(getNamedMinTimestamp(timestampName2)).hasValue(70L);
+
+        namedMinTimestampLock2.unlock(REQUEST_ID_1);
+        assertThat(getImmutableTimestamp()).hasValue(90L);
+        assertThat(getNamedMinTimestamp(timestampName1)).hasValue(80L);
+        assertThat(getNamedMinTimestamp(timestampName2)).hasValue(70L);
+
+        immutableTimestampLock1.unlock(REQUEST_ID_1);
+        namedMinTimestampLock3.unlock(REQUEST_ID_2);
+        assertThat(getImmutableTimestamp()).hasValue(90L);
+        assertThat(getNamedMinTimestamp(timestampName1)).hasValue(80L);
+        assertThat(getNamedMinTimestamp(timestampName2)).isEmpty();
+
+        namedMinTimestampLock1.unlock(REQUEST_ID_2);
+        assertThat(getImmutableTimestamp()).hasValue(90L);
+        assertThat(getNamedMinTimestamp(timestampName1)).isEmpty();
+        assertThat(getNamedMinTimestamp(timestampName2)).isEmpty();
+
+        immutableTimestampLock2.unlock(REQUEST_ID_2);
+        assertThat(getImmutableTimestamp()).isEmpty();
+        assertThat(getNamedMinTimestamp(timestampName1)).isEmpty();
+        assertThat(getNamedMinTimestamp(timestampName2)).isEmpty();
+    }
+
+    private Optional<Long> getNamedMinTimestamp(TimestampLeaseName timestampName) {
+        return locks.getNamedMinTimestamp(timestampName);
+    }
+
+    private AsyncLock getNamedTimestampLock(TimestampLeaseName timestampName, long timestamp) {
+        return locks.getNamedTimestampLock(timestampName, timestamp);
+    }
+
     private Optional<Long> getImmutableTimestamp() {
         return locks.getImmutableTimestamp();
     }
 
-    private AsyncLock getLock(long timestamp) {
+    private AsyncLock getImmutableTimestampLock(long timestamp) {
         return locks.getImmutableTimestampLock(timestamp);
+    }
+
+    private static Set<TimestampLeaseName> getTimestampLeaseNames() {
+        return Set.of(
+                TimestampLeaseName.of("CommitImmutableTimestamp"),
+                TimestampLeaseName.of("ToyTimestamp"),
+                TimestampLeaseName.of("AnotherTimestamp"));
     }
 }


### PR DESCRIPTION
## General
**Before this PR**:

**After this PR**:
Implement named min timestamp methods in lock collection and wire in async lock service.
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P1
**Concerns / possible downsides (what feedback would you like?)**:
- The testing is a bit awkward for `NamedMinTimestampLockCollection`. It is possible to use an intermediate class one which is exactly the same and does not check anything about the timestamp name, or know about the immutable timestamp. And, then have a wrapper that does the checks.
**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
Added coverage
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
No-op
**Has the safety of all log arguments been decided correctly?**:
Yes
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
No-op
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
No
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@sverma30
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
