### PR TITLE
[Named min timestamp leases] Server API skeletons

### DIFF
--- a/timelock-api/build.gradle
+++ b/timelock-api/build.gradle
@@ -11,9 +11,11 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.google.guava:guava'
+    implementation 'com.palantir.safe-logging:preconditions'
 
     testImplementation project(':atlasdb-api')
     testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
+    testImplementation 'com.palantir.safe-logging:preconditions-assertj'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -8,6 +8,10 @@ types:
       base-type: string
       external:
         java: com.palantir.atlasdb.timelock.api.Namespace
+    TimestampLeaseName:
+      base-type: string
+      external:
+        java: com.palantir.atlasdb.timelock.api.TimestampLeaseName
     NanoTime:
       base-type: safelong
       external:
@@ -155,6 +159,13 @@ types:
       ConjureLockTokenV2:
         alias: uuid
         safety: safe
+      LeaseIdentifier:
+        alias: uuid
+        safety: safe
+      LeaseGuarantee:
+        fields:
+          identifier: LeaseIdentifier
+          lease: Lease
       SuccessfulLockResponse:
         fields:
           lockToken: ConjureLockToken
@@ -217,6 +228,35 @@ types:
       LeaderTimes:
         fields:
           leaderTimes: map<Namespace, LeaderTime>
+      TimestampLeaseRequest:
+         fields:
+           requestId:
+             type: uuid
+             safety: safe
+           numFreshTimestamps:
+             type: integer
+             safety: safe
+      TimestampLeaseRequests:
+         alias: map<TimestampLeaseName, TimestampLeaseRequest>
+      MultiClientTimestampLeaseRequest:
+         alias: map<Namespace, TimestampLeaseRequests>
+      TimestampLeaseResponse:
+         fields:
+           minLeased: Long
+           leaseGuarantee: LeaseGuarantee
+           freshTimestamps: ConjureTimestampRange
+      TimestampLeaseResponses:
+         alias: map<TimestampLeaseName, TimestampLeaseResponse>
+      MultiClientTimestampLeaseResponse:
+         alias: map<Namespace, TimestampLeaseResponses>
+      GetMinLeasedTimestampRequests:
+         alias: list<TimestampLeaseName>
+      MultiClientGetMinLeasedTimestampRequest:
+         alias: map<Namespace, GetMinLeasedTimestampRequests>
+      GetMinLeasedTimestampResponses:
+         alias: map<TimestampLeaseName, Long>
+      MultiClientGetMinLeasedTimestampResponse:
+         alias: map<Namespace, GetMinLeasedTimestampResponses>
 
 services:
   ConjureTimelockService:
@@ -449,3 +489,31 @@ services:
         returns: map<Namespace, ConjureUnlockResponseV2>
         docs: |
           Version of unlockV2 to unlock locks across multiple namespaces.
+      acquireTimestampLease:
+        http: POST /atl
+        args:
+          requests: MultiClientTimestampLeaseRequest
+        tags:
+          - server-request-context
+        returns: MultiClientTimestampLeaseResponse
+        docs: |
+          For each request, acquires a lease on the specified named timestamp for the relevant namespace.
+          The lease is taken out with a new fresh timestamp. The returned timestamps are fresh timestamps
+          obtained strictly after the lease is taken out.
+
+          It is possible for the endpoint not to return a response for certain pairs of namespace and
+          timestamp. It is also possible to return a smaller range than the was provided in the request.
+          In these cases, clients may retry.
+      getMinLeasedTimestamp:
+        http: POST /gmlt
+        args:
+          requests: MultiClientGetMinLeasedTimestampRequest
+        tags:
+          - server-request-context
+        returns: MultiClientGetMinLeasedTimestampResponse
+        docs: |
+          For each request, returns the smallest leased timestamp in the associated named collection
+          for the relevant namespace at the time of the call. If there are no active leases, a fresh
+          timestamp is obtained and returned.
+
+          The endpoint must return a response for each namespace and timestamp pair requested.

--- a/timelock-api/src/main/java/com/palantir/atlasdb/timelock/api/TimestampLeaseName.java
+++ b/timelock-api/src/main/java/com/palantir/atlasdb/timelock/api/TimestampLeaseName.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.api;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import org.immutables.value.Value;
+
+@JsonDeserialize(as = ImmutableTimestampLeaseName.class)
+@JsonSerialize(as = ImmutableTimestampLeaseName.class)
+@Value.Immutable
+public interface TimestampLeaseName {
+    String RESERVED_NAME_FOR_IMMUTABLE_TIMESTAMP = "ImmutableTimestamp";
+
+    @JsonValue
+    String name();
+
+    @Value.Check
+    default void check() {
+        Preconditions.checkArgument(
+                !name().startsWith(RESERVED_NAME_FOR_IMMUTABLE_TIMESTAMP),
+                "Name must not be a reserved name",
+                SafeArg.of("name", name()));
+    }
+
+    static TimestampLeaseName of(String name) {
+        return ImmutableTimestampLeaseName.builder().name(name).build();
+    }
+}

--- a/timelock-api/src/test/java/com/palantir/atlasdb/timelock/api/TimestampLeaseNameTest.java
+++ b/timelock-api/src/test/java/com/palantir/atlasdb/timelock/api/TimestampLeaseNameTest.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.api;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public final class TimestampLeaseNameTest {
+    @ValueSource(strings = {"ImmutableTimestamp", "ImmutableTimestampTest", "ImmutableTimestampX"})
+    @ParameterizedTest
+    public void throwsWhenProvidedNameStartsWithImmutableTimestamp(String name) {
+        assertThatLoggableExceptionThrownBy(() -> TimestampLeaseName.of(name))
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasLogMessage("Name must not be a reserved name")
+                .hasExactlyArgs(SafeArg.of("name", name));
+    }
+
+    @ValueSource(strings = {"NotImmutableTimestamp", "CommitImmutableTimestamp", "Unrelated"})
+    @ParameterizedTest
+    public void doesNotThrowWhenProvidedNameDoesNotStartWithImmutableTimestamp(String name) {
+        assertThatCode(() -> TimestampLeaseName.of(name)).doesNotThrowAnyException();
+    }
+}

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockService.java
@@ -21,6 +21,8 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
+import com.palantir.atlasdb.timelock.api.TimestampLeaseName;
+import com.palantir.atlasdb.timelock.api.TimestampLeaseResponse;
 import com.palantir.atlasdb.timelock.lock.watch.LockWatchingService;
 import com.palantir.lock.client.IdentifiedLockRequest;
 import com.palantir.lock.v2.IdentifiedTimeLockRequest;
@@ -44,6 +46,7 @@ import com.palantir.tritium.annotations.Instrument;
 import java.io.Closeable;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 @Instrument
 public interface AsyncTimelockService
@@ -72,6 +75,11 @@ public interface AsyncTimelockService
     ListenableFuture<LeaderTime> leaderTime();
 
     ListenableFuture<TimestampRange> getFreshTimestampsAsync(int timestampsToRequest);
+
+    ListenableFuture<TimestampLeaseResponse> acquireTimestampLease(
+            TimestampLeaseName timestampName, UUID requestId, int numFreshTimestamps);
+
+    ListenableFuture<Long> getMinLeasedTimestamp(TimestampLeaseName timestampName);
 
     default ListenableFuture<Long> getFreshTimestampAsync() {
         return Futures.transform(

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/AsyncTimelockServiceImpl.java
@@ -24,6 +24,8 @@ import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsRequest;
 import com.palantir.atlasdb.timelock.api.ConjureStartTransactionsResponse;
 import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.LockWatchRequest;
+import com.palantir.atlasdb.timelock.api.TimestampLeaseName;
+import com.palantir.atlasdb.timelock.api.TimestampLeaseResponse;
 import com.palantir.atlasdb.timelock.lock.AsyncLockService;
 import com.palantir.atlasdb.timelock.lock.AsyncResult;
 import com.palantir.atlasdb.timelock.lock.Leased;
@@ -249,6 +251,19 @@ public class AsyncTimelockServiceImpl implements AsyncTimelockService {
     @Override
     public ListenableFuture<TimestampRange> getFreshTimestampsAsync(int timestampsToRequest) {
         return Futures.immediateFuture(getFreshTimestamps(timestampsToRequest));
+    }
+
+    @Override
+    public ListenableFuture<TimestampLeaseResponse> acquireTimestampLease(
+            TimestampLeaseName timestampName, UUID requestId, int numFreshTimestamps) {
+        // TODO(aalouane): implement this method
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ListenableFuture<Long> getMinLeasedTimestamp(TimestampLeaseName timestampName) {
+        // TODO(aalouane): implement this method
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override

--- a/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
+++ b/timelock-impl/src/main/java/com/palantir/atlasdb/timelock/batch/MultiClientConjureTimelockResource.java
@@ -40,6 +40,10 @@ import com.palantir.atlasdb.timelock.api.GetCommitTimestampsResponse;
 import com.palantir.atlasdb.timelock.api.LeaderTimes;
 import com.palantir.atlasdb.timelock.api.MultiClientConjureTimelockService;
 import com.palantir.atlasdb.timelock.api.MultiClientConjureTimelockServiceEndpoints;
+import com.palantir.atlasdb.timelock.api.MultiClientGetMinLeasedTimestampRequest;
+import com.palantir.atlasdb.timelock.api.MultiClientGetMinLeasedTimestampResponse;
+import com.palantir.atlasdb.timelock.api.MultiClientTimestampLeaseRequest;
+import com.palantir.atlasdb.timelock.api.MultiClientTimestampLeaseResponse;
 import com.palantir.atlasdb.timelock.api.Namespace;
 import com.palantir.atlasdb.timelock.api.UndertowMultiClientConjureTimelockService;
 import com.palantir.conjure.java.undertow.lib.RequestContext;
@@ -144,6 +148,20 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
                         requests.entrySet(), e -> unlockForSingleNamespace(e.getKey(), e.getValue(), context))),
                 ImmutableMap::copyOf,
                 MoreExecutors.directExecutor()));
+    }
+
+    @Override
+    public ListenableFuture<MultiClientTimestampLeaseResponse> acquireTimestampLease(
+            AuthHeader authHeader, MultiClientTimestampLeaseRequest requests, @Nullable RequestContext context) {
+        // TODO(aalouane): implement
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ListenableFuture<MultiClientGetMinLeasedTimestampResponse> getMinLeasedTimestamp(
+            AuthHeader authHeader, MultiClientGetMinLeasedTimestampRequest requests, @Nullable RequestContext context) {
+        // TODO(aalouane): implement
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     private ListenableFuture<Entry<Namespace, ConjureUnlockResponseV2>> unlockForSingleNamespace(
@@ -262,6 +280,18 @@ public final class MultiClientConjureTimelockResource implements UndertowMultiCl
         public Map<Namespace, ConjureUnlockResponseV2> unlock(
                 AuthHeader authHeader, Map<Namespace, ConjureUnlockRequestV2> requests) {
             return unwrap(resource.unlock(authHeader, requests, null));
+        }
+
+        @Override
+        public MultiClientTimestampLeaseResponse acquireTimestampLease(
+                AuthHeader authHeader, MultiClientTimestampLeaseRequest requests) {
+            return unwrap(resource.acquireTimestampLease(authHeader, requests, null));
+        }
+
+        @Override
+        public MultiClientGetMinLeasedTimestampResponse getMinLeasedTimestamp(
+                AuthHeader authHeader, MultiClientGetMinLeasedTimestampRequest requests) {
+            return unwrap(resource.getMinLeasedTimestamp(authHeader, requests, null));
         }
 
         private static <T> T unwrap(ListenableFuture<T> future) {


### PR DESCRIPTION
Defines the server API like https://github.com/palantir/atlasdb/pull/7327 but better.

Specifically, the difference is that instead of having the following:

Endpoints taking: namespace, timstampName and request
Endpoints taking: a batch of (namespace, timestampName, request) requests
We replace it with:

Endpoints taking: namespace and a batch of (timstampName and request)
Endpoints taking: a batch of (namespace, timestampName, request) requests
This matches better the expected client (AtlasDB internal) usage which will be one of two:

If you use the meta internal service, you use the cross-client batcher and so you will use the latter
If you are any other service using AtlasDB, you use a batcher just for you and so you will use the former
This is the setup that allows the autobatcher to have a single RPC to process events (modulo trying to get more timestamps).