### PR TITLE
Make cache proxy exception handling more robust

### DIFF
--- a/atlasdb-impl-shared/build.gradle
+++ b/atlasdb-impl-shared/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
   implementation 'com.github.ben-manes.caffeine:caffeine'
   implementation 'com.palantir.common:streams'
+  implementation 'com.palantir.conjure.java.api:errors'
   implementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
   implementation 'com.palantir.safe-logging:safe-logging'
   implementation 'com.palantir.safe-logging:preconditions'

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
@@ -83,7 +83,7 @@ public final class ResilientLockWatchProxy<T> extends AbstractInvocationHandler 
     private synchronized RuntimeException handleException(InvocationTargetException rethrow) {
         try {
             throw rethrow.getCause();
-        } catch (TransactionLockWatchFailedException | QosException | CancellationException | Error e) {
+        } catch (TransactionLockWatchFailedException | QosException | CancellationException e) {
             throw e;
         } catch (Throwable t) {
             if (delegate == fallbackCache) {

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/keyvalue/api/ResilientLockWatchProxy.java
@@ -20,6 +20,7 @@ import com.google.common.reflect.AbstractInvocationHandler;
 import com.palantir.atlasdb.keyvalue.api.cache.CacheMetrics;
 import com.palantir.atlasdb.keyvalue.api.cache.LockWatchValueScopingCache;
 import com.palantir.atlasdb.transaction.api.TransactionLockWatchFailedException;
+import com.palantir.conjure.java.api.errors.QosException;
 import com.palantir.lock.watch.LockWatchEventCache;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
@@ -28,6 +29,7 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.concurrent.CancellationException;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
@@ -81,7 +83,7 @@ public final class ResilientLockWatchProxy<T> extends AbstractInvocationHandler 
     private synchronized RuntimeException handleException(InvocationTargetException rethrow) {
         try {
             throw rethrow.getCause();
-        } catch (TransactionLockWatchFailedException e) {
+        } catch (TransactionLockWatchFailedException | QosException | CancellationException | Error e) {
             throw e;
         } catch (Throwable t) {
             if (delegate == fallbackCache) {


### PR DESCRIPTION
AtlasDB doesn't wrap its operation with some 'loader' exception concept, so really we may end up needing to catch a lot of exception types here eventually.