### PR TITLE
Refactor LockManager.

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -423,6 +423,17 @@ acceptedBreaks:
       new: "method void com.palantir.atlasdb.keyvalue.api.InsufficientConsistencyException::<init>(java.lang.String,\
         \ java.lang.Throwable, com.palantir.logsafe.Arg<?>[])"
       justification: "I have fixed all the implementations and it is not used externally"
+  "0.1168.0":
+    com.palantir.atlasdb:atlasdb-api:
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void com.palantir.atlasdb.transaction.api.precommit.PreCommitRequirementValidator::throwIfImmutableTsOrCommitLocksExpired(com.palantir.lock.v2.LockToken)"
+      new: "method void com.palantir.atlasdb.transaction.api.precommit.PreCommitRequirementValidator::throwIfImmutableTsOrCommitLocksExpired()"
+      justification: "Internal APIs"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void com.palantir.atlasdb.transaction.api.precommit.PreCommitRequirementValidator::throwIfPreCommitRequirementsNotMet(com.palantir.lock.v2.LockToken,\
+        \ long)"
+      new: "method void com.palantir.atlasdb.transaction.api.precommit.PreCommitRequirementValidator::throwIfPreCommitRequirementsNotMet(long)"
+      justification: "Internal APIs"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/precommit/PreCommitRequirementValidator.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/precommit/PreCommitRequirementValidator.java
@@ -19,9 +19,7 @@ package com.palantir.atlasdb.transaction.api.precommit;
 import com.palantir.atlasdb.keyvalue.api.Cell;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.transaction.api.TransactionFailedException;
-import com.palantir.lock.v2.LockToken;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 public interface PreCommitRequirementValidator {
     /**
@@ -41,10 +39,10 @@ public interface PreCommitRequirementValidator {
      * user pre-commit condition is no longer valid, or possibly because of other internal state such as commit
      * locks having expired.
      */
-    void throwIfPreCommitRequirementsNotMet(@Nullable LockToken commitLocksToken, long timestamp);
+    void throwIfPreCommitRequirementsNotMet(long timestamp);
 
     /**
      * Throws a {@link TransactionFailedException} if the immutable timestamp lock or commit locks have expired.
      */
-    void throwIfImmutableTsOrCommitLocksExpired(@Nullable LockToken commitLocksToken);
+    void throwIfImmutableTsOrCommitLocksExpired();
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/precommit/DefaultReadSnapshotValidator.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/precommit/DefaultReadSnapshotValidator.java
@@ -44,7 +44,7 @@ public final class DefaultReadSnapshotValidator implements ReadSnapshotValidator
     public ValidationState throwIfPreCommitRequirementsNotMetOnRead(
             TableReference tableRef, long timestamp, boolean allPossibleCellsReadAndPresent) {
         if (isValidationNecessaryOnReads(tableRef, allPossibleCellsReadAndPresent)) {
-            preCommitRequirementValidator.throwIfPreCommitRequirementsNotMet(null, timestamp);
+            preCommitRequirementValidator.throwIfPreCommitRequirementsNotMet(timestamp);
             return ValidationState.COMPLETELY_VALIDATED;
         }
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/precommit/DefaultReadSnapshotValidatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/transaction/impl/precommit/DefaultReadSnapshotValidatorTest.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.transaction.impl.precommit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -129,7 +128,7 @@ public final class DefaultReadSnapshotValidatorTest {
 
         assertThat(readSnapshotValidator.throwIfPreCommitRequirementsNotMetOnRead(testTable, TIMESTAMP, false))
                 .isEqualTo(ValidationState.NOT_COMPLETELY_VALIDATED);
-        verify(preCommitRequirementValidator, never()).throwIfPreCommitRequirementsNotMet(any(), anyLong());
+        verify(preCommitRequirementValidator, never()).throwIfPreCommitRequirementsNotMet(anyLong());
     }
 
     @MethodSource("testTables")
@@ -146,21 +145,21 @@ public final class DefaultReadSnapshotValidatorTest {
 
         assertThat(readSnapshotValidator.throwIfPreCommitRequirementsNotMetOnRead(testTable, TIMESTAMP, true))
                 .isEqualTo(ValidationState.COMPLETELY_VALIDATED);
-        verify(preCommitRequirementValidator, never()).throwIfPreCommitRequirementsNotMet(any(), anyLong());
+        verify(preCommitRequirementValidator, never()).throwIfPreCommitRequirementsNotMet(anyLong());
     }
 
     @Test
     public void incompleteReadsOnConservativeTablesDoNotRequireValidationOnReadByDefault() {
         assertThat(readSnapshotValidator.throwIfPreCommitRequirementsNotMetOnRead(CONSERVATIVE_TABLE, TIMESTAMP, false))
                 .isEqualTo(ValidationState.NOT_COMPLETELY_VALIDATED);
-        verify(preCommitRequirementValidator, never()).throwIfPreCommitRequirementsNotMet(any(), anyLong());
+        verify(preCommitRequirementValidator, never()).throwIfPreCommitRequirementsNotMet(anyLong());
     }
 
     @Test
     public void incompleteReadsOnThoroughTablesRequireValidationOnReadByDefault() {
         assertThat(readSnapshotValidator.throwIfPreCommitRequirementsNotMetOnRead(THOROUGH_TABLE, TIMESTAMP, false))
                 .isEqualTo(ValidationState.COMPLETELY_VALIDATED);
-        verify(preCommitRequirementValidator).throwIfPreCommitRequirementsNotMet(any(), anyLong());
+        verify(preCommitRequirementValidator).throwIfPreCommitRequirementsNotMet(anyLong());
     }
 
     @MethodSource("testTables")
@@ -168,7 +167,7 @@ public final class DefaultReadSnapshotValidatorTest {
     public void completeReadsAreCompletelyValidatedAndDoNotRequireValidationOnReadByDefault(TableReference testTable) {
         assertThat(readSnapshotValidator.throwIfPreCommitRequirementsNotMetOnRead(testTable, TIMESTAMP, true))
                 .isEqualTo(ValidationState.COMPLETELY_VALIDATED);
-        verify(preCommitRequirementValidator, never()).throwIfPreCommitRequirementsNotMet(any(), anyLong());
+        verify(preCommitRequirementValidator, never()).throwIfPreCommitRequirementsNotMet(anyLong());
     }
 
     private static Stream<TableReference> testTables() {

--- a/changelog/@unreleased/pr-7352.v2.yml
+++ b/changelog/@unreleased/pr-7352.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refactor LockManager.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7352


### PR DESCRIPTION
## General
**Before this PR**:
We don't have a way of explicitly tracking the ownership of locks that are acquired as part of running a transaction. This small component is a central point for registering cleanup actions that release the locks and re-uses the closer.

We should eventually expose this capability to e.g. advisory locks to cleanup this flow. AND it feels like this is a solution to my concerns in https://github.com/palantir/atlasdb/pull/7322 around the immutable timestamp lock being released and cleaned up separately from all the other locks. We would simply register the immutable timestamp lock with the LockManager and it would be cleaned up as everything else. #callbacks-rule

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Refactor LockManager.
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:
*** I am touching a pretty foundational part of the protocol, we should make sure we checked all of the possible interactions and codepaths.

*** In the case of Serializable transaction read-write checks, how is the lockmanager constructed: should that have the commit locks carried over? do we ever actually check locks?

No, we do not pass the current set of locks and in fact we pass ```Optional.empty()``` for immutable timestamp lock. So this codepath is equivalent.

*** Could we ever unlock the immutable timestamp twice somehow?

When creating a SnapshotTransaction in SerializableTransaction, we pass ```Optional.empty(),``` for the immutable timestamp lock. So we won't unlock it twice this way.

*** Would it be a problem if we unlocked locks twice?

Should not be a problem: In the case of AsyncUnlocker, we simply remove it from the list of locks to refresh, and if it's not there it's a noop. And in general unlock on an already unlocked token is just noop. 

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
Yes, I am breaking some internal APIs.

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
Nope.

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes.

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
Nope.

**Does this PR need a schema migration?**
Nope.

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
I think my PR is aligning us to a world where SnapshotTransaction has more and more callbacks to drive the various parts of it's behavior.

**What was existing testing like? What have you done to improve it?**:
* Existing test found that I was unnecessarily calling #tryUnlock on a read-only transaction (that does not have an immutable timestamp lock, seemingly).
* I added some small tests for the closing behavior.

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
* I believe it's correct. I just took the big swing and synchronized everything, as right now we just need it to be thread safe, we don't expect any contention.
* I also made sure I take copies of the collections before calling other APIs.

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
* Yes this PR involves changing how we track locks acquired in the context of a transaction. As such, I cleaned up the lock cleanup flow to centralize it in the transaction-scoped Closer.

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
