### PR TITLE
[ASTS] New SweepableBucketRetriever

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSweepableBucketRetriever.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSweepableBucketRetriever.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts;
+
+import com.palantir.atlasdb.sweep.asts.bucketingthings.SweepBucketPointerTable;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.SweepBucketsTable;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.table.description.SweeperStrategy;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class DefaultSweepableBucketRetriever implements SweepableBucketRetriever {
+    private final Set<ShardAndStrategy> shardsAndStrategies;
+    private final SweepBucketPointerTable sweepBucketPointerTable;
+    private final SweepBucketsTable sweepBucketsTable;
+
+    private DefaultSweepableBucketRetriever(
+            Set<ShardAndStrategy> shardsAndStrategies,
+            SweepBucketPointerTable sweepBucketPointerTable,
+            SweepBucketsTable sweepBucketsTable) {
+        this.shardsAndStrategies = shardsAndStrategies;
+        this.sweepBucketPointerTable = sweepBucketPointerTable;
+        this.sweepBucketsTable = sweepBucketsTable;
+    }
+
+    public static SweepableBucketRetriever create(
+            int numberOfShards,
+            List<SweeperStrategy> strategies,
+            SweepBucketPointerTable sweepBucketPointerTable,
+            SweepBucketsTable sweepBucketsTable) {
+        Set<ShardAndStrategy> shardsAndStrategies = IntStream.range(0, numberOfShards)
+                .boxed()
+                .flatMap(shard -> strategies.stream().map(strategy -> ShardAndStrategy.of(shard, strategy)))
+                .collect(Collectors.toSet());
+        return new DefaultSweepableBucketRetriever(shardsAndStrategies, sweepBucketPointerTable, sweepBucketsTable);
+    }
+
+    @Override
+    public Set<SweepableBucket> getSweepableBuckets() {
+        if (shardsAndStrategies.isEmpty()) {
+            return Set.of();
+        }
+        Set<Bucket> startingBuckets = sweepBucketPointerTable.getStartingBucketsForShards(shardsAndStrategies);
+        return sweepBucketsTable.getSweepableBuckets(startingBuckets);
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultSweepableBucketRetrieverTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/DefaultSweepableBucketRetrieverTest.java
@@ -1,0 +1,107 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.asts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.palantir.atlasdb.sweep.asts.bucketingthings.SweepBucketPointerTable;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.SweepBucketsTable;
+import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
+import com.palantir.atlasdb.table.description.SweeperStrategy;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.immutables.value.Value;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public final class DefaultSweepableBucketRetrieverTest {
+    @Mock
+    SweepBucketPointerTable bucketPointerTable;
+
+    @Mock
+    SweepBucketsTable bucketsTable;
+
+    @ParameterizedTest
+    @MethodSource("numShardsAndStrategies")
+    public void getSweepableBucketsRetrievesSweepableBucketsForAllShardsAndStrategiesRequested(TestContext context) {
+        Bucket bucket = Bucket.of(ShardAndStrategy.of(1, SweeperStrategy.CONSERVATIVE), 1);
+        SweepableBucket sweepableBucket = SweepableBucket.of(bucket, TimestampRange.of(1, 2));
+
+        when(bucketPointerTable.getStartingBucketsForShards(context.shardsAndStrategies()))
+                .thenReturn(Set.of(bucket));
+        when(bucketsTable.getSweepableBuckets(Set.of(bucket))).thenReturn(Set.of(sweepableBucket));
+
+        SweepableBucketRetriever retriever = DefaultSweepableBucketRetriever.create(
+                context.numShards(), context.strategies(), bucketPointerTable, bucketsTable);
+
+        // Assumes the context calculation for shards and strategies has the same result as the
+        // SweepableBucketRetriever.
+        assertThat(retriever.getSweepableBuckets()).containsExactly(sweepableBucket);
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyShardAndStrategies")
+    public void getSweepableBucketsReturnsEmptyIfShardsAndStrategiesEmpty(TestContext context) {
+        assertThat(context.shardsAndStrategies()).isEmpty();
+
+        SweepableBucketRetriever retriever = DefaultSweepableBucketRetriever.create(
+                context.numShards(), context.strategies(), bucketPointerTable, bucketsTable);
+
+        assertThat(retriever.getSweepableBuckets()).isEmpty();
+        verifyNoInteractions(bucketPointerTable, bucketsTable);
+    }
+
+    private static Stream<TestContext> numShardsAndStrategies() {
+        return Stream.of(
+                TestContext.of(1, List.of(SweeperStrategy.CONSERVATIVE)),
+                TestContext.of(256, List.of(SweeperStrategy.CONSERVATIVE, SweeperStrategy.THOROUGH)));
+    }
+
+    private static Stream<TestContext> emptyShardAndStrategies() {
+        return Stream.of(TestContext.of(0, List.of(SweeperStrategy.CONSERVATIVE)), TestContext.of(256, List.of()));
+    }
+
+    @Value.Immutable
+    public interface TestContext {
+        @Value.Parameter
+        int numShards();
+
+        @Value.Parameter
+        List<SweeperStrategy> strategies();
+
+        @Value.Derived
+        default Set<ShardAndStrategy> shardsAndStrategies() {
+            return IntStream.range(0, numShards())
+                    .boxed()
+                    .flatMap(shard -> strategies().stream().map(strategy -> ShardAndStrategy.of(shard, strategy)))
+                    .collect(Collectors.toSet());
+        }
+
+        static TestContext of(int numShards, List<SweeperStrategy> strategies) {
+            return ImmutableTestContext.of(numShards, strategies);
+        }
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
The old ShardedSweepableBucketRetriever works off the old fine partition mechanism. As we moved to a bucket world, this is no longer applicable
**After this PR**:

A new retriever using buckets.
A future PR will remove the unused code.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
N/A
**Is documentation needed?**:
N/a
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
N/A
**What was existing testing like? What have you done to improve it?**:
Added test
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No, bucket loading is limited to 2 row reads
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
If 200 buckets every 2 minutes l is insufficient to keep up (200 buckets = 2000 minutes = 33 hours worth of data)
## Development Process
**Where should we start reviewing?**:
The main class
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
