### PR TITLE
[ASTS] Targeted Sweeper Part 5: Separating the queue from the sweeper

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/DelegatingMultiTableSweepQueueWriter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/DelegatingMultiTableSweepQueueWriter.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import com.palantir.async.initializer.Callback;
+import com.palantir.atlasdb.keyvalue.api.Cell;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.table.description.SweeperStrategy;
+import com.palantir.atlasdb.transaction.api.TransactionManager;
+import com.palantir.exception.NotInitializedException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class DelegatingMultiTableSweepQueueWriter implements MultiTableSweepQueueWriter {
+    private final Future<MultiTableSweepQueueWriter> delegate;
+
+    public DelegatingMultiTableSweepQueueWriter(Future<MultiTableSweepQueueWriter> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void enqueue(Map<TableReference, ? extends Map<Cell, byte[]>> writes, long timestamp) {
+        delegate().enqueue(writes, timestamp);
+    }
+
+    @Override
+    public void enqueue(List<WriteInfo> writes) {
+        delegate().enqueue(writes);
+    }
+
+    @Override
+    public void initialize(TransactionManager txManager) {
+        delegate().initialize(txManager);
+    }
+
+    @Override
+    public void onInitializationFailureCleanup(TransactionManager resource, Throwable initFailure) {
+        delegate().onInitializationFailureCleanup(resource, initFailure);
+    }
+
+    @Override
+    public Callback<TransactionManager> singleAttemptCallback() {
+        return delegate().singleAttemptCallback();
+    }
+
+    @Override
+    public Callback<TransactionManager> retryUnlessCleanupThrowsCallback() {
+        return delegate().retryUnlessCleanupThrowsCallback();
+    }
+
+    @Override
+    public List<WriteInfo> toWriteInfos(Map<TableReference, ? extends Map<Cell, byte[]>> writes, long timestamp) {
+        return delegate().toWriteInfos(writes, timestamp);
+    }
+
+    @Override
+    public void close() {
+        delegate().close();
+    }
+
+    @Override
+    public SweeperStrategy getSweepStrategy(TableReference tableReference) {
+        return delegate().getSweepStrategy(tableReference);
+    }
+
+    private MultiTableSweepQueueWriter delegate() {
+        try {
+            return delegate.get(0, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException | TimeoutException | RuntimeException t) {
+            throw new NotInitializedException(DelegatingMultiTableSweepQueueWriter.class.getSimpleName(), t);
+        } catch (InterruptedException t) {
+            Thread.currentThread().interrupt();
+            throw new NotInitializedException(DelegatingMultiTableSweepQueueWriter.class.getSimpleName(), t);
+        }
+    }
+}

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/DelegatingMultiTableSweepQueueWriterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/DelegatingMultiTableSweepQueueWriterTest.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.util.concurrent.SettableFuture;
+import com.palantir.exception.NotInitializedException;
+import com.palantir.logsafe.SafeArg;
+import org.junit.jupiter.api.Test;
+
+public final class DelegatingMultiTableSweepQueueWriterTest {
+    private final SettableFuture<MultiTableSweepQueueWriter> delegate = SettableFuture.create();
+    private final DelegatingMultiTableSweepQueueWriter writer = new DelegatingMultiTableSweepQueueWriter(delegate);
+
+    @Test
+    public void methodFailsWithNotInitializedExceptionIfDelegateNotSet() {
+        assertThatLoggableExceptionThrownBy(() -> writer.enqueue(null))
+                .isInstanceOf(NotInitializedException.class)
+                .hasExactlyArgs(SafeArg.of("objectName", DelegatingMultiTableSweepQueueWriter.class.getSimpleName()));
+    }
+
+    @Test
+    public void methodFailsWithNotInitializedExceptionWithCauseIfDelegateFailed() {
+        Throwable cause = new RuntimeException();
+        delegate.setException(cause);
+        assertThatLoggableExceptionThrownBy(() -> writer.enqueue(null))
+                .isInstanceOf(NotInitializedException.class)
+                .hasExactlyArgs(SafeArg.of("objectName", DelegatingMultiTableSweepQueueWriter.class.getSimpleName()))
+                .hasRootCause(cause);
+    }
+
+    @Test
+    public void methodDelegatesToUnderlyingOnceSet() {
+        MultiTableSweepQueueWriter delegateWriter = mock(MultiTableSweepQueueWriter.class);
+        delegate.set(delegateWriter);
+
+        writer.enqueue(null, 0L);
+        verify(delegateWriter).enqueue(null, 0L);
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
See the previous 4 parts. The goal of this PR is to enable a refactor in a subsequent PR to not use TargetedSweeper as the  queue itself, but for TargetedSweeper to simply initialise a queue that was passed in from elsewhere, using a similar pattern that has been used elsewhere internally

**After this PR**:
A delegating writer, in the same style as the existing AsyncInitializable ( :( )  dependent classes 
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P2 
**Concerns / possible downsides (what feedback would you like?)**:
N/A - unless you want it wired in this PR.
**Is documentation needed?**:
N/A
## Compatibility
N/A

## Testing and Correctness
Added tests
## Execution
Not wired

## Scale
No change
## Development Process
**Where should we start reviewing?**:
SweepQueueWriter
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
