### PR TITLE
[ASTS] Targeted Sweeper Part 6: Split out the SweepQueueFactory

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKvsSerializableTransactionTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/AbstractCassandraKvsSerializableTransactionTest.java
@@ -21,12 +21,16 @@ import com.palantir.atlasdb.AtlasDbConstants;
 import com.palantir.atlasdb.containers.CassandraResource;
 import com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics;
 import com.palantir.atlasdb.sweep.queue.MultiTableSweepQueueWriter;
+import com.palantir.atlasdb.sweep.queue.NumberOfShardsProvider.MismatchBehaviour;
 import com.palantir.atlasdb.sweep.queue.SweepQueue;
 import com.palantir.atlasdb.sweep.queue.SweepQueueReader;
+import com.palantir.atlasdb.sweep.queue.TargetedSweepFollower;
 import com.palantir.atlasdb.sweep.queue.TargetedSweeper;
 import com.palantir.atlasdb.transaction.api.Transaction;
+import com.palantir.atlasdb.transaction.api.TransactionManager;
 import com.palantir.atlasdb.transaction.impl.AbstractSerializableTransactionTest;
 import com.palantir.atlasdb.transaction.impl.TransactionSchemaVersionEnforcement;
+import java.util.List;
 import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -69,7 +73,10 @@ public abstract class AbstractCassandraKvsSerializableTransactionTest extends Ab
                 keyValueService,
                 timelockService,
                 () -> 128,
-                SweepQueueReader.DEFAULT_READ_BATCHING_RUNTIME_CONTEXT);
+                SweepQueueReader.DEFAULT_READ_BATCHING_RUNTIME_CONTEXT,
+                // TODO(mdaudali): This will almost certainly change once we deprecate sweep queue.
+                new TargetedSweepFollower(List.of(), mock(TransactionManager.class)),
+                MismatchBehaviour.UPDATE);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueue.java
@@ -18,21 +18,15 @@ package com.palantir.atlasdb.sweep.queue;
 import com.palantir.atlasdb.keyvalue.api.KeyValueService;
 import com.palantir.atlasdb.keyvalue.api.TableReference;
 import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.LogSafety;
-import com.palantir.atlasdb.schema.TargetedSweepSchema;
 import com.palantir.atlasdb.schema.generated.TargetedSweepTableFactory;
 import com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics;
 import com.palantir.atlasdb.sweep.queue.NumberOfShardsProvider.MismatchBehaviour;
 import com.palantir.atlasdb.sweep.queue.SweepQueueReader.ReadBatchingRuntimeContext;
-import com.palantir.atlasdb.sweep.queue.clear.DefaultTableClearer;
-import com.palantir.atlasdb.table.description.Schemas;
 import com.palantir.atlasdb.table.description.SweeperStrategy;
-import com.palantir.atlasdb.transaction.impl.TimelockTimestampServiceAdapter;
 import com.palantir.atlasdb.transaction.service.TransactionService;
-import com.palantir.atlasdb.transaction.service.TransactionServices;
 import com.palantir.lock.v2.TimelockService;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,22 +43,22 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
     private final SweepProgressResetter resetter;
 
     private SweepQueue(
-            SweepQueueFactory factory,
-            TargetedSweepFollower follower,
+            SweepQueueComponents components,
+            KeyValueService keyValueService,
+            TargetedSweepMetrics metrics,
             AbandonedTransactionConsumer abandonedTransactionConsumer) {
-        this.progress = factory.progress;
-        this.writer = factory.createWriter();
-        this.numShardsProvider = NumberOfShardsProvider.createMemoizingProvider(
-                progress, factory.numShards, MismatchBehaviour.UPDATE, Duration.ofMillis(SweepQueueUtils.REFRESH_TIME));
+        this.progress = components.shardProgress();
+        this.writer = components.writer();
+        this.numShardsProvider = components.numberOfShardsProvider();
         this.sweeper = new DefaultSingleBatchSweeper(
-                factory.metrics,
+                metrics,
                 progress,
                 abandonedTransactionConsumer,
-                factory.createReader(),
-                factory.createDeleter(follower),
-                factory.createCleaner());
+                components.reader(),
+                components.deleter(),
+                components.cleaner());
         this.resetter = new DefaultSweepProgressResetter(
-                factory.kvs,
+                keyValueService,
                 // TODO(mdaudali): Don't do this hackery - we'll likely move things around when the sweep queue dies
                 TargetedSweepTableFactory.of().getSweepBucketProgressTable(null).getTableRef(),
                 TargetedSweepTableFactory.of()
@@ -84,22 +78,40 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
             TargetedSweepFollower follower,
             ReadBatchingRuntimeContext readBatchingRuntimeContext,
             Function<TableReference, Optional<LogSafety>> tablesToTrackDeletions) {
-        SweepQueueFactory factory = SweepQueueFactory.create(
-                metrics, kvs, timelock, shardsConfig, transaction, readBatchingRuntimeContext, tablesToTrackDeletions);
-        return new SweepQueue(factory, follower, abortedTransactionConsumer);
+        SweepQueueComponents components = SweepQueueComponents.create(
+                metrics,
+                kvs,
+                timelock,
+                shardsConfig,
+                transaction,
+                readBatchingRuntimeContext,
+                tablesToTrackDeletions,
+                follower,
+                MismatchBehaviour.UPDATE);
+        return new SweepQueue(components, kvs, metrics, abortedTransactionConsumer);
     }
 
     /**
      * Creates a SweepQueueWriter, performing all the necessary initialization.
+     * Only used in tests (TODO(mdaudali): this will be removed soon.)
      */
     public static MultiTableSweepQueueWriter createWriter(
             TargetedSweepMetrics metrics,
             KeyValueService kvs,
             TimelockService timelock,
             Supplier<Integer> shardsConfig,
-            ReadBatchingRuntimeContext readBatchingRuntimeContext) {
-        return SweepQueueFactory.create(metrics, kvs, timelock, shardsConfig, readBatchingRuntimeContext)
-                .createWriter();
+            ReadBatchingRuntimeContext readBatchingRuntimeContext,
+            TargetedSweepFollower follower,
+            MismatchBehaviour mismatchBehaviourForShards) {
+        return SweepQueueComponents.create(
+                        metrics,
+                        kvs,
+                        timelock,
+                        shardsConfig,
+                        readBatchingRuntimeContext,
+                        follower,
+                        mismatchBehaviourForShards)
+                .writer();
     }
 
     @Override
@@ -126,112 +138,5 @@ public final class SweepQueue implements MultiTableSweepQueueWriter {
 
     public Map<ShardAndStrategy, Long> getLastSweptTimestamps(Set<ShardAndStrategy> shardAndStrategies) {
         return progress.getLastSweptTimestamps(shardAndStrategies);
-    }
-
-    public static final class SweepQueueFactory {
-        private final ShardProgress progress;
-        private final Supplier<Integer> numShards;
-        private final SweepableCells cells;
-        private final SweepableTimestamps timestamps;
-        private final WriteInfoPartitioner partitioner;
-        private final TargetedSweepMetrics metrics;
-        private final KeyValueService kvs;
-        private final TimelockService timelock;
-        private final ReadBatchingRuntimeContext readBatchingRuntimeContext;
-        private final Function<TableReference, Optional<LogSafety>> tablesToTrackDeletions;
-
-        private SweepQueueFactory(
-                ShardProgress progress,
-                Supplier<Integer> numShards,
-                SweepableCells cells,
-                SweepableTimestamps timestamps,
-                WriteInfoPartitioner partitioner,
-                TargetedSweepMetrics metrics,
-                KeyValueService kvs,
-                TimelockService timelock,
-                ReadBatchingRuntimeContext readBatchingRuntimeContext,
-                Function<TableReference, Optional<LogSafety>> tablesToTrackDeletions) {
-            this.progress = progress;
-            this.numShards = numShards;
-            this.cells = cells;
-            this.timestamps = timestamps;
-            this.partitioner = partitioner;
-            this.metrics = metrics;
-            this.kvs = kvs;
-            this.timelock = timelock;
-            this.readBatchingRuntimeContext = readBatchingRuntimeContext;
-            this.tablesToTrackDeletions = tablesToTrackDeletions;
-        }
-
-        static SweepQueueFactory create(
-                TargetedSweepMetrics metrics,
-                KeyValueService kvs,
-                TimelockService timelock,
-                Supplier<Integer> shardsConfig,
-                ReadBatchingRuntimeContext readBatchingRuntimeContext) {
-            // It is OK that the transaction service is different from the one used by the transaction manager,
-            // as transaction services must not hold any local state in them that would affect correctness.
-            TransactionService transaction =
-                    TransactionServices.createRaw(kvs, new TimelockTimestampServiceAdapter(timelock), false);
-            return create(
-                    metrics,
-                    kvs,
-                    timelock,
-                    shardsConfig,
-                    transaction,
-                    readBatchingRuntimeContext,
-                    _unused -> Optional.empty());
-        }
-
-        static SweepQueueFactory create(
-                TargetedSweepMetrics metrics,
-                KeyValueService kvs,
-                TimelockService timelock,
-                Supplier<Integer> shardsConfig,
-                TransactionService transaction,
-                ReadBatchingRuntimeContext readBatchingRuntimeContext,
-                Function<TableReference, Optional<LogSafety>> tablesToTrackDeletions) {
-            Schemas.createTablesAndIndexes(TargetedSweepSchema.INSTANCE.getLatestSchema(), kvs);
-            ShardProgress shardProgress = new ShardProgress(kvs);
-            Supplier<Integer> shards = NumberOfShardsProvider.createMemoizingProvider(
-                    shardProgress,
-                    shardsConfig,
-                    MismatchBehaviour.UPDATE,
-                    Duration.ofMillis(SweepQueueUtils.REFRESH_TIME))::getNumberOfShards;
-            WriteInfoPartitioner partitioner = new WriteInfoPartitioner(kvs, shards);
-            SweepableCells cells = new SweepableCells(kvs, partitioner, metrics, transaction);
-            SweepableTimestamps timestamps = new SweepableTimestamps(kvs, partitioner);
-            return new SweepQueueFactory(
-                    shardProgress,
-                    shards,
-                    cells,
-                    timestamps,
-                    partitioner,
-                    metrics,
-                    kvs,
-                    timelock,
-                    readBatchingRuntimeContext,
-                    tablesToTrackDeletions);
-        }
-
-        private SweepQueueWriter createWriter() {
-            return new SweepQueueWriter(timestamps, cells, partitioner);
-        }
-
-        private SweepQueueReader createReader() {
-            return new SweepQueueReader(timestamps, cells, readBatchingRuntimeContext);
-        }
-
-        private SweepQueueDeleter createDeleter(TargetedSweepFollower follower) {
-            return new SweepQueueDeleter(
-                    kvs,
-                    follower,
-                    new DefaultTableClearer(kvs, timelock::getImmutableTimestamp),
-                    tablesToTrackDeletions);
-        }
-
-        private SweepQueueCleaner createCleaner() {
-            return new SweepQueueCleaner(cells, timestamps, progress);
-        }
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueComponents.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepQueueComponents.java
@@ -1,0 +1,119 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.sweep.queue;
+
+import com.palantir.atlasdb.keyvalue.api.KeyValueService;
+import com.palantir.atlasdb.keyvalue.api.TableReference;
+import com.palantir.atlasdb.protos.generated.TableMetadataPersistence.LogSafety;
+import com.palantir.atlasdb.schema.TargetedSweepSchema;
+import com.palantir.atlasdb.sweep.metrics.TargetedSweepMetrics;
+import com.palantir.atlasdb.sweep.queue.NumberOfShardsProvider.MismatchBehaviour;
+import com.palantir.atlasdb.sweep.queue.SweepQueueReader.ReadBatchingRuntimeContext;
+import com.palantir.atlasdb.sweep.queue.clear.DefaultTableClearer;
+import com.palantir.atlasdb.table.description.Schemas;
+import com.palantir.atlasdb.transaction.impl.TimelockTimestampServiceAdapter;
+import com.palantir.atlasdb.transaction.service.TransactionService;
+import com.palantir.atlasdb.transaction.service.TransactionServices;
+import com.palantir.lock.v2.TimelockService;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface SweepQueueComponents {
+    SweepQueueReader reader();
+
+    SweepQueueWriter writer();
+
+    SweepQueueDeleter deleter();
+
+    SweepQueueCleaner cleaner();
+
+    ShardProgress shardProgress();
+
+    SweepableCells sweepableCells();
+
+    SweepableTimestamps sweepableTimestamps();
+
+    NumberOfShardsProvider numberOfShardsProvider();
+
+    static SweepQueueComponents create(
+            TargetedSweepMetrics metrics,
+            KeyValueService kvs,
+            TimelockService timelock,
+            Supplier<Integer> shardsConfig,
+            ReadBatchingRuntimeContext readBatchingRuntimeContext,
+            TargetedSweepFollower follower,
+            MismatchBehaviour mismatchBehaviourForShards) {
+        // It is OK that the transaction service is different from the one used by the transaction manager,
+        // as transaction services must not hold any local state in them that would affect correctness.
+        TransactionService transaction =
+                TransactionServices.createRaw(kvs, new TimelockTimestampServiceAdapter(timelock), false);
+        return create(
+                metrics,
+                kvs,
+                timelock,
+                shardsConfig,
+                transaction,
+                readBatchingRuntimeContext,
+                _unused -> Optional.empty(),
+                follower,
+                mismatchBehaviourForShards);
+    }
+
+    static SweepQueueComponents create(
+            TargetedSweepMetrics metrics,
+            KeyValueService kvs,
+            TimelockService timelock,
+            Supplier<Integer> shardsConfig,
+            TransactionService transaction,
+            ReadBatchingRuntimeContext readBatchingRuntimeContext,
+            Function<TableReference, Optional<LogSafety>> tablesToTrackDeletions,
+            TargetedSweepFollower follower,
+            MismatchBehaviour mismatchBehaviourForShards) {
+        Schemas.createTablesAndIndexes(TargetedSweepSchema.INSTANCE.getLatestSchema(), kvs);
+        ShardProgress shardProgress = new ShardProgress(kvs);
+
+        NumberOfShardsProvider numberOfShardsProvider = NumberOfShardsProvider.createMemoizingProvider(
+                shardProgress,
+                shardsConfig,
+                mismatchBehaviourForShards,
+                Duration.ofMillis(SweepQueueUtils.REFRESH_TIME));
+
+        WriteInfoPartitioner partitioner = new WriteInfoPartitioner(kvs, numberOfShardsProvider::getNumberOfShards);
+        SweepableCells cells = new SweepableCells(kvs, partitioner, metrics, transaction);
+        SweepableTimestamps timestamps = new SweepableTimestamps(kvs, partitioner);
+
+        SweepQueueReader reader = new SweepQueueReader(timestamps, cells, readBatchingRuntimeContext);
+        SweepQueueWriter writer = new SweepQueueWriter(timestamps, cells, partitioner);
+        SweepQueueDeleter deleter = new SweepQueueDeleter(
+                kvs, follower, new DefaultTableClearer(kvs, timelock::getImmutableTimestamp), tablesToTrackDeletions);
+        SweepQueueCleaner cleaner = new SweepQueueCleaner(cells, timestamps, shardProgress);
+        return ImmutableSweepQueueComponents.builder()
+                .reader(reader)
+                .writer(writer)
+                .deleter(deleter)
+                .cleaner(cleaner)
+                .shardProgress(shardProgress)
+                .sweepableCells(cells)
+                .sweepableTimestamps(timestamps)
+                .numberOfShardsProvider(numberOfShardsProvider)
+                .build();
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
The SweepQueueFactory is coupled to the SweepQueue, which is going to be removed shortly. Moreover, we need access to the individual components for ASTS.


**After this PR**:
Splits out the SweepQueueFactory.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
This moves from constructing the individual pieces on demand to constructing all the components when the factory is initialised.  I did this because all the places that currently use it (and will use it) just construct the factory and then the individual pieces immediately later. Open to going back to lazily loading.

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
See concerns
**What was existing testing like? What have you done to improve it?**:
Uses existing tests
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
Should be no visible change

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A

## Development Process
**Where should we start reviewing?**:
SweepQueueComponents
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
