### PR TITLE
[ASTS] no timestamp record throws NoSuchElementException

### DIFF
--- a/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraDefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-cassandra-integration-tests/src/test/java/com/palantir/atlasdb/keyvalue/cassandra/CassandraDefaultSweepAssignedBucketStoreTest.java
@@ -17,10 +17,10 @@
 package com.palantir.atlasdb.keyvalue.cassandra;
 
 import com.palantir.atlasdb.containers.CassandraResource;
-import com.palantir.atlasdb.sweep.asts.progress.AbstractDefaultBucketProgressStoreTest;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.AbstractDefaultSweepAssignedBucketStoreTest;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CassandraDefaultSweepAssignedBucketStoreTest extends AbstractDefaultBucketProgressStoreTest {
+public class CassandraDefaultSweepAssignedBucketStoreTest extends AbstractDefaultSweepAssignedBucketStoreTest {
     @RegisterExtension
     public static final CassandraResource CASSANDRA = new CassandraResource();
 

--- a/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresDefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-dbkvs-tests/src/test/java/com/palantir/atlasdb/keyvalue/dbkvs/impl/postgres/DbKvsPostgresDefaultSweepAssignedBucketStoreTest.java
@@ -17,12 +17,12 @@
 package com.palantir.atlasdb.keyvalue.dbkvs.impl.postgres;
 
 import com.palantir.atlasdb.keyvalue.impl.TestResourceManager;
-import com.palantir.atlasdb.sweep.asts.progress.AbstractDefaultBucketProgressStoreTest;
+import com.palantir.atlasdb.sweep.asts.bucketingthings.AbstractDefaultSweepAssignedBucketStoreTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 @ExtendWith(DbKvsPostgresExtension.class)
-public class DbKvsPostgresDefaultSweepAssignedBucketStoreTest extends AbstractDefaultBucketProgressStoreTest {
+public class DbKvsPostgresDefaultSweepAssignedBucketStoreTest extends AbstractDefaultSweepAssignedBucketStoreTest {
     @RegisterExtension
     public static final TestResourceManager TRM = new TestResourceManager(DbKvsPostgresExtension::createKvs);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
@@ -38,6 +38,7 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -229,9 +230,7 @@ final class DefaultSweepAssignedBucketStore
     public TimestampRange getTimestampRangeRecord(long bucketIdentifier) {
         Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketRecordsCell(bucketIdentifier);
         return readCell(cell, timestampRangePersister::tryDeserialize)
-                .orElseThrow(() -> new SafeIllegalStateException(
-                        "No timestamp range record found for bucket identifier",
-                        SafeArg.of("bucketIdentifier", bucketIdentifier)));
+                .orElseThrow(() -> new NoSuchElementException("No timestamp range record found for bucket identifier"));
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketRecordsTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketRecordsTable.java
@@ -20,7 +20,8 @@ import com.palantir.atlasdb.sweep.asts.TimestampRange;
 
 public interface SweepBucketRecordsTable {
     /**
-     * Returns the {@link TimestampRange} for the given bucket identifier, throwing if one is not present.
+     * Returns the {@link TimestampRange} for the given bucket identifier, throwing a
+     * {@link java.util.NoSuchElementException} if one is not present.
      */
     TimestampRange getTimestampRangeRecord(long bucketIdentifier);
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/AbstractDefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/AbstractDefaultSweepAssignedBucketStoreTest.java
@@ -34,10 +34,10 @@ import com.palantir.atlasdb.sweep.asts.TimestampRange;
 import com.palantir.atlasdb.sweep.queue.ShardAndStrategy;
 import com.palantir.atlasdb.table.description.Schemas;
 import com.palantir.atlasdb.table.description.SweeperStrategy;
-import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -285,10 +285,9 @@ public abstract class AbstractDefaultSweepAssignedBucketStoreTest {
 
     @Test
     public void getTimestampRangeRecordThrowsIfRecordNotPresent() {
-        assertThatLoggableExceptionThrownBy(() -> store.getTimestampRangeRecord(1))
-                .isInstanceOf(SafeIllegalStateException.class)
-                .hasLogMessage("No timestamp range record found for bucket identifier")
-                .hasExactlyArgs(SafeArg.of("bucketIdentifier", 1L));
+        assertThatThrownBy(() -> store.getTimestampRangeRecord(1))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("No timestamp range record found for bucket identifier");
     }
 
     @Test
@@ -320,9 +319,8 @@ public abstract class AbstractDefaultSweepAssignedBucketStoreTest {
         assertThat(store.getTimestampRangeRecord(1)).isEqualTo(timestampRange);
 
         store.deleteTimestampRangeRecord(1);
-        assertThatLoggableExceptionThrownBy(() -> store.getTimestampRangeRecord(1))
-                .isInstanceOf(SafeIllegalStateException.class)
-                .hasLogMessage("No timestamp range record found for bucket identifier")
-                .hasExactlyArgs(SafeArg.of("bucketIdentifier", 1L));
+        assertThatThrownBy(() -> store.getTimestampRangeRecord(1))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("No timestamp range record found for bucket identifier");
     }
 }


### PR DESCRIPTION
## General
**Before this PR**:
Getting a timestamp record for a bucket identifier that doesn't exist throws a SafeIllegalStateException
**After this PR**:
Now throws a NoSuchElementException - Also fixes a silly bug in test execution.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
Do double check the tests are executing...
**Is documentation needed?**:
No
## Compatibility
N/A

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
Tests were broken
**What was existing testing like? What have you done to improve it?**:
Fixed and updated them

## Execution
N/A

## Scale
N/A
## Development Process
**Where should we start reviewing?**:
[DefaultSweepAssignedBucketStore.java](https://github.com/palantir/atlasdb/compare/mdaudali/10-18-_asts_no_timestamp_record_throws_nosuchelementexception?expand=1#diff-c88c8e49278492489c6fe69fab206cdea86ed9df8d8988eb358e572817957f5f)
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
