### PR TITLE
[ASTS] Add puncherstore as argument to targeted sweeper

### DIFF
--- a/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
+++ b/atlasdb-dagger/src/main/java/com/palantir/atlasdb/services/TransactionManagerModule.java
@@ -19,9 +19,12 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.palantir.atlasdb.cache.DefaultTimestampCache;
 import com.palantir.atlasdb.cell.api.DataKeyValueServiceManager;
+import com.palantir.atlasdb.cleaner.CachingPuncherStore;
 import com.palantir.atlasdb.cleaner.CleanupFollower;
 import com.palantir.atlasdb.cleaner.DefaultCleanerBuilder;
 import com.palantir.atlasdb.cleaner.Follower;
+import com.palantir.atlasdb.cleaner.KeyValueServicePuncherStore;
+import com.palantir.atlasdb.cleaner.PuncherStore;
 import com.palantir.atlasdb.cleaner.api.Cleaner;
 import com.palantir.atlasdb.config.AtlasDbConfig;
 import com.palantir.atlasdb.config.AtlasDbRuntimeConfig;
@@ -87,7 +90,16 @@ public class TransactionManagerModule {
             TransactionService transactionService,
             MetricsManager metricsManager) {
         AtlasDbConfig atlasDbConfig = config.atlasDbConfig();
-        return new DefaultCleanerBuilder(kvs, timelock, ImmutableList.of(follower), transactionService, metricsManager)
+        PuncherStore keyValuePuncherStore = KeyValueServicePuncherStore.create(kvs, atlasDbConfig.initializeAsync());
+        PuncherStore cachingPuncherStore =
+                CachingPuncherStore.create(keyValuePuncherStore, atlasDbConfig.getPunchIntervalMillis() * 3);
+        return new DefaultCleanerBuilder(
+                        kvs,
+                        timelock,
+                        ImmutableList.of(follower),
+                        transactionService,
+                        metricsManager,
+                        cachingPuncherStore)
                 .setBackgroundScrubAggressively(atlasDbConfig.backgroundScrubAggressively())
                 .setBackgroundScrubBatchSize(atlasDbConfig.getBackgroundScrubBatchSize())
                 .setBackgroundScrubFrequencyMillis(atlasDbConfig.getBackgroundScrubFrequencyMillis())

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/cleaner/DefaultCleanerBuilder.java
@@ -38,6 +38,7 @@ public class DefaultCleanerBuilder {
     private final List<Follower> followerList;
     private final TransactionService transactionService;
     private final MetricsManager metricsManager;
+    private final PuncherStore puncherStore;
 
     private long transactionReadTimeout = AtlasDbConstants.DEFAULT_TRANSACTION_READ_TIMEOUT;
     private long punchIntervalMillis = AtlasDbConstants.DEFAULT_PUNCH_INTERVAL_MILLIS;
@@ -53,12 +54,14 @@ public class DefaultCleanerBuilder {
             TimelockService timelockService,
             List<? extends Follower> followerList,
             TransactionService transactionService,
-            MetricsManager metricsManager) {
+            MetricsManager metricsManager,
+            PuncherStore puncherStore) {
         this.keyValueService = keyValueService;
         this.timelockService = timelockService;
         this.followerList = ImmutableList.copyOf(followerList);
         this.transactionService = transactionService;
         this.metricsManager = metricsManager;
+        this.puncherStore = puncherStore;
     }
 
     public DefaultCleanerBuilder setTransactionReadTimeout(long transactionReadTimeout) {

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweeperTest.java
@@ -167,7 +167,8 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
                 ImmutableList.of(),
                 _unused -> {},
                 spiedKvs,
-                SettableFuture.create());
+                SettableFuture.create(),
+                puncherStore);
         secondQueue.initializeWithoutRunning(
                 timestampsSupplier,
                 timelockService,
@@ -204,7 +205,8 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
                 ImmutableList.of(),
                 _unused -> {},
                 spiedKvs,
-                SettableFuture.create());
+                SettableFuture.create(),
+                puncherStore);
         secondQueue.initializeWithoutRunning(
                 timestampsSupplier,
                 mock(TimelockService.class),
@@ -1297,7 +1299,8 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
                 ImmutableList.of(),
                 _unused -> {},
                 spiedKvs,
-                initialisableWriter);
+                initialisableWriter,
+                puncherStore);
         sweepQueue = new DelegatingMultiTableSweepQueueWriter(initialisableWriter);
 
         mockFollower = mock(TargetedSweepFollower.class);
@@ -1547,7 +1550,8 @@ public class TargetedSweeperTest extends AbstractSweepQueueTest {
                     ImmutableList.of(),
                     _unused -> {},
                     spiedKvs,
-                    SettableFuture.create());
+                    SettableFuture.create(),
+                    puncherStore);
             sweeperInstance.initializeWithoutRunning(
                     timestampsSupplier, stickyLockService, spiedKvs, txnService, mockFollower);
             sweeperInstance.runInBackground();


### PR DESCRIPTION
## General
**Before this PR**:
We don't have access to puncher store, but we need this for the bucketing. It's hidden behind cleaner, so this pulls it out.
**After this PR**:
PuncherStore is now wired into TargetedSweeper.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
I don't believe I care that puncher store might not be initialised by the time we start bucketing - since we can handle failures.

**Is documentation needed?**:

## Compatibility
N/A

## Testing and Correctness
No change
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
No change
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Break change
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
N/A
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
Rollback
## Scale
No change
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
