### PR TITLE
[ASTS] Wiring up ASTS to be enabled

### DIFF
--- a/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
+++ b/atlasdb-cli/src/test/java/com/palantir/atlasdb/cli/command/KeyValueServiceMigratorsTest.java
@@ -59,6 +59,7 @@ import com.palantir.atlasdb.transaction.service.TransactionService;
 import com.palantir.atlasdb.transaction.service.TransactionServices;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
+import com.palantir.refreshable.Refreshable;
 import com.palantir.timelock.paxos.InMemoryTimelockExtension;
 import com.palantir.timestamp.ManagedTimestampService;
 import java.util.Map;
@@ -363,7 +364,8 @@ public class KeyValueServiceMigratorsTest {
         when(mockServices.getTransactionService()).thenReturn(transactionService);
         when(mockServices.getKeyValueService()).thenReturn(kvs);
         SettableFuture<MultiTableSweepQueueWriter> initialisableWriter = SettableFuture.create();
-        TargetedSweeper sweeper = TargetedSweeper.createUninitializedForTest(kvs, () -> 1, initialisableWriter);
+        TargetedSweeper sweeper =
+                TargetedSweeper.createUninitializedForTest(kvs, Refreshable.only(1), initialisableWriter);
         SerializableTransactionManager txManager = SerializableTransactionManager.createForTest(
                 metricsManager,
                 new DelegatingDataKeyValueServiceManager(kvs),

--- a/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
+++ b/atlasdb-config/src/main/java/com/palantir/atlasdb/factory/TransactionManagers.java
@@ -1070,7 +1070,7 @@ public abstract class TransactionManagers {
             MetricsManager metricsManager,
             TargetedSweepInstallConfig install,
             Follower follower,
-            Supplier<TargetedSweepRuntimeConfig> runtime,
+            Refreshable<TargetedSweepRuntimeConfig> runtime,
             CoordinationService<InternalSchemaMetadata> coordinationService,
             SettableFuture<MultiTableSweepQueueWriter> initialisableWriter,
             PuncherStore puncherStore) {

--- a/atlasdb-ete-tests/build.gradle
+++ b/atlasdb-ete-tests/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.apache.commons:commons-text'
     implementation 'io.dropwizard:dropwizard-jackson'
     implementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
+    implementation 'com.palantir.refreshable:refreshable'
 
     implementation project(':atlasdb-api')
     implementation project(':atlasdb-client')
@@ -207,4 +208,3 @@ distribution {
     args 'server', 'var/conf/atlasdb-ete.yml'
     defaultJvmOpts '-Xmx768M'
 }
-

--- a/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
+++ b/atlasdb-ete-tests/src/main/java/com/palantir/atlasdb/AtlasDbEteServer.java
@@ -62,6 +62,7 @@ import com.palantir.conjure.java.server.jersey.ConjureJerseyFeature;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.refreshable.Refreshable;
 import com.palantir.tritium.metrics.registry.SharedTaggedMetricRegistries;
 import com.palantir.tritium.metrics.registry.TaggedMetricRegistry;
 import io.dropwizard.Application;
@@ -106,7 +107,7 @@ public class AtlasDbEteServer extends Application<AtlasDbEteConfiguration> {
         Supplier<SweepTaskRunner> sweepTaskRunner = Suppliers.memoize(() -> getSweepTaskRunner(txManager));
         SettableFuture<MultiTableSweepQueueWriter> initialisableWriter = SettableFuture.create();
         TargetedSweeper sweeper = TargetedSweeper.createUninitializedForTest(
-                txManager.getKeyValueService(), () -> 1, initialisableWriter);
+                txManager.getKeyValueService(), Refreshable.only(1), initialisableWriter);
         Supplier<TargetedSweeper> sweeperSupplier = Suppliers.memoize(() -> initializeAndGet(sweeper, txManager));
         Supplier<SingleBatchSweeper> singleBatchSweeper = Suppliers.memoize(() -> {
             SweepQueueComponents components = sweeperSupplier.get().components();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/DefaultSweepProgressResetter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/DefaultSweepProgressResetter.java
@@ -22,6 +22,7 @@ import com.palantir.atlasdb.table.description.SweeperStrategy;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.util.Collection;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -47,7 +48,7 @@ public class DefaultSweepProgressResetter implements SweepProgressResetter {
     }
 
     @Override
-    public void resetProgress(Set<SweeperStrategy> strategies) {
+    public void resetProgress(Collection<SweeperStrategy> strategies) {
         log.info("Truncating bucket progress and sweep bucket assigned tables as part of resetting sweep progress");
         keyValueService.truncateTables(Set.of(bucketProgressTable, sweepBucketAssignedTable));
         int shards = numberOfShardsSupplier.get();

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/NumberOfShardsProvider.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/NumberOfShardsProvider.java
@@ -43,16 +43,10 @@ public interface NumberOfShardsProvider {
     private static int getNumberOfShards(
             ShardProgress progress, Supplier<Integer> shards, MismatchBehaviour mismatchBehaviour) {
         switch (mismatchBehaviour) {
-            case THROW:
-                int shardsFromSupplier = shards.get();
-                int shardsFromProgress = progress.getNumberOfShards();
-                if (shardsFromSupplier != shardsFromProgress) {
-                    throw new SafeIllegalStateException(
-                            "Number of shards from supplier and progress do not match",
-                            SafeArg.of("shardsFromSupplier", shardsFromSupplier),
-                            SafeArg.of("shardsFromProgress", shardsFromProgress));
-                }
-                return shardsFromSupplier;
+            case IGNORE_UPDATES:
+                // Here, we will never update the number of shards from config. This is because the ASTS work requires
+                // knowing the number of shards at all time from the beginning of install, and changing is quite painful
+                return progress.getNumberOfShards();
             case UPDATE:
                 return progress.updateNumberOfShards(shards.get());
             default:
@@ -83,7 +77,7 @@ public interface NumberOfShardsProvider {
     }
 
     enum MismatchBehaviour {
-        THROW,
+        IGNORE_UPDATES,
         UPDATE,
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepProgressResetter.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/queue/SweepProgressResetter.java
@@ -17,7 +17,7 @@
 package com.palantir.atlasdb.sweep.queue;
 
 import com.palantir.atlasdb.table.description.SweeperStrategy;
-import java.util.Set;
+import java.util.Collection;
 
 public interface SweepProgressResetter {
     /**
@@ -25,5 +25,5 @@ public interface SweepProgressResetter {
      * an HA configuration, then the reset is only guaranteed to be complete after this has executed across all nodes
      * of your service.
      */
-    void resetProgress(Set<SweeperStrategy> strategies);
+    void resetProgress(Collection<SweeperStrategy> strategies);
 }

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/AbstractTargetedSweepTest.java
@@ -44,6 +44,7 @@ import com.palantir.atlasdb.table.description.TableMetadata;
 import com.palantir.atlasdb.util.MetricsManager;
 import com.palantir.atlasdb.util.MetricsManagers;
 import com.palantir.lock.v2.TimelockService;
+import com.palantir.refreshable.Refreshable;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -72,10 +73,10 @@ public class AbstractTargetedSweepTest extends AbstractSweepTest {
         targetedSweeper = TargetedSweeper.createUninitializedForTest(
                 kvs,
                 metricsManager,
-                () -> ImmutableTargetedSweepRuntimeConfig.builder()
+                Refreshable.create(ImmutableTargetedSweepRuntimeConfig.builder()
                         .shards(1)
                         .maximumPartitionsToBatchInSingleRead(8)
-                        .build(),
+                        .build()),
                 initialisableWriter);
         targetedSweeper.initializeWithoutRunning(
                 timestampsSupplier, mock(TimelockService.class), kvs, txService, mock(TargetedSweepFollower.class));

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/SweepTestUtils.java
@@ -45,6 +45,7 @@ import com.palantir.lock.LockServerOptions;
 import com.palantir.lock.LockService;
 import com.palantir.lock.impl.LockServiceImpl;
 import com.palantir.lock.v2.TimelockService;
+import com.palantir.refreshable.Refreshable;
 import com.palantir.timelock.paxos.AbstractInMemoryTimelockExtension;
 import com.palantir.timestamp.TimestampManagementService;
 import java.time.Duration;
@@ -78,7 +79,8 @@ public final class SweepTestUtils {
         ConflictDetectionManager cdm = ConflictDetectionManagers.createWithoutWarmingCache(kvs);
         Cleaner cleaner = new NoOpCleaner();
         SettableFuture<MultiTableSweepQueueWriter> initialisableWriter = SettableFuture.create();
-        TargetedSweeper sweeper = TargetedSweeper.createUninitializedForTest(kvs, () -> 1, initialisableWriter);
+        TargetedSweeper sweeper =
+                TargetedSweeper.createUninitializedForTest(kvs, Refreshable.only(1), initialisableWriter);
         TransactionKnowledgeComponents knowledge =
                 TransactionKnowledgeComponents.createForTests(kvs, metricsManager.getTaggedRegistry());
         TransactionManager txManager = SerializableTransactionManager.createForTest(

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/AtlasDbTestCase.java
@@ -60,6 +60,8 @@ import com.palantir.common.concurrent.PTExecutors;
 import com.palantir.lock.LockClient;
 import com.palantir.lock.LockService;
 import com.palantir.lock.v2.TimelockService;
+import com.palantir.refreshable.Refreshable;
+import com.palantir.refreshable.SettableRefreshable;
 import com.palantir.timelock.paxos.InMemoryTimelockExtension;
 import com.palantir.timestamp.TimestampService;
 import java.util.concurrent.ExecutorService;
@@ -87,7 +89,7 @@ public class AtlasDbTestCase {
     protected MultiTableSweepQueueWriter sweepQueue;
     protected SpecialTimestampsSupplier sweepTimestampSupplier;
     protected SingleBatchSweeper sweeper;
-    protected int sweepQueueShards = 128;
+    protected SettableRefreshable<Integer> sweepQueueShards = Refreshable.create(128);
 
     protected TransactionKnowledgeComponents knowledge;
 
@@ -114,8 +116,8 @@ public class AtlasDbTestCase {
 
         // Hackery - we don't want to set the initialisableWriter inside targetedSweeper - we want to create a spied
         // version instead
-        targetedSweep = TargetedSweeper.createUninitializedForTest(
-                keyValueService, () -> sweepQueueShards, SettableFuture.create());
+        targetedSweep =
+                TargetedSweeper.createUninitializedForTest(keyValueService, sweepQueueShards, SettableFuture.create());
         sweepQueue = new DelegatingMultiTableSweepQueueWriter(initialisableWriter);
         knowledge = TransactionKnowledgeComponents.createForTests(keyValueService, metricsManager.getTaggedRegistry());
         DeleteExecutor typedDeleteExecutor = new DefaultDeleteExecutor(keyValueService, deleteExecutor);

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweepTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/sweep/queue/TargetedSweepTest.java
@@ -288,7 +288,7 @@ public class TargetedSweepTest extends AtlasDbTestCase {
     }
 
     private void useOneSweepQueueShard() {
-        sweepQueueShards = 1;
+        sweepQueueShards.update(1);
     }
 
     private void assertOnlySentinelBeforeTs(TableReference tableRef, Cell cell, long ts) {


### PR DESCRIPTION
## General
**Before this PR**:
While we have all the general components, the current TargetedSweeper can only use the queue based system. This is because TargetedSweeper is not wired up to switch between the implementations

This is the final PR of Milestone 1 (70 PRs...)
**After this PR**:
TargetedSweeper now uses the underlying factory to switch between sweepers.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
TargetedSweeper can now be configured to use the new bucket based sweeper.
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
N/A
**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
Not at this point
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That the code works :D We'll be writing integration tests after for the last wiring, but everything else is pretty thoroughly tested
**What was existing testing like? What have you done to improve it?**:
Updated
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Can switch to ASTS, and the existing sweep continues to work
**Has the safety of all log arguments been decided correctly?**:
No change
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Sweep stops running, or you cannot switch to ASTS
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback - however, you'll likely have already moved to 128 shards if the service had less than this before, which is irreversible. This is generally fine.
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No more than what we've already planned around
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Not yet, but we're doing scaling
## Development Process
**Where should we start reviewing?**:
TargetedSweeper
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
