### PR TITLE
[Named min timestamp leases] Add timestamp lease acquirer

### DIFF
--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/TimestampLeaseResult.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/TimestampLeaseResult.java
@@ -30,4 +30,8 @@ public interface TimestampLeaseResult {
     static TimestampLeaseResult of(long minLeasedTimestamp, LongSupplier freshTimestampsSupplier) {
         return ImmutableTimestampLeaseResult.of(minLeasedTimestamp, freshTimestampsSupplier);
     }
+
+    static ImmutableTimestampLeaseResult.Builder builder() {
+        return ImmutableTimestampLeaseResult.builder();
+    }
 }

--- a/lock-api-objects/src/main/java/com/palantir/lock/v2/TimestampLeaseResults.java
+++ b/lock-api-objects/src/main/java/com/palantir/lock/v2/TimestampLeaseResults.java
@@ -31,4 +31,8 @@ public interface TimestampLeaseResults {
     static TimestampLeaseResults of(LockToken lock, Map<TimestampLeaseName, TimestampLeaseResult> results) {
         return ImmutableTimestampLeaseResults.of(lock, results);
     }
+
+    static ImmutableTimestampLeaseResults.Builder builder() {
+        return ImmutableTimestampLeaseResults.builder();
+    }
 }

--- a/lock-api/build.gradle
+++ b/lock-api/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'javax.ws.rs:javax.ws.rs-api'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.github.rholder:guava-retrying'
     implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation 'com.palantir.refreshable:refreshable'

--- a/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/LeasedLockToken.java
@@ -39,7 +39,7 @@ public final class LeasedLockToken implements LockToken {
     @GuardedBy("this")
     private boolean invalidated = false;
 
-    static LeasedLockToken of(ConjureLockToken serverToken, Lease lease) {
+    public static LeasedLockToken of(ConjureLockToken serverToken, Lease lease) {
         return new LeasedLockToken(serverToken, UniqueIds.pseudoRandomUuidV4(), lease);
     }
 
@@ -53,7 +53,7 @@ public final class LeasedLockToken implements LockToken {
         return serverToken;
     }
 
-    synchronized Lease getLease() {
+    public synchronized Lease getLease() {
         return lease;
     }
 

--- a/lock-api/src/main/java/com/palantir/lock/client/timestampleases/TimestampLeaseAcquirerImpl.java
+++ b/lock-api/src/main/java/com/palantir/lock/client/timestampleases/TimestampLeaseAcquirerImpl.java
@@ -16,28 +16,175 @@
 
 package com.palantir.lock.client.timestampleases;
 
+import com.github.rholder.retry.Attempt;
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
+import com.palantir.atlasdb.timelock.api.ConjureLockToken;
+import com.palantir.atlasdb.timelock.api.LeaseGuarantee;
+import com.palantir.atlasdb.timelock.api.LeaseIdentifier;
+import com.palantir.atlasdb.timelock.api.NamespaceTimestampLeaseRequest;
+import com.palantir.atlasdb.timelock.api.RequestId;
 import com.palantir.atlasdb.timelock.api.TimestampLeaseName;
-import com.palantir.lock.client.TimeLockUnlocker;
+import com.palantir.atlasdb.timelock.api.TimestampLeaseRequests;
+import com.palantir.atlasdb.timelock.api.TimestampLeaseResponse;
+import com.palantir.atlasdb.timelock.api.TimestampLeaseResponses;
+import com.palantir.common.exception.AtlasDbDependencyException;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.lock.ConjureTimestampRangeTimestampSupplier;
+import com.palantir.lock.LimitingLongSupplier;
+import com.palantir.lock.client.LeasedLockToken;
+import com.palantir.lock.v2.TimestampLeaseResult;
 import com.palantir.lock.v2.TimestampLeaseResults;
+import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import com.palantir.tritium.ids.UniqueIds;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 final class TimestampLeaseAcquirerImpl implements TimestampLeaseAcquirer {
-    private final NamespacedTimestampLeaseService delegate;
-    private final TimeLockUnlocker unlocker;
+    private static final SafeLogger log = SafeLoggerFactory.get(TimestampLeaseAcquirerImpl.class);
 
-    public TimestampLeaseAcquirerImpl(NamespacedTimestampLeaseService delegate, TimeLockUnlocker unlocker) {
+    private final NamespacedTimestampLeaseService delegate;
+    private final Unlocker unlocker;
+    private final Supplier<UUID> uuidSupplier;
+
+    private final Retryer<Optional<TimestampLeaseResponses>> retryer =
+            RetryerBuilder.<Optional<TimestampLeaseResponses>>newBuilder()
+                    .retryIfResult(Optional::isEmpty)
+                    .withStopStrategy(StopStrategies.stopAfterAttempt(3))
+                    .build();
+
+    @VisibleForTesting
+    TimestampLeaseAcquirerImpl(
+            NamespacedTimestampLeaseService delegate, Unlocker unlocker, Supplier<UUID> uuidSupplier) {
         this.delegate = delegate;
         this.unlocker = unlocker;
+        this.uuidSupplier = uuidSupplier;
+    }
+
+    public TimestampLeaseAcquirerImpl(NamespacedTimestampLeaseService delegate, Unlocker unlocker) {
+        this(delegate, unlocker, UniqueIds::pseudoRandomUuidV4);
     }
 
     @Override
     public TimestampLeaseResults acquireNamedTimestampLeases(Map<TimestampLeaseName, Integer> requests) {
-        // TODO(aalouane): implement
-        throw new UnsupportedOperationException("Not implemented yet");
+        TimestampLeaseResponses response = acquireLeasesWithRetry(requests);
+        try {
+            return TimestampLeaseResults.builder()
+                    .lock(createLeasedLockToken(response))
+                    .results(createTimestampLeaseResult(requests, response.getTimestampLeaseResponses()))
+                    .build();
+        } catch (RuntimeException | Error e) {
+            log.error("Unexpected exception while creating client results", e);
+            unlock(response);
+            throw e;
+        }
     }
 
     @Override
     public void close() {
         // TODO(aalouane): decide whether or not to close the unlocker depending on ownership
+    }
+
+    private TimestampLeaseResponses acquireLeasesWithRetry(Map<TimestampLeaseName, Integer> requests) {
+        try {
+            return retryer.call(() -> acquireLeases(requests)).orElseThrow();
+        } catch (ExecutionException e) {
+            // should not happen with how the retryer is set up
+            log.warn("Unexpected exception. Expected a retry exception", e);
+            throw new SafeRuntimeException(e);
+        } catch (RetryException e) {
+            Attempt<?> lastFailedAttempt = e.getLastFailedAttempt();
+            log.warn(
+                    "Exhausted retries to get enough timestamps while acquiring timestamp lease",
+                    SafeArg.of("requests", requests),
+                    SafeArg.of("numRetries", lastFailedAttempt.getAttemptNumber()),
+                    SafeArg.of("attemptHadException", lastFailedAttempt.hasException()),
+                    e);
+            throw new AtlasDbDependencyException(
+                    "Exhausted retries to get enough timestamps while acquiring timestamp lease",
+                    lastFailedAttempt.hasException() ? lastFailedAttempt.getExceptionCause() : null,
+                    SafeArg.of("requests", requests),
+                    SafeArg.of("numRetries", lastFailedAttempt.getAttemptNumber()),
+                    SafeArg.of(
+                            "maybeResult",
+                            lastFailedAttempt.hasResult() ? lastFailedAttempt.getResult() : Optional.empty()));
+        }
+    }
+
+    private Optional<TimestampLeaseResponses> acquireLeases(Map<TimestampLeaseName, Integer> requestedFreshTimestamps) {
+        // we prefer to use a new request id for non-dialogue-native dialogue attempts
+        TimestampLeaseRequests request =
+                TimestampLeaseRequests.of(RequestId.of(uuidSupplier.get()), requestedFreshTimestamps);
+        NamespaceTimestampLeaseRequest requests = NamespaceTimestampLeaseRequest.of(List.of(request));
+
+        TimestampLeaseResponses response = Iterables.getOnlyElement(
+                delegate.acquireTimestampLeases(requests).get());
+        Map<TimestampLeaseName, TimestampLeaseResponse> responseMap = response.getTimestampLeaseResponses();
+
+        Preconditions.checkArgument(
+                requestedFreshTimestamps.keySet().equals(responseMap.keySet()),
+                "Response lease timestamps need to match request timestamp names exactly");
+
+        boolean wasFullyFulfilled = requestedFreshTimestamps.keySet().stream().allMatch(timestampName -> {
+            int requestedTimestamps = requestedFreshTimestamps.get(timestampName);
+            long returnedTimestamps =
+                    responseMap.get(timestampName).getFreshTimestamps().getCount();
+            return returnedTimestamps >= requestedTimestamps;
+        });
+
+        if (!wasFullyFulfilled) {
+            unlock(response);
+            log.info(
+                    "Timestamp lease request was not fully fulfilled. This should happen infrequently.",
+                    SafeArg.of("requests", requests),
+                    SafeArg.of("responses", response));
+            return Optional.empty();
+        }
+
+        return Optional.of(response);
+    }
+
+    private void unlock(TimestampLeaseResponses responses) {
+        unlocker.unlock(responses.getLeaseGuarantee().getIdentifier());
+    }
+
+    private static Map<TimestampLeaseName, TimestampLeaseResult> createTimestampLeaseResult(
+            Map<TimestampLeaseName, Integer> requestedTimestamps,
+            Map<TimestampLeaseName, TimestampLeaseResponse> responses) {
+        return KeyedStream.stream(responses)
+                .<TimestampLeaseResult>map((timestampName, response) -> {
+                    int requestedForName = requestedTimestamps.get(timestampName);
+                    LongSupplier freshTimestamps = new LimitingLongSupplier(
+                            new ConjureTimestampRangeTimestampSupplier(response.getFreshTimestamps()),
+                            requestedForName);
+                    return TimestampLeaseResult.builder()
+                            .minLeasedTimestamp(response.getMinLeased())
+                            .freshTimestampsSupplier(freshTimestamps)
+                            .build();
+                })
+                .collectToMap();
+    }
+
+    private static LeasedLockToken createLeasedLockToken(TimestampLeaseResponses responses) {
+        LeaseGuarantee leaseGuarantee = responses.getLeaseGuarantee();
+        return LeasedLockToken.of(
+                ConjureLockToken.of(leaseGuarantee.getIdentifier().get()), leaseGuarantee.getLease());
+    }
+
+    interface Unlocker {
+        void unlock(LeaseIdentifier leaseGuarantee);
     }
 }

--- a/lock-api/src/test/java/com/palantir/lock/client/timestampleases/TimestampLeaseAcquirerImplTest.java
+++ b/lock-api/src/test/java/com/palantir/lock/client/timestampleases/TimestampLeaseAcquirerImplTest.java
@@ -1,0 +1,201 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.lock.client.timestampleases;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.palantir.atlasdb.timelock.api.ConjureLockToken;
+import com.palantir.atlasdb.timelock.api.ConjureTimestampRange;
+import com.palantir.atlasdb.timelock.api.LeaseGuarantee;
+import com.palantir.atlasdb.timelock.api.LeaseIdentifier;
+import com.palantir.atlasdb.timelock.api.NamespaceTimestampLeaseRequest;
+import com.palantir.atlasdb.timelock.api.NamespaceTimestampLeaseResponse;
+import com.palantir.atlasdb.timelock.api.RequestId;
+import com.palantir.atlasdb.timelock.api.TimestampLeaseName;
+import com.palantir.atlasdb.timelock.api.TimestampLeaseRequests;
+import com.palantir.atlasdb.timelock.api.TimestampLeaseResponse;
+import com.palantir.atlasdb.timelock.api.TimestampLeaseResponses;
+import com.palantir.common.exception.AtlasDbDependencyException;
+import com.palantir.common.streams.KeyedStream;
+import com.palantir.common.time.NanoTime;
+import com.palantir.lock.client.LeasedLockToken;
+import com.palantir.lock.client.timestampleases.TimestampLeaseAcquirerImpl.Unlocker;
+import com.palantir.lock.v2.LeaderTime;
+import com.palantir.lock.v2.LeadershipId;
+import com.palantir.lock.v2.Lease;
+import com.palantir.lock.v2.TimestampLeaseResults;
+import com.palantir.logsafe.SafeArg;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.OngoingStubbing;
+
+@ExtendWith(MockitoExtension.class)
+public final class TimestampLeaseAcquirerImplTest {
+    private static final TimestampLeaseName NAME_1 = TimestampLeaseName.of("name1");
+    private static final TimestampLeaseName NAME_2 = TimestampLeaseName.of("name2");
+
+    @Mock
+    private NamespacedTimestampLeaseService service;
+
+    @Mock
+    private Unlocker unlocker;
+
+    @Mock
+    private Supplier<UUID> uuidSupplier;
+
+    private TimestampLeaseAcquirer acquirer;
+
+    @BeforeEach
+    public void before() {
+        acquirer = new TimestampLeaseAcquirerImpl(service, unlocker, uuidSupplier);
+    }
+
+    @Test
+    public void returnsLeasedLockTokenWithMatchingLeaseAndServerTokenWhenNoRetryWithNoCleanup() {
+        UUID uuid = UUID.randomUUID();
+        Lease lease = createRandomLease();
+        Map<TimestampLeaseName, Integer> requested = Map.of(NAME_1, 10, NAME_2, 5);
+
+        when(uuidSupplier.get()).thenReturn(uuid).thenThrow(new RuntimeException("not expected to be invoked again"));
+        when(service.acquireTimestampLeases(createRequest(requested, uuid)))
+                .thenReturn(createResponseWithEnoughTimestamps(requested, uuid, lease));
+
+        TimestampLeaseResults results = acquirer.acquireNamedTimestampLeases(requested);
+
+        assertThat(results.lock()).isInstanceOf(LeasedLockToken.class);
+        LeasedLockToken asLeasedLockToken = (LeasedLockToken) results.lock();
+        assertThat(asLeasedLockToken.serverToken()).isEqualTo(ConjureLockToken.of(uuid));
+        assertThat(asLeasedLockToken.getLease()).isEqualTo(lease);
+        verifyNoInteractions(unlocker);
+    }
+
+    @ValueSource(ints = {1, 2})
+    @ParameterizedTest
+    public void succeedsWhenTimeLockOnlyReturnsEnoughTimestampsOnRetryAndCleansUpLocks(int numFailedRetries) {
+        List<UUID> uuidsForFailedRequests =
+                Stream.generate(UUID::randomUUID).limit(numFailedRetries).collect(Collectors.toList());
+        UUID uuidForSuccessfulRequest = UUID.randomUUID();
+        Lease leaseForSuccessfulRequest = createRandomLease();
+        Map<TimestampLeaseName, Integer> requested = Map.of(NAME_1, 10, NAME_2, 5);
+
+        stubUuidSupplier(uuidsForFailedRequests, uuidForSuccessfulRequest);
+        for (UUID uuidForFailedRequest : uuidsForFailedRequests) {
+            when(service.acquireTimestampLeases(createRequest(requested, uuidForFailedRequest)))
+                    .thenReturn(createResponseWithoutEnoughTimestamps(requested, uuidForFailedRequest));
+        }
+        when(service.acquireTimestampLeases(createRequest(requested, uuidForSuccessfulRequest)))
+                .thenReturn(createResponseWithEnoughTimestamps(
+                        requested, uuidForSuccessfulRequest, leaseForSuccessfulRequest));
+
+        TimestampLeaseResults results = acquirer.acquireNamedTimestampLeases(requested);
+
+        assertThat(results.lock()).isInstanceOf(LeasedLockToken.class);
+        LeasedLockToken asLeasedLockToken = (LeasedLockToken) results.lock();
+        assertThat(asLeasedLockToken.serverToken()).isEqualTo(ConjureLockToken.of(uuidForSuccessfulRequest));
+        assertThat(asLeasedLockToken.getLease()).isEqualTo(leaseForSuccessfulRequest);
+
+        for (UUID uuidForFailedRequest : uuidsForFailedRequests) {
+            verify(unlocker).unlock(LeaseIdentifier.of(uuidForFailedRequest));
+        }
+        verifyNoMoreInteractions(unlocker);
+    }
+
+    @Test
+    public void throwsAtlasDbDependencyExceptionWhenRetriesAreExhausted() {
+        int maxRetries = 3;
+        List<UUID> uuids = Stream.generate(UUID::randomUUID).limit(maxRetries).collect(Collectors.toList());
+        Map<TimestampLeaseName, Integer> requested = Map.of(NAME_1, 10, NAME_2, 5);
+
+        stubUuidSupplier(uuids);
+        for (UUID uuidForFailedRequest : uuids) {
+            when(service.acquireTimestampLeases(createRequest(requested, uuidForFailedRequest)))
+                    .thenReturn(createResponseWithoutEnoughTimestamps(requested, uuidForFailedRequest));
+        }
+
+        assertThatLoggableExceptionThrownBy(() -> acquirer.acquireNamedTimestampLeases(requested))
+                .isExactlyInstanceOf(AtlasDbDependencyException.class)
+                .containsArgs(SafeArg.of("requests", requested), SafeArg.of("numRetries", 3L));
+
+        for (UUID uuid : uuids) {
+            verify(unlocker).unlock(LeaseIdentifier.of(uuid));
+        }
+        verifyNoMoreInteractions(unlocker);
+    }
+
+    private void stubUuidSupplier(List<UUID> uuids, UUID... moreUuids) {
+        OngoingStubbing<UUID> stubbing = when(uuidSupplier.get());
+        for (UUID uuid : uuids) {
+            stubbing = stubbing.thenReturn(uuid);
+        }
+        for (UUID uuid : moreUuids) {
+            stubbing = stubbing.thenReturn(uuid);
+        }
+        stubbing.thenThrow(new RuntimeException("not expected to be invoked again"));
+    }
+
+    private static NamespaceTimestampLeaseRequest createRequest(Map<TimestampLeaseName, Integer> requested, UUID uuid) {
+        return NamespaceTimestampLeaseRequest.of(List.of(TimestampLeaseRequests.of(RequestId.of(uuid), requested)));
+    }
+
+    private static NamespaceTimestampLeaseResponse createResponseWithoutEnoughTimestamps(
+            Map<TimestampLeaseName, Integer> requestedMap, UUID uuid) {
+        LeaseGuarantee leaseGuarantee = LeaseGuarantee.of(LeaseIdentifier.of(uuid), createRandomLease());
+        int randomIndex = ThreadLocalRandom.current().nextInt(1, requestedMap.size());
+        TimestampLeaseName selectedNameForNotEnoughTimestamps =
+                requestedMap.keySet().stream().skip(randomIndex - 1).findFirst().orElseThrow();
+
+        Map<TimestampLeaseName, TimestampLeaseResponse> responses = KeyedStream.stream(requestedMap)
+                .map((name, requested) -> {
+                    int toFulfill = name.equals(selectedNameForNotEnoughTimestamps) ? requested - 1 : requested;
+                    return TimestampLeaseResponse.of(1, ConjureTimestampRange.of(1, toFulfill));
+                })
+                .collectToMap();
+
+        return NamespaceTimestampLeaseResponse.of(List.of(TimestampLeaseResponses.of(leaseGuarantee, responses)));
+    }
+
+    private static NamespaceTimestampLeaseResponse createResponseWithEnoughTimestamps(
+            Map<TimestampLeaseName, Integer> requestedMap, UUID uuid, Lease lease) {
+        return NamespaceTimestampLeaseResponse.of(List.of(TimestampLeaseResponses.of(
+                LeaseGuarantee.of(LeaseIdentifier.of(uuid), lease),
+                KeyedStream.stream(requestedMap)
+                        .map(requested -> TimestampLeaseResponse.of(1, ConjureTimestampRange.of(1, requested)))
+                        .collectToMap())));
+    }
+
+    private static Lease createRandomLease() {
+        return Lease.of(LeaderTime.of(LeadershipId.random(), NanoTime.now()), Duration.ofMinutes(1));
+    }
+}

--- a/timelock-api/src/main/conjure/timelock-api.yml
+++ b/timelock-api/src/main/conjure/timelock-api.yml
@@ -248,8 +248,7 @@ types:
            leaseGuarantee: LeaseGuarantee
            timestampLeaseResponses: map<TimestampLeaseName, TimestampLeaseResponse>
       NamespaceTimestampLeaseResponse:
-         fields:
-           alias: list<TimestampLeaseResponses>
+         alias: list<TimestampLeaseResponses>
       MultiClientTimestampLeaseResponse:
          alias: map<Namespace, NamespaceTimestampLeaseResponse>
       GetMinLeasedTimestampRequests:


### PR DESCRIPTION
## General
**Before this PR**:
We have no way to grab timestamp leases from the client
**After this PR**:
Add very-non-batched way to grab timestamp leases from the client
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P1
**Concerns / possible downsides (what feedback would you like?)**:
See PR comments:
- Design hinges on assumption of rare partial fills from timelock, will add metrics to track this later
- Batching may be added in the future, but deferred to when needed
- Unlocking will be done synchronously in a later PR, which is OK if ^^assumption holds. I actually think the unlocker we use can be made to expose something async anyway which would be amazing!
- Should we even be retrying here given the assumption, or should we be retrying more aggressively
**Is documentation needed?**:
Not yet, the whole work would need an ADR eventually I guess
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
See concerns on the design assumptions.
**What was existing testing like? What have you done to improve it?**:
Added coverage.
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
We unlock locks on retries and on some exceptions
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
N/A
**Has the safety of all log arguments been decided correctly?**:
Yes
**Will this change significantly affect our spending on metrics or logs?**:
No
**How would I tell that this PR does not work in production? (monitors, etc.)**:
No op
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Rollback
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Maybe, this goes to testing first
## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
