### PR TITLE
Refactor `OpenTransaction` interface

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -450,8 +450,40 @@ acceptedBreaks:
   "0.1184.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.method.addedToInterface"
+      new: "method void com.palantir.atlasdb.transaction.api.OpenTransaction::close()"
+      justification: "OpenTransaction has a single internal consumer, and it's current\
+        \ interface caused confusion in recent refactors"
+    - code: "java.method.addedToInterface"
       new: "method void com.palantir.atlasdb.transaction.api.Transaction::onCommitOrAbort(java.lang.Runnable)"
       justification: "similar to onSuccess, already used in other prod codepaths"
+    - code: "java.method.removed"
+      old: "method <T, E extends java.lang.Exception> T com.palantir.atlasdb.transaction.api.OpenTransaction::finish(com.palantir.atlasdb.transaction.api.TransactionTask<T,\
+        \ E>) throws E, com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException"
+      justification: "OpenTransaction has a single internal consumer, and it's current\
+        \ interface caused confusion in recent refactors"
+    - code: "java.method.removed"
+      old: "method <T, E extends java.lang.Exception> T com.palantir.atlasdb.transaction.api.OpenTransaction::finishWithCallback(com.palantir.atlasdb.transaction.api.TransactionTask<T,\
+        \ E>, java.lang.Runnable) throws E, com.palantir.atlasdb.transaction.api.TransactionFailedRetriableException"
+      justification: "OpenTransaction has a single internal consumer, and it's current\
+        \ interface caused confusion in recent refactors"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method java.util.List<com.palantir.atlasdb.transaction.api.OpenTransaction>\
+        \ com.palantir.atlasdb.transaction.api.AutoDelegate_TransactionManager::startTransactions(java.util.List<?\
+        \ extends com.palantir.atlasdb.transaction.api.PreCommitCondition>)"
+      new: "method java.util.List<? extends com.palantir.atlasdb.transaction.api.OpenTransaction>\
+        \ com.palantir.atlasdb.transaction.api.AutoDelegate_TransactionManager::startTransactions(java.util.List<?\
+        \ extends com.palantir.atlasdb.transaction.api.PreCommitCondition>)"
+      justification: "OpenTransaction has a single internal consumer, and it's current\
+        \ interface caused confusion in recent refactors"
+    - code: "java.method.returnTypeTypeParametersChanged"
+      old: "method java.util.List<com.palantir.atlasdb.transaction.api.OpenTransaction>\
+        \ com.palantir.atlasdb.transaction.api.TransactionManager::startTransactions(java.util.List<?\
+        \ extends com.palantir.atlasdb.transaction.api.PreCommitCondition>)"
+      new: "method java.util.List<? extends com.palantir.atlasdb.transaction.api.OpenTransaction>\
+        \ com.palantir.atlasdb.transaction.api.TransactionManager::startTransactions(java.util.List<?\
+        \ extends com.palantir.atlasdb.transaction.api.PreCommitCondition>)"
+      justification: "OpenTransaction has a single internal consumer, and it's current\
+        \ interface caused confusion in recent refactors"
   "0.770.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.class.removed"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -450,6 +450,10 @@ acceptedBreaks:
   "0.1184.0":
     com.palantir.atlasdb:atlasdb-api:
     - code: "java.method.addedToInterface"
+      new: "method boolean com.palantir.atlasdb.transaction.api.Transaction::isDefinitivelyCommitted()"
+      justification: "adding a new method to confirm if a transaction successfully\
+        \ committed from the atlas perspective"
+    - code: "java.method.addedToInterface"
       new: "method void com.palantir.atlasdb.transaction.api.OpenTransaction::close()"
       justification: "OpenTransaction has a single internal consumer, and it's current\
         \ interface caused confusion in recent refactors"

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/OpenTransaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/OpenTransaction.java
@@ -16,27 +16,13 @@
 
 package com.palantir.atlasdb.transaction.api;
 
-import com.palantir.atlasdb.metrics.Timed;
+import java.io.Closeable;
 
-public interface OpenTransaction extends Transaction {
-
+public interface OpenTransaction extends Transaction, Closeable {
     /**
-     * Runs a provided task, commits the transaction, and performs cleanup. If no further work needs to be done with the
-     * transaction, a no-op task can be passed in.
-     *
-     * @return value returned by the task
+     * Aborts the transaction if uncommitted and cleanups transaction state.
+     * All open transactions <b>must be closed</b>.
      */
-    @Timed
-    <T, E extends Exception> T finish(TransactionTask<T, E> task) throws E, TransactionFailedRetriableException;
-
-    /**
-     * Like {@link #finish(TransactionTask)}, except runs a callback after the task has finished. This callback will
-     * not run while the transaction remains in an uncommitted state, but may run afterwards, regardless of whether
-     * the commit was successful, finished, or aborted.
-     *
-     * If the callback is run, it will run before any {@link Transaction#onSuccess(Runnable)} callbacks.
-     */
-    @Timed
-    <T, E extends Exception> T finishWithCallback(TransactionTask<T, E> task, Runnable callback)
-            throws E, TransactionFailedRetriableException;
+    @Override
+    void close();
 }

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/OpenTransaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/OpenTransaction.java
@@ -22,6 +22,7 @@ public interface OpenTransaction extends Transaction, Closeable {
     /**
      * Aborts the transaction if uncommitted and cleanups transaction state.
      * All open transactions <b>must be closed</b>.
+     * Not closing transactions after they're no longer in use may lead to arbitrary delays elsewhere in the system.
      */
     @Override
     void close();

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -406,13 +406,23 @@ public interface Transaction {
     boolean isAborted();
 
     /**
-     * Gets whether the transaction has not been committed.
+     * Gets whether the transaction has not been committed nor aborted.
      *
      * @return <code>true</code> if neither <code>commit()</code> or <code>abort()</code> have been called,
      *         otherwise <code>false</code>
      */
     @Idempotent
     boolean isUncommitted();
+
+    /**
+     * Gets whether the transaction been committed. Note that it's possible for the underlying KVS to have committed
+     * the transaction but {@link #isDefinitivelyCommitted()} to return false (e.g. when the KVS call timed out
+     * client-side but succeeded server-side).
+     *
+     * @return <code>true</code> <code>commit()</code> has been called and did not throw, otherwise <code>false</code>.
+     */
+    @Idempotent
+    boolean isDefinitivelyCommitted();
 
     /**
      * Gets the timestamp the current transaction is running at.

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/Transaction.java
@@ -453,6 +453,10 @@ public interface Transaction {
     /**
      * Allow consumers to register callbacks to be run on {@link #commit()} or {@link #abort()},
      * after a transaction has committed or aborted.
+     * <p>
+     * {@link #onCommitOrAbort(Runnable)} callbacks are added in a stack and run in opposite order they were added to
+     * the stack. I.e. they're FILO (first-in-last-out).
+     * <p>
      * {@link #onCommitOrAbort(Runnable)} callbacks run before {@link #onSuccess(Runnable)} callbacks.
      * <p>
      * Callbacks are usually cleanup tasks, e.g. {@link PreCommitCondition#cleanup()}.

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -438,7 +438,7 @@ public interface TransactionManager extends AutoCloseable {
      * <p>
      * On commit or abort, the {@link PreCommitCondition#cleanup()} associated with a transaction will be run,
      * so clients should not worry about manually cleaning up pre-commit conditions. Pre-commit conditions are also
-     * cleaned up in case a transaction throws.
+     * cleaned up in case we fail to open transactions.
      * <p>
      * Note the caller must call {@link OpenTransaction#close()} after the transaction is committed to perform
      * additional cleanup. Failure to do so might incur in

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -429,12 +429,18 @@ public interface TransactionManager extends AutoCloseable {
     void registerClosingCallback(Runnable closingCallback);
 
     /**
-     * This method can be used for direct control over the lifecycle of a batch of transactions. For example, if the
-     * work done in each given transaction is interactive and cannot be expressed as a {@link TransactionTask} ahead of
-     * time, this method allows for a long lived transaction object. For any data read or written to the transaction to
-     * be valid, the transaction must be committed by calling {@link OpenTransaction#finish(TransactionTask)} to
-     * also perform additional cleanup. Note that this does not clean up the pre commit condition associated with that
-     * task. The order of transactions returned corresponds with the pre commit conditions passed in, however there are
+     * This method can be used for direct control over the lifecycle of a batch of transactions.
+     * For example, if the work done in each given transaction is interactive and cannot be expressed as a
+     * {@link TransactionTask} ahead of time, this method allows for a long lived transaction object.
+     * <p>
+     * For any data read or written to the transaction to be valid, the transaction must be committed explicitly
+     * by the caller with {@link Transaction#commit()}.
+     * <p>
+     * Note the caller must also call {@link OpenTransaction#close()} after the transaction is committed to perform
+     * additional cleanup. {@link OpenTransaction#close} does not clean up the pre commit condition associated with that
+     * task.
+     * <p>
+     * The order of transactions returned corresponds with the pre commit conditions passed in, however there are
      * no guarantees on the ordering of transactions returned with respect to their start timestamp.
      *
      * @return a batch of transactions with associated immutable timestamp locks

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -436,9 +436,12 @@ public interface TransactionManager extends AutoCloseable {
      * For any data read or written to the transaction to be valid, the transaction must be committed explicitly
      * by the caller with {@link Transaction#commit()}.
      * <p>
-     * Note the caller must also call {@link OpenTransaction#close()} after the transaction is committed to perform
-     * additional cleanup. {@link OpenTransaction#close} does not clean up the pre commit condition associated with that
-     * task.
+     * On commit or abort, the {@link PreCommitCondition#cleanup()} associated with a transaction will be run,
+     * so clients should not worry about manually cleaning up pre-commit conditions. Pre-commit conditions are also
+     * cleaned up in case a transaction throws.
+     * <p>
+     * Note the caller must call {@link OpenTransaction#close()} after the transaction is committed to perform
+     * additional cleanup. Failure to do so might incur in
      * <p>
      * The order of transactions returned corresponds with the pre commit conditions passed in, however there are
      * no guarantees on the ordering of transactions returned with respect to their start timestamp.

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -436,9 +436,9 @@ public interface TransactionManager extends AutoCloseable {
      * For any data read or written to the transaction to be valid, the transaction must be committed explicitly
      * by the caller with {@link Transaction#commit()}.
      * <p>
-     * On commit or abort, the {@link PreCommitCondition#cleanup()} associated with a transaction will be run,
-     * so clients should not worry about manually cleaning up pre-commit conditions. Pre-commit conditions are also
-     * cleaned up in case we fail to open transactions.
+     * {@link PreCommitCondition#cleanup()} associated with a transaction will be run when the respective transaction
+     * commits or aborts.
+     * All pre-commit conditions are also cleaned in case {@link #startTransactions(List)} throws.
      * <p>
      * Note the caller must call {@link OpenTransaction#close()} after the transaction is committed to perform
      * additional cleanup. Failure to do so might incur in

--- a/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
+++ b/atlasdb-api/src/main/java/com/palantir/atlasdb/transaction/api/TransactionManager.java
@@ -448,7 +448,7 @@ public interface TransactionManager extends AutoCloseable {
      */
     @Deprecated
     @Timed
-    List<OpenTransaction> startTransactions(List<? extends PreCommitCondition> condition);
+    List<? extends OpenTransaction> startTransactions(List<? extends PreCommitCondition> condition);
 
     /**
      * Frees resources used by this TransactionManager, and invokes any callbacks registered to run on close.

--- a/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
+++ b/atlasdb-client/src/main/java/com/palantir/atlasdb/transaction/impl/ForwardingTransaction.java
@@ -180,6 +180,11 @@ public abstract class ForwardingTransaction extends ForwardingObject implements 
     }
 
     @Override
+    public boolean isDefinitivelyCommitted() {
+        return delegate().isDefinitivelyCommitted();
+    }
+
+    @Override
     public long getTimestamp() {
         return delegate().getTimestamp();
     }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransaction.java
@@ -1831,6 +1831,11 @@ public class SnapshotTransaction extends AbstractTransaction
         return state.get() == State.UNCOMMITTED;
     }
 
+    @Override
+    public boolean isDefinitivelyCommitted() {
+        return state.get() == State.COMMITTED;
+    }
+
     private void ensureUncommitted() {
         if (!isUncommitted()) {
             throw new CommittedTransactionException();
@@ -1846,16 +1851,6 @@ public class SnapshotTransaction extends AbstractTransaction
     private boolean isStillRunning() {
         State stateNow = state.get();
         return stateNow == State.UNCOMMITTED || stateNow == State.COMMITTING;
-    }
-
-    /**
-     * Returns true iff the transaction is known to have successfully committed.
-     * <p>
-     * Be careful when using this method! A transaction that the client thinks has failed could actually have
-     * committed as far as the key-value service is concerned.
-     */
-    private boolean isDefinitivelyCommitted() {
-        return state.get() == State.COMMITTED;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -196,7 +196,6 @@ import java.util.stream.Collectors;
         try {
             openTransaction = runTimed(
                     () -> Iterables.getOnlyElement(startTransactions(ImmutableList.of(condition))), "setupTask");
-            openTransaction.onCommitOrAbort(condition::cleanup);
         } catch (Exception e) {
             condition.cleanup();
             throw e;

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -255,8 +255,7 @@ import java.util.stream.Collectors;
                                 // `onCommitOrAbort` is FILO, and we need to run `onTransactionCommit` before
                                 // `requestTransactionStateRemovalFromCache`
                                 transaction.onCommitOrAbort(() -> {
-                                    if (!transaction.isAborted()) {
-                                        // in onCommitOrAbort + not aborted == committed
+                                    if (transaction.isDefinitivelyCommitted()) {
                                         lockWatchManager.onTransactionCommit(transaction.getTimestamp());
                                     }
                                 });

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -245,6 +245,7 @@ import java.util.stream.Collectors;
                                 ExpectationsAwareTransaction transaction = createTransaction(
                                         immutableTs, startTimestampSupplier, immutableTsLock, condition);
 
+                                transaction.onCommitOrAbort(transaction::reportExpectationsCollectedData);
                                 transaction.onCommitOrAbort(condition::cleanup);
                                 transaction.onCommitOrAbort(
                                         () -> lockWatchManager.requestTransactionStateRemovalFromCache(
@@ -311,7 +312,6 @@ import java.util.stream.Collectors;
                     txn.abort();
                 }
             } finally {
-                txn.reportExpectationsCollectedData();
                 openTransactionCounter.dec();
             }
             scrubForAggressiveHardDelete(extractSnapshotTransaction(txn));

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -209,6 +209,7 @@ import java.util.stream.Collectors;
                 closer.close();
             } catch (IOException ex) {
                 e.addSuppressed(ex);
+                log.info("Failed to cleanup pre-commit conditions on startTransaction failure", ex);
             }
             throw e;
         }
@@ -274,6 +275,7 @@ import java.util.stream.Collectors;
                 closer.close();
             } catch (IOException e) {
                 t.addSuppressed(e);
+                log.info("Failed to cleanup startTransaction resources on startTransaction failure", t);
             }
             throw Throwables.rewrapAndThrowUncheckedException(t);
         }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManager.java
@@ -251,8 +251,9 @@ import java.util.stream.Collectors;
                                         () -> lockWatchManager.requestTransactionStateRemovalFromCache(
                                                 response.startTimestampAndPartition()
                                                         .timestamp()));
-                                // N.B. run this before clearing the state from the cache with
-                                // requestTransactionStateRemovalFromCache
+                                // N.B. register `onTransactionCommit` after `requestTransactionStateRemovalFromCache`
+                                // `onCommitOrAbort` is FILO, and we need to run `onTransactionCommit` before
+                                // `requestTransactionStateRemovalFromCache`
                                 transaction.onCommitOrAbort(() -> {
                                     if (!transaction.isAborted()) {
                                         // in onCommitOrAbort + not aborted == committed

--- a/atlasdb-service/src/main/java/com/palantir/atlasdb/impl/AtlasDbServiceImpl.java
+++ b/atlasdb-service/src/main/java/com/palantir/atlasdb/impl/AtlasDbServiceImpl.java
@@ -192,7 +192,9 @@ public class AtlasDbServiceImpl implements AtlasDbService {
     public void commit(TransactionToken token) {
         OpenTransaction openTxn = transactions.getIfPresent(token);
         if (openTxn != null) {
-            openTxn.finish((TxTask) transaction -> null);
+            try (openTxn) {
+                openTxn.commit();
+            }
             transactions.invalidate(token);
         }
     }
@@ -201,10 +203,9 @@ public class AtlasDbServiceImpl implements AtlasDbService {
     public void abort(TransactionToken token) {
         OpenTransaction openTxn = transactions.getIfPresent(token);
         if (openTxn != null) {
-            openTxn.finish((TxTask) transaction -> {
-                transaction.abort();
-                return null;
-            });
+            try (openTxn) {
+                openTxn.abort();
+            }
             transactions.invalidate(token);
         }
     }

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -74,7 +74,7 @@ public class SnapshotTransactionManagerTest {
     private static final String SETUP_TASK_METRIC_NAME =
             SnapshotTransactionManager.class.getCanonicalName() + ".setupTask";
     private static final String FINISH_TASK_METRIC_NAME =
-            SnapshotTransactionManager.class.getCanonicalName() + ".finishTask";
+            SnapshotTransactionManager.class.getCanonicalName() + ".runTaskThrowOnConflict";
 
     private final CloseableLockService closeableLockService = mock(CloseableLockService.class);
     private final Cleaner cleaner = mock(Cleaner.class);
@@ -290,7 +290,7 @@ public class SnapshotTransactionManagerTest {
     public void startEmptyBatchOfTransactionsDoesNotCallTimelockService() {
         TimelockService timelockService = spy(inMemoryTimelockClassExtension.getLegacyTimelockService());
         SnapshotTransactionManager transactionManager = createSnapshotTransactionManager(timelockService, false);
-        List<OpenTransaction> transactions = transactionManager.startTransactions(ImmutableList.of());
+        List<? extends OpenTransaction> transactions = transactionManager.startTransactions(ImmutableList.of());
 
         assertThat(transactions).isEmpty();
         verify(timelockService, never()).startIdentifiedAtlasDbTransactionBatch(anyInt());

--- a/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
+++ b/atlasdb-tests-shared/src/test/java/com/palantir/atlasdb/transaction/impl/SnapshotTransactionManagerTest.java
@@ -73,7 +73,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class SnapshotTransactionManagerTest {
     private static final String SETUP_TASK_METRIC_NAME =
             SnapshotTransactionManager.class.getCanonicalName() + ".setupTask";
-    private static final String FINISH_TASK_METRIC_NAME =
+    private static final String RUN_TASK_METRIC_NAME =
             SnapshotTransactionManager.class.getCanonicalName() + ".runTaskThrowOnConflict";
 
     private final CloseableLockService closeableLockService = mock(CloseableLockService.class);
@@ -250,14 +250,14 @@ public class SnapshotTransactionManagerTest {
         TaggedMetricRegistry registry = snapshotTransactionManager.metricsManager.getTaggedRegistry();
         assertThat(registry.getMetrics().keySet().stream().map(MetricName::safeName))
                 .contains(SETUP_TASK_METRIC_NAME)
-                .contains(FINISH_TASK_METRIC_NAME);
+                .contains(RUN_TASK_METRIC_NAME);
         assertThat(registry.timer(MetricName.builder()
                                 .safeName(SETUP_TASK_METRIC_NAME)
                                 .build())
                         .getCount())
                 .isGreaterThanOrEqualTo(1);
         assertThat(registry.timer(MetricName.builder()
-                                .safeName(FINISH_TASK_METRIC_NAME)
+                                .safeName(RUN_TASK_METRIC_NAME)
                                 .build())
                         .getCount())
                 .isGreaterThanOrEqualTo(1);

--- a/changelog/@unreleased/pr-7411.v2.yml
+++ b/changelog/@unreleased/pr-7411.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Refactor `OpenTransaction` interface.
+
+    We now put the burden of committing or aborting the transaction explicitly in the hands of the consumer, and modify the contract to require only the consumer to call `close()`.
+    We then abort the transaction on `close()` if uncommitted.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7411

--- a/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchEventIntegrationTest.java
+++ b/timelock-server/src/integTest/java/com/palantir/atlasdb/timelock/LockWatchEventIntegrationTest.java
@@ -189,8 +189,8 @@ public final class LockWatchEventIntegrationTest {
         assertThat(unlockedDescriptors(update.events())).containsExactlyInAnyOrderElementsOf(getDescriptors(CELL_3));
         assertThat(watchDescriptors(update.events())).isEmpty();
 
-        secondTxn.finish(_unused -> null);
-        fifthTxn.finish(_unused -> null);
+        secondTxn.close();
+        fifthTxn.close();
         cleanup.run();
     }
 


### PR DESCRIPTION
## General
**Before this PR**:
The interface `OpenTransaction` was confusing. It stated that methods needed to use `finish` or `finishWithCallback` for a transaction to succeed, but our main internal consumer called these only on `close()` for cleanup, which caused https://github.com/palantir/atlasdb/pull/7407.

**After this PR**:
This PR clarifies the usage of `OpenTransaction`. It explicitly delegates to clients the responsibility of calling `commit()` or `abort()`, and moves cleanup to a `close()` method. It also makes it explicit that `close()` is idempotent, and can be called several times (with further calls simply no-oping).
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
