### PR TITLE
Fix `TimestampLeaseRequests` serialization

### DIFF
--- a/atlasdb-commons-api/build.gradle
+++ b/atlasdb-commons-api/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     annotationProcessor 'org.immutables:value'
 
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
-    implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.palantir.safe-logging:preconditions'
 

--- a/atlasdb-commons-api/src/main/java/com/palantir/atlasdb/common/api/timelock/TimestampLeaseName.java
+++ b/atlasdb-commons-api/src/main/java/com/palantir/atlasdb/common/api/timelock/TimestampLeaseName.java
@@ -16,17 +16,14 @@
 
 package com.palantir.atlasdb.common.api.timelock;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import java.util.Comparator;
 import org.immutables.value.Value;
 
-@JsonDeserialize(as = ImmutableTimestampLeaseName.class)
-@JsonSerialize(as = ImmutableTimestampLeaseName.class)
 @Value.Immutable
 @Safe
 public interface TimestampLeaseName {
@@ -45,6 +42,7 @@ public interface TimestampLeaseName {
                 SafeArg.of("name", name()));
     }
 
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     static TimestampLeaseName of(@Safe String name) {
         return ImmutableTimestampLeaseName.builder().name(name).build();
     }

--- a/changelog/@unreleased/pr-7421.v2.yml
+++ b/changelog/@unreleased/pr-7421.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix `TimestampLeaseRequests` serialization and de-serialization.
+  links:
+  - https://github.com/palantir/atlasdb/pull/7421

--- a/timelock-api/build.gradle
+++ b/timelock-api/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava'
 
     testImplementation project(':atlasdb-api')
+    testImplementation project(':atlasdb-commons-api')
     testImplementation 'com.palantir.conjure.java.runtime:conjure-java-jackson-serialization'
     testImplementation 'com.palantir.safe-logging:preconditions-assertj'
     testImplementation 'org.assertj:assertj-core'
@@ -22,6 +23,7 @@ dependencies {
 subprojects {
     apply from: "../../gradle/shared.gradle"
     dependencies {
+        api project(':atlasdb-commons-api')
         api project(':lock-api-objects')
         api project(':timelock-api')
         api project(':leader-election-api')

--- a/timelock-api/src/test/java/com/palantir/atlasdb/timelock/api/TimestampLeaseRequestsTest.java
+++ b/timelock-api/src/test/java/com/palantir/atlasdb/timelock/api/TimestampLeaseRequestsTest.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.atlasdb.timelock.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.palantir.atlasdb.common.api.timelock.TimestampLeaseName;
+import com.palantir.conjure.java.serialization.ObjectMappers;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class TimestampLeaseRequestsTest {
+    private static final ObjectMapper SERIALIZATION_MAPPER =
+            ObjectMappers.newClientObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    private static final ObjectMapper DESERIALIZATION_MAPPER =
+            ObjectMappers.newServerObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    @Test
+    void canSerializeAndDeserialize() throws IOException {
+        Namespace namespace1 = Namespace.of("timelock-client-namespace");
+        TimestampLeaseRequests leaseRequests1 = TimestampLeaseRequests.of(
+                RequestId.of(new UUID(0, 0)),
+                Map.of(
+                        TimestampLeaseName.of("timestamp-lease-name-1"), 10,
+                        TimestampLeaseName.of("timestamp-lease-name-2"), 20));
+
+        Namespace namespace2 = Namespace.of("another-timelock-client-namespace");
+        TimestampLeaseRequests leaseRequests2 = TimestampLeaseRequests.of(
+                RequestId.of(new UUID(0, 1)), Map.of(TimestampLeaseName.of("another-timestamp-lease-name"), 30));
+
+        MultiClientTimestampLeaseRequest request = MultiClientTimestampLeaseRequest.of(Map.of(
+                namespace1,
+                NamespaceTimestampLeaseRequest.of(List.of(leaseRequests1)),
+                namespace2,
+                NamespaceTimestampLeaseRequest.of(List.of(leaseRequests2))));
+        byte[] asBytes = SERIALIZATION_MAPPER.writeValueAsBytes(request);
+        MultiClientTimestampLeaseRequest deserialized =
+                DESERIALIZATION_MAPPER.readValue(asBytes, MultiClientTimestampLeaseRequest.class);
+        assertThat(deserialized).isEqualTo(request);
+    }
+}


### PR DESCRIPTION
## General
**Before this PR**:
In integration tests we noticed that `TimestampLeaseRequests` would fail to de-serialize in Timelock with
```
com.palantir.conjure.java.undertow.runtime.FrameworkException: Failed to deserialize request
...
Cannot find a (Map) Key deserializer for type [simple type, class com.palantir.atlasdb.common.api.timelock.TimestampLeaseName]
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1]
```

**After this PR**:
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:

**Concerns / possible downsides (what feedback would you like?)**:

**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:

**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:

**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:

**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:

**Does this PR need a schema migration?**

## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:

**What was existing testing like? What have you done to improve it?**:

**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:

**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:

## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:

**Has the safety of all log arguments been decided correctly?**:

**Will this change significantly affect our spending on metrics or logs?**:

**How would I tell that this PR does not work in production? (monitors, etc.)**:

**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:

**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:

## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:

**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:

**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:

## Development Process
**Where should we start reviewing?**:

**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
