### PR TITLE
[ASTS] Fix: ensure forward progress even if a single window does not have enough timestamps

### DIFF
--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketCloseTimestampCalculatorTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultBucketCloseTimestampCalculatorTest.java
@@ -67,14 +67,6 @@ public final class DefaultBucketCloseTimestampCalculatorTest {
     }
 
     @Test
-    public void returnsEmptyIfSufficientTimeHasNotPassedSinceStartTimestamp() {
-        long startTimestamp = 18 * SweepQueueUtils.TS_COARSE_GRANULARITY; // Arbitrarily chosen.
-        when(puncherStore.getMillisForTimestamp(startTimestamp)).thenReturn(clock.millis());
-        OptionalLong maybeEndTimestamp = bucketCloseTimestampCalculator.getBucketCloseTimestamp(startTimestamp);
-        assertThat(maybeEndTimestamp).isEmpty();
-    }
-
-    @Test
     public void
             returnsLogicalTimestampSufficientTimeAfterStartTimestampIfTenMinutesHasPassedAndLogicalTimestampAheadOfStart() {
         long startTimestamp = 123 * SweepQueueUtils.TS_COARSE_GRANULARITY;
@@ -90,13 +82,17 @@ public final class DefaultBucketCloseTimestampCalculatorTest {
 
     @ParameterizedTest
     @ValueSource(
-            longs = {2300 * SweepQueueUtils.TS_COARSE_GRANULARITY, 2315 * SweepQueueUtils.TS_COARSE_GRANULARITY
-            }) // less than, and equal to.
-    // This is to test what happens when the puncher store returns a timestamp less than (or equal to) the start
-    // timestamp
-    // In both of these cases, we should not use the punch table result, but instead fallback to the relevant algorithm.
+            longs = {
+                2300 * SweepQueueUtils.TS_COARSE_GRANULARITY,
+                2315 * SweepQueueUtils.TS_COARSE_GRANULARITY,
+                2315 * SweepQueueUtils.TS_COARSE_GRANULARITY + 1,
+                2316 * SweepQueueUtils.TS_COARSE_GRANULARITY - 1
+            }) // less than, equal to, and insufficiently greater than
+    // This is to test what happens when the puncher store returns a timestamp less than / equal / insufficiently
+    // greater than the start timestamp
+    // In all of these cases, we should not use the punch table result, but instead fallback to the relevant algorithm.
     public void
-            returnsEmptyIfSufficientTimeHasPassedPuncherTimestampBeforeStartAndLatestFreshTimestampNotFarEnoughAhead(
+            returnsEmptyIfSufficientTimeHasPassedPuncherTimestampInsufficientlyFarAndLatestFreshTimestampNotFarEnoughAhead(
                     long puncherTimestamp) {
         long startTimestamp = 2315 * SweepQueueUtils.TS_COARSE_GRANULARITY;
         when(puncherStore.getMillisForTimestamp(startTimestamp)).thenReturn(clock.millis());
@@ -110,9 +106,15 @@ public final class DefaultBucketCloseTimestampCalculatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(longs = {123 * SweepQueueUtils.TS_COARSE_GRANULARITY, 312 * SweepQueueUtils.TS_COARSE_GRANULARITY})
+    @ValueSource(
+            longs = {
+                123 * SweepQueueUtils.TS_COARSE_GRANULARITY,
+                312 * SweepQueueUtils.TS_COARSE_GRANULARITY,
+                312 * SweepQueueUtils.TS_COARSE_GRANULARITY + 1,
+                313 * SweepQueueUtils.TS_COARSE_GRANULARITY - 1
+            })
     public void
-            returnsLatestClampedFreshTimestampIfSufficientTimeHasPassedPuncherTimestampBeforeStartAndCalculatedTimestampFarEnoughAhead(
+            returnsLatestClampedFreshTimestampIfSufficientTimeHasPassedPuncherTimestampInsufficientlyFarAndCalculatedTimestampFarEnoughAhead(
                     long puncherTimestamp) {
         long startTimestamp = 312 * SweepQueueUtils.TS_COARSE_GRANULARITY;
         when(puncherStore.getMillisForTimestamp(startTimestamp)).thenReturn(clock.millis());
@@ -126,8 +128,14 @@ public final class DefaultBucketCloseTimestampCalculatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(longs = {98 * SweepQueueUtils.TS_COARSE_GRANULARITY, 100 * SweepQueueUtils.TS_COARSE_GRANULARITY})
-    public void returnsClampedAndCappedTimestampIfPuncherTimestampBeforeStartAndLatestFreshTimestampIsTooFarAhead(
+    @ValueSource(
+            longs = {
+                98 * SweepQueueUtils.TS_COARSE_GRANULARITY,
+                100 * SweepQueueUtils.TS_COARSE_GRANULARITY,
+                100 * SweepQueueUtils.TS_COARSE_GRANULARITY + 1,
+                101 * SweepQueueUtils.TS_COARSE_GRANULARITY - 1
+            })
+    public void returnsClampedAndCappedTimestampIfPuncherTimestampInsufficientlyFarAndLatestFreshTimestampIsTooFarAhead(
             long puncherTimestamp) {
         long startTimestamp = 100 * SweepQueueUtils.TS_COARSE_GRANULARITY;
         when(puncherStore.getMillisForTimestamp(startTimestamp)).thenReturn(clock.millis());


### PR DESCRIPTION
## General
**Before this PR**:
We calculate the range of a sweepable bucket by (rough description):
1. Using the startTs of the bucket, calculate the approx wall clock time (T)
2. Find the timestamp (endTs) associated with T + 10 minutes, if T + 10 minutes < the current time
3. If endTs - startTs < min bucket size, say that the bucket is not closed, otherwise clamp and close the bucket.

`endTs - startTs < min bucket size, say that the bucket is not closed` was a later change when we decided to clamp bucket boundaries on to a coarse partition size, but it introduces a liveness issue. Namely, as the punch table entry is unlikely* to change (and therefore if endTs - startTs < min bucket size is true at some point, it will remain true), the bucket will never close


*It's possible for a given node of AtlasDB to, for whatever reason (clock drift, GC pause, non-scheduled threads) to write an entry in the past with a _higher_ timestamp, resulting in a subsequent punch table read at T + 10 returning a sufficiently high enough timestamp. We must not rely on that though!

**After this PR**:
If `endTs - startTs < min bucket size`, then we'll use the same escape hatch as if we detected clock drift. Read the comment in the code for more information.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
This has revealed a few issues with the static 10 million timestamp min bucket size. We may want to re-evaluate our bucket calculation algorithm - e.g., the more complex approach noted in a code comment. I don't believe we should do that right now, as that would block initial testing.

**Is documentation needed?**:
No
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
N/A
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
No new assumptions
**What was existing testing like? What have you done to improve it?**:
Updated tests to match the required behaviour
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Buckets are continuously created on services that don't have high enough timestamp usage. This is visible in metrics and logs
**Has the safety of all log arguments been decided correctly?**:
No change
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Metrics show that buckets are not being created.
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Fix the code / turn off ASTS - this is only being tested in a very controlled environment.
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
N/A
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
Yes. See concern above. We'll review this next week.

## Development Process
**Where should we start reviewing?**:
Calculator
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:
N/A
**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
