### PR TITLE
[DNM - RC ONLY][ASTS] Changes to background task

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/BucketBasedTargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/BucketBasedTargetedSweeper.java
@@ -149,6 +149,7 @@ public final class BucketBasedTargetedSweeper implements BackgroundSweeper {
                 bucketProgressStore,
                 new SweepQueueProgressUpdater(cleaner),
                 sweepAssignedBucketStore,
+                sweepAssignedBucketStore,
                 sweepAssignedBucketStore);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTask.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/DefaultSingleBucketSweepTask.java
@@ -84,6 +84,10 @@ public class DefaultSingleBucketSweepTask implements SingleBucketSweepTask {
 
         BucketProgress existingBucketProgress =
                 bucketProgressStore.getBucketProgress(sweepableBucket.bucket()).orElse(BucketProgress.INITIAL_PROGRESS);
+        log.info(
+                "Existing bucket progress",
+                SafeArg.of("bucket", sweepableBucket.bucket()),
+                SafeArg.of("progress", existingBucketProgress));
 
         // This is inclusive.
         long lastSweptTimestampInBucket =
@@ -159,8 +163,13 @@ public class DefaultSingleBucketSweepTask implements SingleBucketSweepTask {
 
         long lastTsOffset = lastTs - sweepableBucket.timestampRange().startInclusive();
 
+        log.info(
+                "Updating bucket progress",
+                SafeArg.of("bucket", sweepableBucket.bucket()),
+                SafeArg.of("progress", lastTsOffset));
         bucketProgressStore.updateBucketProgressToAtLeast(
                 sweepableBucket.bucket(), BucketProgress.createForTimestampProgress(lastTsOffset));
+
         if (isCompletelySwept(sweepableBucket.timestampRange().endExclusive(), lastTs)) {
             // we've finished the bucket!
             markBucketCompleteIfEligible(sweepableBucket);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
@@ -223,6 +223,15 @@ public final class DefaultSweepAssignedBucketStore
     }
 
     @Override
+    public Optional<SweepableBucket> getSweepableBucket(Bucket bucket) {
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketsCell(bucket);
+        return readCell(
+                cell,
+                (byte[] bytes) -> SweepAssignedBucketStoreKeyPersister.INSTANCE.fromSweepBucketCellAndValue(
+                        cell, Value.create(bytes, -1), timestampRangePersister));
+    }
+
+    @Override
     public void putTimestampRangeForBucket(
             Bucket bucket, Optional<TimestampRange> oldTimestampRange, TimestampRange newTimestampRange) {
         Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketsCell(bucket);

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketsTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketsTable.java
@@ -29,6 +29,8 @@ public interface SweepBucketsTable {
      */
     Set<SweepableBucket> getSweepableBuckets(Set<Bucket> startBuckets);
 
+    Optional<SweepableBucket> getSweepableBucket(Bucket bucket);
+
     void putTimestampRangeForBucket(
             Bucket bucket, Optional<TimestampRange> oldTimestampRange, TimestampRange newTimestampRange);
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/AbstractDefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/AbstractDefaultSweepAssignedBucketStoreTest.java
@@ -257,6 +257,14 @@ public abstract class AbstractDefaultSweepAssignedBucketStoreTest {
     }
 
     @Test
+    public void getSweepableBucketReturnsSweepableBucketIfExists() {
+        Bucket bucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 21);
+        TimestampRange range = TimestampRange.of(1, 4);
+        store.putTimestampRangeForBucket(bucket, Optional.empty(), range);
+        assertThat(store.getSweepableBucket(bucket)).contains(SweepableBucket.of(bucket, range));
+    }
+
+    @Test
     public void putTimestampRangeForBucketFailsIfOldTimestampRangeDoesNotMatchCurrent() {
         Bucket bucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 512);
         TimestampRange oldTimestampRange = TimestampRange.of(0, 1); // Not actually set
@@ -289,7 +297,7 @@ public abstract class AbstractDefaultSweepAssignedBucketStoreTest {
         TimestampRange timestampRange = TimestampRange.of(1, 2);
         store.putTimestampRangeForBucket(bucket, Optional.empty(), timestampRange);
         store.deleteBucketEntry(bucket);
-        assertThat(store.getSweepableBuckets(Set.of(bucket))).isEmpty();
+        assertThat(store.getSweepableBucket(bucket)).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
The algorithm for determining the point up to which we should update the min swept Ts relies on records being present when a bucket is opened, and progress persisting after a bucket is complete. The former is not true (records are created on close) and the latter doesn't work (we delete progress after a bucket is complete, but even if we didn't, the task cleans up progress, and would therefore stop the task from searching future buckets if it failed part way).


This is not being merged as is, as we should verify this is the direction we want to go in.