### PR TITLE
[ASTS] Fix: Update getTimestampRangeRecord to return empty when record not present

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
@@ -37,7 +37,6 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -239,10 +238,9 @@ public final class DefaultSweepAssignedBucketStore
     }
 
     @Override
-    public TimestampRange getTimestampRangeRecord(long bucketIdentifier) {
+    public Optional<TimestampRange> getTimestampRangeRecord(long bucketIdentifier) {
         Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketRecordsCell(bucketIdentifier);
-        return readCell(cell, timestampRangePersister::tryDeserialize)
-                .orElseThrow(() -> new NoSuchElementException("No timestamp range record found for bucket identifier"));
+        return readCell(cell, timestampRangePersister::tryDeserialize);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketRecordsTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketRecordsTable.java
@@ -17,13 +17,15 @@
 package com.palantir.atlasdb.sweep.asts.bucketingthings;
 
 import com.palantir.atlasdb.sweep.asts.TimestampRange;
+import java.util.Optional;
 
 public interface SweepBucketRecordsTable {
     /**
-     * Returns the {@link TimestampRange} for the given bucket identifier, throwing a
-     * {@link java.util.NoSuchElementException} if one is not present.
+     * Returns a {@link TimestampRange} for the given bucket identifier, if one exists. If the record is present, then
+     * the bucket is definitely closed. If the record is not present, the bucket is either open or closed (the record
+     * may simply not have been written yet).
      */
-    TimestampRange getTimestampRangeRecord(long bucketIdentifier);
+    Optional<TimestampRange> getTimestampRangeRecord(long bucketIdentifier);
 
     void putTimestampRangeRecord(long bucketIdentifier, TimestampRange timestampRange);
 

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/AbstractDefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/AbstractDefaultSweepAssignedBucketStoreTest.java
@@ -38,7 +38,6 @@ import com.palantir.atlasdb.table.description.SweeperStrategy;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashSet;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -293,17 +292,15 @@ public abstract class AbstractDefaultSweepAssignedBucketStoreTest {
     }
 
     @Test
-    public void getTimestampRangeRecordThrowsIfRecordNotPresent() {
-        assertThatThrownBy(() -> store.getTimestampRangeRecord(1))
-                .isInstanceOf(NoSuchElementException.class)
-                .hasMessage("No timestamp range record found for bucket identifier");
+    public void getTimestampRangeRecordReturnsEmptyIfRecordDoesNotExist() {
+        assertThat(store.getTimestampRangeRecord(1)).isEmpty();
     }
 
     @Test
     public void putTimestampRangeRecordPutsRecord() {
         TimestampRange timestampRange = TimestampRange.of(1, 2);
         store.putTimestampRangeRecord(1, timestampRange);
-        assertThat(store.getTimestampRangeRecord(1)).isEqualTo(timestampRange);
+        assertThat(store.getTimestampRangeRecord(1)).hasValue(timestampRange);
     }
 
     @Test
@@ -323,11 +320,9 @@ public abstract class AbstractDefaultSweepAssignedBucketStoreTest {
     public void deleteTimestampRangeRecordDeletesRecord() {
         TimestampRange timestampRange = TimestampRange.of(1, 2);
         store.putTimestampRangeRecord(1, timestampRange);
-        assertThat(store.getTimestampRangeRecord(1)).isEqualTo(timestampRange);
+        assertThat(store.getTimestampRangeRecord(1)).hasValue(timestampRange);
 
         store.deleteTimestampRangeRecord(1);
-        assertThatThrownBy(() -> store.getTimestampRangeRecord(1))
-                .isInstanceOf(NoSuchElementException.class)
-                .hasMessage("No timestamp range record found for bucket identifier");
+        assertThat(store.getTimestampRangeRecord(1)).isEmpty();
     }
 }


### PR DESCRIPTION
## General
**Before this PR**:
Part 1 (of ~3): The background shard progress updater assumes that buckets without progress are unstarted. This is incorrect, because 1) we delete progress when the bucket is complete, but separately 2) we delete progress right after finding completed buckets, and so if we crashed after deleting progress but before updating the starting bucket (and assuming the foreground task removes the sweepable bucket entry too), then we'd never make progress past the bucket we crashed on.

Instead, we need a new method to determine when a bucket is completed, as shown in the draft #7424.

**After this PR**:
Updates the guarantees around getTimestampRangeRecord. The signature now reflects the fact that a record may not be present in certain circumstances (open buckets) and that this is not an exceptional event.

We will use this (will exist after this PR) + progress (already exists) + whether a sweepable bucket entry exists (method coming in another PR) to determine the status of a bucket. 
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**:
P2
**Concerns / possible downsides (what feedback would you like?)**:
The ShardProgressUpdater is still broken. I'll fix it in the final PR.
**Is documentation needed?**:

## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
No
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
No
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
Yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
No
**Does this PR need a schema migration?**
No
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
That ASTS is not being used outside of one test env
**What was existing testing like? What have you done to improve it?**:
Updated the tests
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Final PR


## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
N/A
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
N/A
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
N/A
## Development Process
**Where should we start reviewing?**:
DSABS
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
