### PR TITLE
[ASTS] Background Shard Progress Updater now correctly calculates last swept progress

### DIFF
--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/BucketBasedTargetedSweeper.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/BucketBasedTargetedSweeper.java
@@ -149,6 +149,7 @@ public final class BucketBasedTargetedSweeper implements BackgroundSweeper {
                 bucketProgressStore,
                 new SweepQueueProgressUpdater(cleaner),
                 sweepAssignedBucketStore,
+                sweepAssignedBucketStore,
                 sweepAssignedBucketStore);
     }
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
@@ -222,6 +222,15 @@ public final class DefaultSweepAssignedBucketStore
     }
 
     @Override
+    public Optional<SweepableBucket> getSweepableBucket(Bucket bucket) {
+        Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketsCell(bucket);
+        return readCell(
+                cell,
+                value -> SweepAssignedBucketStoreKeyPersister.INSTANCE.fromSweepBucketCellAndValue(
+                        cell, value, timestampRangePersister));
+    }
+
+    @Override
     public void putTimestampRangeForBucket(
             Bucket bucket, Optional<TimestampRange> oldTimestampRange, TimestampRange newTimestampRange) {
         Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketsCell(bucket);
@@ -288,7 +297,7 @@ public final class DefaultSweepAssignedBucketStore
                 Long.MAX_VALUE);
         return reads.entrySet().stream()
                 .map(entry -> SweepAssignedBucketStoreKeyPersister.INSTANCE.fromSweepBucketCellAndValue(
-                        entry.getKey(), entry.getValue(), timestampRangePersister))
+                        entry.getKey(), entry.getValue().getContents(), timestampRangePersister))
                 .collect(Collectors.toSet());
     }
 }

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/DefaultSweepAssignedBucketStore.java
@@ -37,7 +37,6 @@ import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -239,10 +238,9 @@ public final class DefaultSweepAssignedBucketStore
     }
 
     @Override
-    public TimestampRange getTimestampRangeRecord(long bucketIdentifier) {
+    public Optional<TimestampRange> getTimestampRangeRecord(long bucketIdentifier) {
         Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketRecordsCell(bucketIdentifier);
-        return readCell(cell, timestampRangePersister::tryDeserialize)
-                .orElseThrow(() -> new NoSuchElementException("No timestamp range record found for bucket identifier"));
+        return readCell(cell, timestampRangePersister::tryDeserialize);
     }
 
     @Override

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepAssignedBucketStoreKeyPersister.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepAssignedBucketStoreKeyPersister.java
@@ -17,7 +17,6 @@
 package com.palantir.atlasdb.sweep.asts.bucketingthings;
 
 import com.palantir.atlasdb.keyvalue.api.Cell;
-import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.schema.generated.SweepAssignedBucketsTable.SweepAssignedBucketsColumn;
 import com.palantir.atlasdb.schema.generated.SweepAssignedBucketsTable.SweepAssignedBucketsRow;
 import com.palantir.atlasdb.sweep.asts.Bucket;
@@ -76,11 +75,11 @@ enum SweepAssignedBucketStoreKeyPersister {
     }
 
     SweepableBucket fromSweepBucketCellAndValue(
-            Cell cell, Value value, ObjectPersister<TimestampRange> timestampRangePersister) {
+            Cell cell, byte[] value, ObjectPersister<TimestampRange> timestampRangePersister) {
         SweepAssignedBucketsRow row = SweepAssignedBucketsRow.BYTES_HYDRATOR.hydrateFromBytes(cell.getRowName());
         SweepAssignedBucketsColumn column =
                 SweepAssignedBucketsColumn.BYTES_HYDRATOR.hydrateFromBytes(cell.getColumnName());
-        TimestampRange timestampRange = timestampRangePersister.tryDeserialize(value.getContents());
+        TimestampRange timestampRange = timestampRangePersister.tryDeserialize(value);
         int shard = Math.toIntExact(row.getShard()); // throws if invalid shard
         return SweepableBucket.of(
                 Bucket.of(

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketRecordsTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketRecordsTable.java
@@ -17,13 +17,14 @@
 package com.palantir.atlasdb.sweep.asts.bucketingthings;
 
 import com.palantir.atlasdb.sweep.asts.TimestampRange;
+import java.util.Optional;
 
 public interface SweepBucketRecordsTable {
     /**
-     * Returns the {@link TimestampRange} for the given bucket identifier, throwing a
-     * {@link java.util.NoSuchElementException} if one is not present.
+     * Returns a {@link TimestampRange} for the given bucket identifier, if one exists. Iff a bucket is closed, then
+     * the corresponding record will be present. (If the bucket is open, no record will be present.)
      */
-    TimestampRange getTimestampRangeRecord(long bucketIdentifier);
+    Optional<TimestampRange> getTimestampRangeRecord(long bucketIdentifier);
 
     void putTimestampRangeRecord(long bucketIdentifier, TimestampRange timestampRange);
 

--- a/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketsTable.java
+++ b/atlasdb-impl-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepBucketsTable.java
@@ -29,6 +29,8 @@ public interface SweepBucketsTable {
      */
     Set<SweepableBucket> getSweepableBuckets(Set<Bucket> startBuckets);
 
+    Optional<SweepableBucket> getSweepableBucket(Bucket bucket);
+
     void putTimestampRangeForBucket(
             Bucket bucket, Optional<TimestampRange> oldTimestampRange, TimestampRange newTimestampRange);
 

--- a/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepAssignedBucketStoreKeyPersisterTest.java
+++ b/atlasdb-impl-shared/src/test/java/com/palantir/atlasdb/sweep/asts/bucketingthings/SweepAssignedBucketStoreKeyPersisterTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.BaseEncoding;
 import com.palantir.atlasdb.keyvalue.api.Cell;
-import com.palantir.atlasdb.keyvalue.api.Value;
 import com.palantir.atlasdb.schema.generated.SweepAssignedBucketsTable.SweepAssignedBucketsRow;
 import com.palantir.atlasdb.sweep.asts.Bucket;
 import com.palantir.atlasdb.sweep.asts.SweepableBucket;
@@ -59,14 +58,11 @@ public final class SweepAssignedBucketStoreKeyPersisterTest {
             Bucket.of(ShardAndStrategy.nonSweepable(), Long.MAX_VALUE),
             fromBase64("PpljSwhiGMuA/4FHrhR64UeuAg==", "hw=="));
 
-    private static final Map<TimestampRange, Value> GOLDEN_TIMESTAMP_RANGES = Map.of(
+    private static final Map<TimestampRange, byte[]> GOLDEN_TIMESTAMP_RANGES = Map.of(
             TimestampRange.of(912301923, Long.MAX_VALUE),
-            Value.create(
-                    BaseEncoding.base64()
-                            .decode("OikKBfqLZW5kRXhjbHVzaXZlJQN/f39/f39/f76Nc3RhcnRJbmNsdXNpdmUkDUwJe4b7"),
-                    -1),
+            BaseEncoding.base64().decode("OikKBfqLZW5kRXhjbHVzaXZlJQN/f39/f39/f76Nc3RhcnRJbmNsdXNpdmUkDUwJe4b7"),
             TimestampRange.openBucket(13123),
-            Value.create(BaseEncoding.base64().decode("OikKBfqLZW5kRXhjbHVzaXZlwY1zdGFydEluY2x1c2l2ZSQDGob7"), -1));
+            BaseEncoding.base64().decode("OikKBfqLZW5kRXhjbHVzaXZlwY1zdGFydEluY2x1c2l2ZSQDGob7"));
 
     private static final Cell GOLDEN_SWEEP_BUCKET_ASSIGNER_STATE_MACHINE_CELL = Cell.create(
             BaseEncoding.base64().decode("GTH5RX8BW6N/f/8="),
@@ -127,9 +123,7 @@ public final class SweepAssignedBucketStoreKeyPersisterTest {
     @ParameterizedTest
     @MethodSource("sweepableBuckets")
     public void canDeserializeCellsAndValuesBackToSweepableBucket(SweepableBucket sweepableBucket) {
-        Value value = Value.create(
-                TIMESTAMP_RANGE_PERSISTER.trySerialize(sweepableBucket.timestampRange()),
-                -1); // Timestamp does not matter
+        byte[] value = TIMESTAMP_RANGE_PERSISTER.trySerialize(sweepableBucket.timestampRange());
         Cell cell = SweepAssignedBucketStoreKeyPersister.INSTANCE.sweepBucketsCell(sweepableBucket.bucket());
         SweepableBucket deserialisedSweepableBucket =
                 SweepAssignedBucketStoreKeyPersister.INSTANCE.fromSweepBucketCellAndValue(
@@ -141,7 +135,7 @@ public final class SweepAssignedBucketStoreKeyPersisterTest {
     @ParameterizedTest
     @MethodSource("goldenSweepBucketCellsAndValues")
     public void canDeserializeHistoricCellsAndValuesBackToSweepableBucket(
-            SweepableBucket sweepableBucket, Cell cell, Value value) {
+            SweepableBucket sweepableBucket, Cell cell, byte[] value) {
         SweepableBucket deserialisedSweepableBucket =
                 SweepAssignedBucketStoreKeyPersister.INSTANCE.fromSweepBucketCellAndValue(
                         cell, value, TIMESTAMP_RANGE_PERSISTER);

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/AbstractDefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/AbstractDefaultSweepAssignedBucketStoreTest.java
@@ -256,6 +256,20 @@ public abstract class AbstractDefaultSweepAssignedBucketStoreTest {
     }
 
     @Test
+    public void getSweepableBucketReturnsSweepableBucketIfExists() {
+        Bucket bucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 21);
+        TimestampRange range = TimestampRange.of(1, 4);
+        store.putTimestampRangeForBucket(bucket, Optional.empty(), range);
+        assertThat(store.getSweepableBucket(bucket)).contains(SweepableBucket.of(bucket, range));
+    }
+
+    @Test
+    public void getSweepableBucketReturnsEmptyIfSweepableBucketDoesNotExist() {
+        Bucket bucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 21);
+        assertThat(store.getSweepableBucket(bucket)).isEmpty();
+    }
+
+    @Test
     public void putTimestampRangeForBucketFailsIfOldTimestampRangeDoesNotMatchCurrent() {
         Bucket bucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 512);
         TimestampRange oldTimestampRange = TimestampRange.of(0, 1); // Not actually set
@@ -272,8 +286,7 @@ public abstract class AbstractDefaultSweepAssignedBucketStoreTest {
         TimestampRange newTimestampRange = TimestampRange.of(1, 2);
 
         store.putTimestampRangeForBucket(bucket, Optional.empty(), newTimestampRange);
-        Set<SweepableBucket> sweepableBuckets = store.getSweepableBuckets(Set.of(bucket));
-        assertThat(sweepableBuckets).containsExactly(SweepableBucket.of(bucket, newTimestampRange));
+        assertThat(store.getSweepableBucket(bucket)).contains(SweepableBucket.of(bucket, newTimestampRange));
     }
 
     @Test
@@ -287,8 +300,10 @@ public abstract class AbstractDefaultSweepAssignedBucketStoreTest {
         Bucket bucket = Bucket.of(ShardAndStrategy.of(12, SweeperStrategy.THOROUGH), 512);
         TimestampRange timestampRange = TimestampRange.of(1, 2);
         store.putTimestampRangeForBucket(bucket, Optional.empty(), timestampRange);
+        assertThat(store.getSweepableBucket(bucket)).hasValue(SweepableBucket.of(bucket, timestampRange));
+
         store.deleteBucketEntry(bucket);
-        assertThat(store.getSweepableBuckets(Set.of(bucket))).isEmpty();
+        assertThat(store.getSweepableBucket(bucket)).isEmpty();
     }
 
     @Test

--- a/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/AbstractDefaultSweepAssignedBucketStoreTest.java
+++ b/atlasdb-tests-shared/src/main/java/com/palantir/atlasdb/sweep/asts/bucketingthings/AbstractDefaultSweepAssignedBucketStoreTest.java
@@ -38,7 +38,6 @@ import com.palantir.atlasdb.table.description.SweeperStrategy;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.util.HashSet;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -293,17 +292,15 @@ public abstract class AbstractDefaultSweepAssignedBucketStoreTest {
     }
 
     @Test
-    public void getTimestampRangeRecordThrowsIfRecordNotPresent() {
-        assertThatThrownBy(() -> store.getTimestampRangeRecord(1))
-                .isInstanceOf(NoSuchElementException.class)
-                .hasMessage("No timestamp range record found for bucket identifier");
+    public void getTimestampRangeRecordReturnsEmptyIfRecordDoesNotExist() {
+        assertThat(store.getTimestampRangeRecord(1)).isEmpty();
     }
 
     @Test
     public void putTimestampRangeRecordPutsRecord() {
         TimestampRange timestampRange = TimestampRange.of(1, 2);
         store.putTimestampRangeRecord(1, timestampRange);
-        assertThat(store.getTimestampRangeRecord(1)).isEqualTo(timestampRange);
+        assertThat(store.getTimestampRangeRecord(1)).hasValue(timestampRange);
     }
 
     @Test
@@ -323,11 +320,9 @@ public abstract class AbstractDefaultSweepAssignedBucketStoreTest {
     public void deleteTimestampRangeRecordDeletesRecord() {
         TimestampRange timestampRange = TimestampRange.of(1, 2);
         store.putTimestampRangeRecord(1, timestampRange);
-        assertThat(store.getTimestampRangeRecord(1)).isEqualTo(timestampRange);
+        assertThat(store.getTimestampRangeRecord(1)).hasValue(timestampRange);
 
         store.deleteTimestampRangeRecord(1);
-        assertThatThrownBy(() -> store.getTimestampRangeRecord(1))
-                .isInstanceOf(NoSuchElementException.class)
-                .hasMessage("No timestamp range record found for bucket identifier");
+        assertThat(store.getTimestampRangeRecord(1)).isEmpty();
     }
 }


### PR DESCRIPTION
## General
**Before this PR**:
See #7439 

**After this PR**:
Background Shard Progress Updater now calculates the correct timestamp in the presence of deleted progress entries
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

**Priority**: P2

**Concerns / possible downsides (what feedback would you like?)**:
The old code set knownSweepProgress to endExclusive + 1. I'm pretty sure it's endExclusive - 1, since endExclusive hasn't been swept (only _upto_ endExclusive has been swept)

-1 as a placeholder is janky. Happy to move to Optional, but given it's scoped down to within a method and not used as a return value, I figured that not unpacking the optional was easier to read.
**Is documentation needed?**:
N/A
## Compatibility
**Does this PR create any API breaks (e.g. at the Java or HTTP layers) - if so, do we have compatibility?**:
no
**Does this PR change the persisted format of any data - if so, do we have forward and backward compatibility?**:
no
**The code in this PR may be part of a blue-green deploy. Can upgrades from previous versions safely coexist? (Consider restarts of blue or green nodes.)**:
yes
**Does this PR rely on statements being true about other products at a deployment - if so, do we have correct product dependencies on these products (or other ways of verifying that these statements are true)?**:
no
**Does this PR need a schema migration?**
n/a
## Testing and Correctness
**What, if any, assumptions are made about the current state of the world? If they change over time, how will we find out?**:
Not rolled out
**What was existing testing like? What have you done to improve it?**:
Fixed existing and added new tests
**If this PR contains complex concurrent or asynchronous code, is it correct? The onus is on the PR writer to demonstrate this.**:
N/A
**If this PR involves acquiring locks or other shared resources, how do we ensure that these are always released?**:
N/A
## Execution
**How would I tell this PR works in production? (Metrics, logs, etc.)**:
Shard Progress Updater makes progress and updates last swept metric
**Has the safety of all log arguments been decided correctly?**:
N/A
**Will this change significantly affect our spending on metrics or logs?**:
N/A
**How would I tell that this PR does not work in production? (monitors, etc.)**:
Shard Progress Updater still doesn't work
**If this PR does not work as expected, how do I fix that state? Would rollback be straightforward?**:
Fix it
**If the above plan is more complex than “recall and rollback”, please tag the support PoC here (if it is the end of the week, tag both the current and next PoC)**:
N/A
## Scale
**Would this PR be expected to pose a risk at scale? Think of the shopping product at our largest stack.**:
No
**Would this PR be expected to perform a large number of database calls, and/or expensive database calls (e.g., row range scans, concurrent CAS)?**:
No
**Would this PR ever, with time and scale, become the wrong thing to do - and if so, how would we know that we need to do something differently?**:
If too many buckets are being processed between iterations - but at 10 minutes per bucket for creation, that's unlikely. If we move to a world where we're creating lots of tiny buckets, then it's different.
## Development Process
**Where should we start reviewing?**:
DSPU
**If this PR is in excess of 500 lines excluding versions lock-files, why does it not make sense to split it?**:

**Please tag any other people who should be aware of this PR**:
@jeremyk-91
@raiju

<!---
Please remember to:
- Add any necessary release notes (including breaking changes)
- Make sure the documentation is up to date for your change
--->
